### PR TITLE
feat(pina_cli): add automated release workflow for CLI binary distribution

### DIFF
--- a/.changeset/add_cli_release_assets.md
+++ b/.changeset/add_cli_release_assets.md
@@ -1,0 +1,12 @@
+---
+pina_cli: minor
+---
+
+Add automated release workflow for pina CLI binary distribution.
+
+Register `pina_cli` as a knope-managed package with versioning, changelogs,
+and GitHub releases. Add a GitHub Actions workflow that builds and uploads
+cross-platform binaries when a `pina_cli` release is created. Supports 9
+target platforms: Linux (GNU/musl, x86_64/aarch64), macOS (x86_64/aarch64),
+Windows (x86_64/aarch64), and FreeBSD (x86_64). Each binary includes SHA512
+checksums for verification.

--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -1,0 +1,78 @@
+name: "assets"
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  upload_assets:
+    env:
+      CARGO_PROFILE_RELEASE_LTO: true
+      CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
+    permissions:
+      contents: write
+    if: github.repository_owner == 'pina-rs' && startsWith(github.event.release.tag_name, 'pina_cli/v')
+    strategy:
+      matrix:
+        include:
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: aarch64-pc-windows-msvc
+            os: windows-latest
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+          - target: x86_64-unknown-freebsd
+            os: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: extract version
+        id: version
+        shell: bash
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#pina_cli/}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: install rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: setup cross toolchain
+        uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: ${{ matrix.target }}
+        if: startsWith(matrix.os, 'ubuntu') && !contains(matrix.target, '-musl')
+
+      - name: install cross
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
+        if: contains(matrix.target, '-musl')
+
+      - name: set rustflags
+        shell: bash
+        run: echo "RUSTFLAGS=${RUSTFLAGS} -C target-feature=+crt-static" >> "${GITHUB_ENV}"
+        if: endsWith(matrix.target, 'windows-msvc')
+
+      - name: upload binaries
+        uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: pina
+          archive: pina-${{ steps.version.outputs.version }}-$target
+          target: ${{ matrix.target }}
+          tar: all
+          zip: windows
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checksum: sha512

--- a/crates/pina_cli/changelog.md
+++ b/crates/pina_cli/changelog.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/knope.toml
+++ b/knope.toml
@@ -1,3 +1,12 @@
+[packages.pina_cli]
+versioned_files = [
+	"crates/pina_cli/Cargo.toml",
+	"Cargo.lock",
+]
+scopes = ["pina_cli"]
+changelog = "crates/pina_cli/changelog.md"
+extra_changelog_sections = [{ name = "Notes", types = ["note"] }, { name = "Documentation", types = ["docs"] }]
+
 [packages.pina]
 versioned_files = [
 	"crates/pina/Cargo.toml",


### PR DESCRIPTION
## Summary
- Register `pina_cli` as a knope-managed package with versioning, changelogs, and GitHub releases
- Add `.github/workflows/assets.yml` to build and upload cross-platform binaries when a `pina_cli` release is created
- Initialize `crates/pina_cli/changelog.md` for release tracking

## Release flow
1. `knope release` bumps `pina_cli` version and creates a GitHub release tagged `pina_cli/v{version}`
2. The `assets.yml` workflow triggers on the new release
3. 9 parallel jobs cross-compile the `pina` binary and upload archives + SHA512 checksums

## Targets
| Platform | Architectures |
|---|---|
| Linux (GNU) | x86_64, aarch64 |
| Linux (musl) | x86_64, aarch64 |
| macOS | x86_64, aarch64 |
| Windows (MSVC) | x86_64, aarch64 |
| FreeBSD | x86_64 |

## Archive naming
`pina-v{version}-{target}.tar.gz` (`.zip` for Windows)

## Test plan
- [x] `knope --dry-run release` validates the config and picks up `pina_cli`
- [x] Workflow YAML structure matches proven reference (ifiokjr/gelx)
- [x] Clean archive names extracted from `pina_cli/v{version}` tag format
- [x] `shell: bash` on Windows steps for cross-platform compatibility