### PR TITLE
chore: ignore nested target and Cargo.lock in lints and security dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 /target
 /programs/target
+**/lints/**/target
+**/lints/**/Cargo.lock
+**/security/**/target
+**/security/**/Cargo.lock
 /.helix
 /result
 /.direnv


### PR DESCRIPTION
## Summary
- Adds `.gitignore` patterns for `**/lints/**/target`, `**/lints/**/Cargo.lock`, `**/security/**/target`, and `**/security/**/Cargo.lock` to prevent build artifacts from being tracked

## Test plan
- [x] Verify patterns match the intended directories

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version control configuration to exclude additional build artifacts and lock files from tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->