### PR TITLE
[codex] Add mdBook docs and apply relevant unresolved review fixes

### DIFF
--- a/.changeset/pina-mdbook-and-review-followups.md
+++ b/.changeset/pina-mdbook-and-review-followups.md
@@ -1,0 +1,10 @@
+---
+pina: patch
+---
+
+Addressed outstanding review follow-ups and documentation quality:
+
+- Enabled the `solana-address` `curve25519` feature in workspace dependencies so PDA helpers are available in host builds.
+- Added missing `AccountValidation` implementations for token mint/account types used by token helpers.
+- Replaced unchecked counter increment arithmetic in the example with checked overflow handling.
+- Added an mdBook documentation site under `docs/` and wired docs verification into CI.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ jobs:
         run: lint:format
         shell: devenv shell -c -- bash -e {0}
 
+      - name: verify docs
+        run: verify:docs
+        shell: devenv shell -c -- bash -e {0}
+
   test:
     timeout-minutes: 60
     runs-on: blacksmith-2vcpu-ubuntu-2404

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+/docs/book
 /programs/target
 **/lints/**/target
 **/lints/**/Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ proc-macro2 = { default-features = false, version = "^1" }
 quote = { default-features = false, version = "^1" }
 serde = { default-features = false, version = "^1" }
 serde_json = { default-features = false, version = "^1", features = ["std"] }
-solana-address = { default-features = false, version = "^2.0", features = ["bytemuck", "decode"] }
+solana-address = { default-features = false, version = "^2.0", features = ["bytemuck", "curve25519", "decode"] }
 solana-program-log = { default-features = false, version = "^1.1" }
 syn = { default-features = false, version = "^2", features = ["full"] }
 test_utils_solana = { default-features = false, version = "^0.8" }

--- a/crates/pina/src/loaders.rs
+++ b/crates/pina/src/loaders.rs
@@ -435,6 +435,8 @@ macro_rules! impl_account_validation {
 }
 
 #[cfg(feature = "token")]
+impl_account_validation!(crate::token::state::Mint, "Mint account data is invalid");
+#[cfg(feature = "token")]
 impl_account_validation!(
 	crate::token_2022::state::Mint,
 	"Mint account data is invalid"
@@ -442,6 +444,11 @@ impl_account_validation!(
 #[cfg(feature = "token")]
 impl_account_validation!(
 	crate::token::state::TokenAccount,
+	"Token account data is invalid"
+);
+#[cfg(feature = "token")]
+impl_account_validation!(
+	crate::token_2022::state::TokenAccount,
 	"Token account data is invalid"
 );
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -21,6 +21,7 @@ in
       eget
       gcc
       libiconv
+      mdbook
       llvm.bintools
       llvm.clang
       llvm.clang-tools
@@ -212,8 +213,17 @@ in
         set -e
         lint:clippy
         lint:format
+        verify:docs
       '';
       description = "Run all checks.";
+      binary = "bash";
+    };
+    "docs:build" = {
+      exec = ''
+        set -e
+        mdbook build "$DEVENV_ROOT/docs"
+      '';
+      description = "Build the mdBook documentation.";
       binary = "bash";
     };
     "lint:format" = {
@@ -222,6 +232,16 @@ in
         dprint check
       '';
       description = "Check that all files are formatted.";
+      binary = "bash";
+    };
+    "verify:docs" = {
+      exec = ''
+        set -e
+        [ -f "$DEVENV_ROOT/docs/book.toml" ]
+        [ -f "$DEVENV_ROOT/docs/src/SUMMARY.md" ]
+        mdbook build "$DEVENV_ROOT/docs" -d "$DEVENV_ROOT/target/mdbook"
+      '';
+      description = "Verify docs folder structure and build docs.";
       binary = "bash";
     };
     "lint:clippy" = {

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,0 +1,18 @@
+[book]
+title = "Pina Book"
+authors = ["pina-rs contributors"]
+language = "en"
+multilingual = false
+src = "src"
+description = "Comprehensive project documentation for the Pina Solana framework."
+
+[build]
+build-dir = "book"
+create-missing = false
+
+[output.html]
+default-theme = "light"
+preferred-dark-theme = "navy"
+git-repository-url = "https://github.com/pina-rs/pina"
+edit-url-template = "https://github.com/pina-rs/pina/edit/main/docs/{path}"
+site-url = "/docs/"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,0 +1,13 @@
+# Summary
+
+- [Introduction](./index.md)
+- [Project Goals](./project-goals.md)
+- [Getting Started](./getting-started.md)
+- [Core Concepts](./core-concepts.md)
+- [Crates and Features](./crates-and-features.md)
+- [Examples](./examples.md)
+- [Security Model](./security-model.md)
+- [Development Workflow](./development-workflow.md)
+- [CI and Releases](./ci-and-releases.md)
+- [Review Follow-ups](./review-follow-ups.md)
+- [Recommendations](./recommendations.md)

--- a/docs/src/ci-and-releases.md
+++ b/docs/src/ci-and-releases.md
@@ -1,0 +1,26 @@
+# CI and Releases
+
+## CI jobs
+
+The GitHub CI workflow verifies:
+
+- `lint:clippy`
+- `lint:format`
+- `verify:docs`
+- `cargo test`
+- `cargo build --locked`
+- `cargo build --all-features --locked`
+
+This keeps code quality, behavior, and documentation build health aligned.
+
+## Release workflow
+
+Use `knope` for changelog/release management:
+
+```bash
+knope document-change
+knope release
+knope publish
+```
+
+Keep changeset descriptions explicit and user-impact focused.

--- a/docs/src/core-concepts.md
+++ b/docs/src/core-concepts.md
@@ -1,0 +1,27 @@
+# Core Concepts
+
+## Discriminators
+
+Pina uses discriminator enums as first-field tags for instruction/account/event types. This gives stable type identification at runtime and enables explicit parsing/dispatch.
+
+## Zero-copy account models
+
+`#[account]` and `#[instruction]` generate `Pod`/`Zeroable`-compatible layouts for in-place reinterpretation of account/instruction bytes.
+
+## Account validation chains
+
+Validation methods on `AccountView` are composable:
+
+```rust
+account.assert_signer()?.assert_writable()?.assert_owner(&program_id)?;
+```
+
+This pattern improves readability while keeping checks explicit and audit-able.
+
+## Typed account conversions
+
+Traits in `crates/pina/src/loaders.rs` provide typed conversion paths from raw `AccountView` values into strongly typed account states.
+
+## Entrypoint model
+
+`nostd_entrypoint!` wires BPF entrypoint plumbing while preserving `no_std` constraints for on-chain builds.

--- a/docs/src/crates-and-features.md
+++ b/docs/src/crates-and-features.md
@@ -1,0 +1,31 @@
+# Crates and Features
+
+## `crates/pina`
+
+Core runtime crate with:
+
+- Validation traits and helper methods
+- PDA and CPI helpers
+- `nostd_entrypoint!` and dispatch helpers
+- Optional token integrations
+
+### Main features
+
+- `derive` (default): enables proc-macro integration
+- `logs` (default): on-chain log support
+- `token`: SPL token/token-2022 helpers and typed conversions
+
+## `crates/pina_macros`
+
+Proc-macro crate that defines:
+
+- `#[account]`
+- `#[instruction]`
+- `#[event]`
+- `#[error]`
+- `#[discriminator]`
+- `#[derive(Accounts)]`
+
+## `crates/pina_sdk_ids`
+
+Shared Solana IDs for known programs/sysvars to keep address usage centralized and typed.

--- a/docs/src/development-workflow.md
+++ b/docs/src/development-workflow.md
@@ -1,0 +1,26 @@
+# Development Workflow
+
+## Daily loop
+
+```bash
+devenv shell
+cargo build --all-features
+cargo test
+lint:all
+verify:docs
+```
+
+## Formatting and linting
+
+- Rust and markdown formatting are enforced through `dprint`.
+- Clippy runs with strict workspace lint settings.
+
+## Dependency/tooling updates
+
+```bash
+update:deps
+```
+
+## Changesets
+
+Any code changes in `crates/` or `examples/` should include a file in `.changeset/` describing impact and release type.

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -1,0 +1,16 @@
+# Examples
+
+The `examples/` workspace members demonstrate practical usage patterns:
+
+- `hello_solana`: minimal program structure and instruction dispatch.
+- `counter_program`: PDA creation, mutation, and account validation.
+- `transfer_sol`: lamport transfers and account checks.
+- `escrow_program`: richer multi-account flow and token-oriented logic.
+
+Use examples as reference implementations for account layout, instruction parsing, and validation ordering.
+
+When adding new examples:
+
+- Keep instruction/account discriminator handling explicit.
+- Use checked arithmetic in state transitions.
+- Include unit tests and clear doc comments for every instruction path.

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -1,0 +1,37 @@
+# Getting Started
+
+## Prerequisites
+
+- Rust nightly toolchain from `rust-toolchain.toml`
+- `devenv` (Nix-based environment)
+- `gh` (for GitHub workflows)
+
+## Setup
+
+```bash
+devenv shell
+install:all
+```
+
+## Build and test
+
+```bash
+cargo build --all-features
+cargo test
+```
+
+## Common quality checks
+
+```bash
+lint:clippy
+lint:format
+verify:docs
+```
+
+## Build this documentation
+
+```bash
+docs:build
+```
+
+The generated site is written to `docs/book/`.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,14 @@
+# Pina
+
+Pina is a high-performance Solana smart-contract framework built on top of [`pinocchio`](https://github.com/anza-xyz/pinocchio). The project focuses on low compute-unit usage, small dependency surface area, and strong account validation ergonomics for on-chain Rust programs.
+
+This book is the single place for project documentation. It complements API reference docs by describing architecture, patterns, workflows, and quality standards used across the repository.
+
+## What you get in this book
+
+- The project's goals and trade-offs.
+- Setup and day-to-day development workflow.
+- Core framework concepts (`#[account]`, `#[instruction]`, `#[derive(Accounts)]`, discriminator model, and validation chains).
+- Guidance for examples and security-focused development.
+- CI/release pipeline expectations.
+- A practical recommendations roadmap for improving goal alignment.

--- a/docs/src/project-goals.md
+++ b/docs/src/project-goals.md
@@ -1,0 +1,32 @@
+# Project Goals
+
+Pina's codebase currently optimizes for the following goals.
+
+## 1. Performance and low compute units
+
+- Prefer `pinocchio` primitives over heavier Solana SDK surfaces.
+- Minimize instruction overhead by using zero-copy layouts and typed discriminators.
+- Keep runtime checks explicit but lightweight.
+
+## 2. `no_std`-first smart contract ergonomics
+
+- Keep crates deployable to Solana SBF targets.
+- Avoid patterns that introduce allocator/runtime assumptions.
+- Gate entrypoint-specific behavior behind features.
+
+## 3. Safety for account handling and state transitions
+
+- Strong discriminator and owner checks.
+- Explicit validation chains for signer, writable, PDA seeds, and type.
+- Defensive arithmetic and transfer operations.
+
+## 4. Macro-powered developer experience
+
+- Reduce boilerplate with `#[account]`, `#[instruction]`, `#[event]`, `#[error]`, and `#[derive(Accounts)]`.
+- Keep generated behavior predictable, documented, and tested.
+
+## 5. Maintainability and release quality
+
+- Reproducible dev environments (`devenv` + pinned tooling).
+- CI coverage for linting, tests, and builds.
+- Changelog-driven release discipline via changesets.

--- a/docs/src/recommendations.md
+++ b/docs/src/recommendations.md
@@ -1,0 +1,50 @@
+# Recommendations
+
+This section contains concrete suggestions to better align the codebase with Pina's goals.
+
+## 1. Add performance regression baselines
+
+Goal alignment: low compute units.
+
+- Add benchmark harnesses for high-volume instruction paths (counter increment, escrow state transitions, token flows).
+- Track baseline CU budgets in CI and fail when regressions exceed threshold.
+- Keep benchmark inputs deterministic and versioned.
+
+## 2. Strengthen feature-matrix testing
+
+Goal alignment: `no_std` reliability + maintainability.
+
+- Test a matrix of feature combinations (`default`, `--no-default-features`, `--features token`, `--all-features`).
+- Include `bpfel-unknown-none` build checks for all example programs.
+- Add one CI lane for docs/tests under minimal features to catch accidental default-feature coupling.
+
+## 3. Expand security regression coverage
+
+Goal alignment: safety.
+
+- Add explicit regression tests for arithmetic overflow/underflow paths.
+- Add tests for token transfer edge cases (insufficient funds, overflow on destination).
+- Add tests for each account close/transfer helper to verify lamport conservation invariants.
+
+## 4. Improve macro diagnostics quality
+
+Goal alignment: developer experience.
+
+- Add compile-fail tests for malformed macro attributes and unsupported discriminator configurations.
+- Improve error messages to include expected/actual forms and actionable fix text.
+- Maintain a docs page mapping macro attributes to generated behaviors.
+
+## 5. Centralize architecture decision records
+
+Goal alignment: maintainability.
+
+- Add ADR-style markdown files (for example, discriminator approach, token feature boundaries, no-allocator policy).
+- Require new architecture-impacting PRs to link/update an ADR.
+
+## 6. Publish a migration guide from Anchor-style patterns
+
+Goal alignment: adoption.
+
+- Document direct mapping from common Anchor concepts to Pina equivalents.
+- Provide before/after examples for account validation and instruction routing.
+- Include expected CU/dependency differences for realistic workloads.

--- a/docs/src/review-follow-ups.md
+++ b/docs/src/review-follow-ups.md
@@ -1,0 +1,14 @@
+# Review Follow-ups
+
+This project now tracks and resolves relevant previously ignored pull-request feedback where it still applies to the current codebase.
+
+## Addressed items
+
+- Enabled `solana-address` `curve25519` feature to ensure PDA helper APIs are available in host builds.
+- Replaced unchecked `current + 1` increment in the counter example with checked arithmetic and `ProgramError::ArithmeticOverflow` on failure.
+- Fixed stale hello example docs that described behavior not present in code.
+- Added missing `AccountValidation` implementations for all token account/mint types used by token conversion helpers.
+
+## Explicitly ignored as not relevant
+
+Some unresolved comments pointed to paths that no longer exist in the current repository (for example removed historical `security/` and `lints/` paths). These were not applied because there is no active code location to patch.

--- a/docs/src/security-model.md
+++ b/docs/src/security-model.md
@@ -1,0 +1,22 @@
+# Security Model
+
+Pina's safety posture is built around explicit validation and predictable state transitions.
+
+## Core invariants
+
+- Type correctness: account bytes must match expected discriminator and layout.
+- Authority correctness: signer/owner checks must precede mutation.
+- PDA correctness: seed and bump checks must gate PDA-bound operations.
+- Value correctness: arithmetic and balance mutations must be checked.
+
+## High-priority guardrails
+
+- Prefer checked arithmetic (`checked_add`, `checked_sub`) for all user-facing or balance-affecting values.
+- Ensure all token account types used by helper traits implement `AccountValidation`.
+- Keep close/transfer helpers conservation-safe (no temporary double-crediting).
+
+## Testing strategy
+
+- Unit tests for negative validation cases.
+- Regression tests for every previously fixed bug class.
+- Integration tests for cross-account invariants where mutation order matters.

--- a/examples/counter_program/src/lib.rs
+++ b/examples/counter_program/src/lib.rs
@@ -250,7 +250,11 @@ impl<'a> ProcessAccountInfos<'a> for IncrementAccounts<'a> {
 
 		let counter = self.counter.as_account_mut::<CounterState>(&ID)?;
 		let current: u64 = counter.count.into();
-		counter.count = PodU64::from_primitive(current + 1);
+		counter.count = PodU64::from_primitive(
+			current
+				.checked_add(1)
+				.ok_or(ProgramError::ArithmeticOverflow)?,
+		);
 
 		log!("Counter incremented");
 

--- a/examples/hello_solana/src/lib.rs
+++ b/examples/hello_solana/src/lib.rs
@@ -97,7 +97,7 @@ pub struct HelloAccounts<'a> {
 ///
 /// 1. Validate the discriminator via `HelloInstructionData::try_from_bytes`.
 /// 2. Assert the user account is a signer.
-/// 3. Log a greeting with the user's address.
+/// 3. Log a greeting.
 impl<'a> ProcessAccountInfos<'a> for HelloAccounts<'a> {
 	fn process(&self, data: &[u8]) -> ProgramResult {
 		// Validate instruction data (checks the discriminator byte).

--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,16 @@ cargo add pina --features token
 | `logs`   | Yes     | Enables on-chain logging via `solana-program-log`          |
 | `token`  | No      | Enables SPL token / token-2022 helpers and ATA utilities   |
 
+## Documentation
+
+Comprehensive project documentation now lives in the mdBook under `docs/`.
+
+```sh
+docs:build
+```
+
+Use `verify:docs` to validate documentation structure and build output in CI.
+
 ## Quick start
 
 ```rust


### PR DESCRIPTION
## Summary
This pull request adds a full project documentation book using mdBook, integrates docs verification into the local/CI workflow, and resolves relevant unresolved review comments from prior PRs that still apply to current code.

## Problem
The repository did not have a consolidated docs site, and docs integrity was not verified in CI. There were also historical unresolved review threads that still mapped to active code paths, including arithmetic safety and token account validation coverage.

## Root Cause
- Documentation was spread across READMEs and internal notes, with no single structured docs surface.
- CI validated code quality and tests but did not verify that docs exist and compile.
- Some prior PR comments remained unresolved even after code moved forward, leaving a few correctness/documentation inconsistencies.

## What Changed
### Documentation and Tooling
- Added `mdbook` to `devenv.nix` packages.
- Added `docs/` mdBook with a full structure:
  - introduction, goals, getting started, core concepts, crate/features, examples, security model, development workflow, CI/releases, review follow-ups, and recommendations.
- Added new scripts:
  - `docs:build`
  - `verify:docs`
- Updated `lint:all` to include `verify:docs`.
- Added CI step `verify docs` in `.github/workflows/ci.yml`.
- Updated root README with docs build/verify usage.
- Ignored generated docs output via `.gitignore` (`/docs/book`).

### Relevant Historical Review Follow-ups Applied
- Enabled `solana-address` `curve25519` feature in workspace dependencies for PDA helper availability in host builds.
- Replaced unchecked arithmetic in `counter_program` increment path with checked add and explicit `ProgramError::ArithmeticOverflow` handling.
- Fixed stale doc comment in `hello_solana` that incorrectly said the user's address is logged.
- Added missing `AccountValidation` implementations for:
  - `crate::token::state::Mint`
  - `crate::token_2022::state::TokenAccount`

### Changeset
- Added `.changeset/pina-mdbook-and-review-followups.md`.

## Why This Fix Works
- `verify:docs` ensures docs folder structure exists and mdBook compiles successfully.
- CI now enforces docs verification so docs regressions fail early.
- Runtime correctness is improved by checked arithmetic on mutable state transitions.
- Token account helper coverage is now consistent with all token types used by conversion methods.

## Validation
Executed locally in `devenv`:
- `fix:format`
- `lint:format`
- `verify:docs`
- `cargo test`
- `lint:clippy`
- `cargo build --locked`
- `cargo build --all-features --locked`

All commands completed successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Launched comprehensive mdBook documentation site with guides on project goals, security model, development workflow, and core concepts
  * Added documentation verification to CI pipeline

* **Bug Fixes**
  * Counter example now uses checked arithmetic to prevent overflow instead of unchecked increment
  * Added missing account validation implementations for token account types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->