### PR TITLE
[codex] Harden account safety, PDA behavior, and review-thread follow-ups

### DIFF
--- a/.changeset/pina-security-and-api-hardening.md
+++ b/.changeset/pina-security-and-api-hardening.md
@@ -1,0 +1,12 @@
+---
+pina: patch
+---
+
+Hardened account and discriminator handling to avoid panic paths and unsafe deserialization assumptions:
+
+- `IntoDiscriminator` primitive implementations now handle short input slices without panicking.
+- `AsAccount`/`AsAccountMut` now require exact account data length before reinterpretation.
+- PDA helper wrappers now work consistently on native targets and include roundtrip tests.
+- Lamport send/close helpers now reject same-account recipients and enforce writable preconditions before balance mutation.
+
+Also improved security examples by replacing saturating transfer/withdraw arithmetic with checked math that returns explicit `ProgramError` values on insufficient funds or overflow.

--- a/crates/pina/src/pda.rs
+++ b/crates/pina/src/pda.rs
@@ -1,37 +1,26 @@
 //! PDA (Program Derived Address) functions.
 //!
-//! These wrapper functions provide PDA derivation that compiles on both native
-//! and Solana targets. On-chain (Solana BPF), the runtime syscalls are used.
-//! On native targets, these return stub values (`None`/`Err`) since the
-//! syscalls are not available.
+//! These wrapper functions provide PDA derivation across native and Solana
+//! targets.
 
 use crate::Address;
 use crate::ProgramError;
 
 /// Find a valid program derived address and its corresponding bump seed.
 ///
-/// Returns `None` if no valid PDA exists. On native targets (non-Solana), this
-/// always returns `None` since PDA derivation requires Solana runtime syscalls.
+/// Returns `None` if no valid PDA exists.
 #[inline]
 pub fn try_find_program_address(seeds: &[&[u8]], program_id: &Address) -> Option<(Address, u8)> {
-	#[cfg(any(target_os = "solana", target_arch = "bpf"))]
-	{
-		Address::try_find_program_address(seeds, program_id)
-	}
-
-	#[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
-	{
-		core::hint::black_box((seeds, program_id));
-		None
-	}
+	Address::try_find_program_address(seeds, program_id)
 }
 
 /// Find a valid program derived address and its corresponding bump seed.
 ///
 /// # Panics
 ///
-/// Panics if no valid PDA exists. On native targets (non-Solana), this always
-/// panics since PDA derivation requires Solana runtime syscalls.
+/// Panics if no valid PDA exists.
+///
+/// Prefer [`try_find_program_address`] for recoverable error handling.
 #[inline]
 pub fn find_program_address(seeds: &[&[u8]], program_id: &Address) -> (Address, u8) {
 	try_find_program_address(seeds, program_id)
@@ -39,22 +28,30 @@ pub fn find_program_address(seeds: &[&[u8]], program_id: &Address) -> (Address, 
 }
 
 /// Create a valid program derived address without searching for a bump seed.
-///
-/// On native targets (non-Solana), this always returns
-/// `Err(ProgramError::InvalidSeeds)`.
 #[inline]
 pub fn create_program_address(
 	seeds: &[&[u8]],
 	program_id: &Address,
 ) -> Result<Address, ProgramError> {
-	#[cfg(any(target_os = "solana", target_arch = "bpf"))]
-	{
-		Address::create_program_address(seeds, program_id).map_err(|_| ProgramError::InvalidSeeds)
-	}
+	Address::create_program_address(seeds, program_id).map_err(|_| ProgramError::InvalidSeeds)
+}
 
-	#[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
-	{
-		core::hint::black_box((seeds, program_id));
-		Err(ProgramError::InvalidSeeds)
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn native_find_and_create_program_address_roundtrip() {
+		let seeds: &[&[u8]] = &[b"pina-test"];
+		let (pda, bump) =
+			try_find_program_address(seeds, &crate::system::ID).unwrap_or_else(|| {
+				panic!("expected to derive pda");
+			});
+		let bump_seed = [bump];
+		let seeds_with_bump: &[&[u8]] = &[b"pina-test", &bump_seed];
+		let recreated = create_program_address(seeds_with_bump, &crate::system::ID)
+			.unwrap_or_else(|err| panic!("failed to recreate pda: {err:?}"));
+
+		assert_eq!(pda, recreated);
 	}
 }

--- a/crates/pina/src/traits.rs
+++ b/crates/pina/src/traits.rs
@@ -137,8 +137,10 @@ macro_rules! primitive_into_discriminator {
 	($type:ty) => {
 		impl IntoDiscriminator for $type {
 			fn discriminator_from_bytes(bytes: &[u8]) -> Result<Self, $crate::ProgramError> {
-				// SECURITY: panics if `bytes.len() < Self::BYTES`. Callers must
-				// ensure the slice is at least `BYTES` long.
+				if bytes.len() < Self::BYTES {
+					return Err(ProgramError::InvalidInstructionData);
+				}
+
 				let sliced_bytes = &bytes[..Self::BYTES];
 				let mut discriminator_bytes = [0u8; Self::BYTES];
 				discriminator_bytes.copy_from_slice(sliced_bytes);
@@ -147,12 +149,17 @@ macro_rules! primitive_into_discriminator {
 			}
 
 			fn write_discriminator(&self, bytes: &mut [u8]) {
-				assert!(bytes.len() >= Self::BYTES);
+				debug_assert!(bytes.len() >= Self::BYTES);
+				if bytes.len() < Self::BYTES {
+					return;
+				}
 				bytes[..Self::BYTES].copy_from_slice(&self.to_le_bytes());
 			}
 
 			fn matches_discriminator(&self, bytes: &[u8]) -> bool {
-				assert!(bytes.len() >= Self::BYTES);
+				if bytes.len() < Self::BYTES {
+					return false;
+				}
 				self.to_le_bytes().eq(&bytes[..Self::BYTES])
 			}
 		}
@@ -309,24 +316,67 @@ pub trait AsAccount {
 /// Convenience methods for interpreting `AccountView` as SPL token account
 /// types.
 ///
-/// Callers should verify account ownership before trusting the returned
-/// reference, since these methods perform layout casts without owner checks.
+/// The `*_checked` variants enforce owner checks before casting. The raw
+/// variants are lower-level and assume caller-side owner validation.
 #[cfg(feature = "token")]
 pub trait AsTokenAccount {
 	/// Interpret the account data as an SPL Token mint.
 	fn as_token_mint(&self) -> Result<&crate::token::state::Mint, ProgramError>;
+	/// Interpret the account data as an SPL Token mint, validating owner.
+	fn as_token_mint_checked(&self) -> Result<&crate::token::state::Mint, ProgramError>;
+	/// Interpret the account data as an SPL Token mint, validating owner is one
+	/// of the provided program ids.
+	fn as_token_mint_checked_with_owners(
+		&self,
+		owners: &[Address],
+	) -> Result<&crate::token::state::Mint, ProgramError>;
 	/// Interpret the account data as an SPL Token account.
 	fn as_token_account(&self) -> Result<&crate::token::state::TokenAccount, ProgramError>;
+	/// Interpret the account data as an SPL Token account, validating owner.
+	fn as_token_account_checked(&self) -> Result<&crate::token::state::TokenAccount, ProgramError>;
+	/// Interpret the account data as an SPL Token account, validating owner is
+	/// one of the provided program ids.
+	fn as_token_account_checked_with_owners(
+		&self,
+		owners: &[Address],
+	) -> Result<&crate::token::state::TokenAccount, ProgramError>;
 	/// Interpret the account data as a Token-2022 mint.
 	fn as_token_2022_mint(&self) -> Result<&crate::token_2022::state::Mint, ProgramError>;
+	/// Interpret the account data as a Token-2022 mint, validating owner.
+	fn as_token_2022_mint_checked(&self) -> Result<&crate::token_2022::state::Mint, ProgramError>;
+	/// Interpret the account data as a Token-2022 mint, validating owner is one
+	/// of the provided program ids.
+	fn as_token_2022_mint_checked_with_owners(
+		&self,
+		owners: &[Address],
+	) -> Result<&crate::token_2022::state::Mint, ProgramError>;
 	/// Interpret the account data as a Token-2022 token account.
 	fn as_token_2022_account(
 		&self,
+	) -> Result<&crate::token_2022::state::TokenAccount, ProgramError>;
+	/// Interpret the account data as a Token-2022 token account, validating
+	/// owner.
+	fn as_token_2022_account_checked(
+		&self,
+	) -> Result<&crate::token_2022::state::TokenAccount, ProgramError>;
+	/// Interpret the account data as a Token-2022 token account, validating
+	/// owner is one of the provided program ids.
+	fn as_token_2022_account_checked_with_owners(
+		&self,
+		owners: &[Address],
 	) -> Result<&crate::token_2022::state::TokenAccount, ProgramError>;
 	/// Interpret the account data as an associated token account, verifying
 	/// the address matches the derived ATA for the given wallet, mint, and
 	/// token program.
 	fn as_associated_token_account(
+		&self,
+		owner: &Address,
+		mint: &Address,
+		token_program: &Address,
+	) -> Result<&crate::token::state::TokenAccount, ProgramError>;
+	/// Interpret the account data as an associated token account, validating
+	/// both owner and ATA derivation.
+	fn as_associated_token_account_checked(
 		&self,
 		owner: &Address,
 		mint: &Address,
@@ -469,6 +519,17 @@ mod tests {
 
 		let other: u32 = 0x0000_0001;
 		assert!(!other.matches_discriminator(&bytes));
+	}
+
+	#[test]
+	fn discriminator_from_bytes_short_input_returns_err() {
+		let err = u16::discriminator_from_bytes(&[7]).unwrap_err();
+		assert_eq!(err, ProgramError::InvalidInstructionData);
+	}
+
+	#[test]
+	fn discriminator_matches_short_input_returns_false() {
+		assert!(!42u16.matches_discriminator(&[42]));
 	}
 
 	#[test]

--- a/lints/require_empty_before_init/src/lib.rs
+++ b/lints/require_empty_before_init/src/lib.rs
@@ -81,6 +81,10 @@ fn visit_expr(expr: &Expr<'_>, calls: &mut Vec<CallInfo>) {
 			});
 		}
 		ExprKind::Call(callee, args) => {
+			visit_expr(callee, calls);
+			for arg in *args {
+				visit_expr(arg, calls);
+			}
 			if let ExprKind::Path(rustc_hir::QPath::Resolved(_, path)) = &callee.kind {
 				if let Some(seg) = path.segments.last() {
 					let target = args.first().and_then(receiver_name);
@@ -90,10 +94,6 @@ fn visit_expr(expr: &Expr<'_>, calls: &mut Vec<CallInfo>) {
 						target,
 					});
 				}
-			}
-			visit_expr(callee, calls);
-			for arg in *args {
-				visit_expr(arg, calls);
 			}
 		}
 		ExprKind::Block(block, _) => {

--- a/security/02-owner-checks/secure/src/lib.rs
+++ b/security/02-owner-checks/secure/src/lib.rs
@@ -36,8 +36,9 @@ impl<'a> ProcessAccountInfos<'a> for DepositAccounts<'a> {
 		self.depositor.assert_signer()?;
 
 		// SECURE: Verify ownership before deserialization.
-		self.token_account.assert_owners(&SPL_PROGRAM_IDS)?;
-		let token = self.token_account.as_token_account()?;
+		let token = self
+			.token_account
+			.as_token_account_checked_with_owners(&SPL_PROGRAM_IDS)?;
 		let balance = token.amount();
 
 		let amount: u64 = args.amount.into();

--- a/security/03-type-cosplay/insecure/src/lib.rs
+++ b/security/03-type-cosplay/insecure/src/lib.rs
@@ -64,8 +64,10 @@ impl<'a> ProcessAccountInfos<'a> for AdminActionAccounts<'a> {
 		let data = self.config.try_borrow()?;
 		let config: &AdminConfig =
 			bytemuck::try_from_bytes(&data).or(Err(ProgramError::InvalidAccountData))?;
+		let authority = config.authority;
+		drop(data);
 
-		self.authority.assert_address(&config.authority)?;
+		self.authority.assert_address(&authority)?;
 
 		let mut data_mut = self.config.try_borrow_mut()?;
 		let config_mut: &mut AdminConfig = bytemuck::try_from_bytes_mut(&mut data_mut)


### PR DESCRIPTION
## Summary
This PR hardens core account handling APIs, fixes security edge cases in examples, and addresses still-relevant unresolved review feedback from prior merged PRs.

The main goals are:
- eliminate panic/DoS and overflow footguns in core helpers,
- make owner and account-size validation harder to bypass,
- improve PDA behavior consistency on native targets,
- close relevant old review comments that were left unresolved,
- keep docs verification in the CI path.

## Problem And User Impact
Several APIs allowed unsafe or ambiguous behavior:
- discriminator conversion could panic on short input slices,
- account reinterpretation paths could proceed without exact data length checks,
- lamport movement helpers lacked writable/self-transfer guardrails,
- token casts were easy to use without owner validation,
- native PDA wrappers previously relied on stub behavior that obscured real derivation outcomes,
- one CLI PDA mapping path could bind a field to the wrong PDA,
- secure examples used saturating arithmetic patterns that can mask insufficient funds errors.

From a user perspective, these issues can cause runtime panics, inconsistent behavior between native and on-chain environments, and security bugs caused by mistaken assumptions around ownership/balances.

## Root Cause
The root cause was a mix of:
- convenience APIs that were intentionally low-level but too easy to misuse,
- missing guard clauses in edge-case inputs,
- arithmetic expressed in saturating form where explicit failure is required,
- historical unresolved review threads not being fully triaged for relevance after subsequent PRs.

## What Changed
### Core library hardening
- Hardened discriminator conversion/write/match behavior for short slices in `crates/pina/src/traits.rs`.
- Added exact `size_of::<T>()` data length assertions before account reinterpretation in `crates/pina/src/loaders.rs`.
- Added checked token-cast API variants (`*_checked` and `*_checked_with_owners`) and used owner validation paths.
- Added lamport transfer/close invariants:
  - writable checks for sender and recipient,
  - explicit rejection of same-account transfers/closes,
  - checked arithmetic helper functions with tests.
- Updated PDA wrappers in `crates/pina/src/pda.rs` to use `Address::{try_find_program_address,create_program_address}` directly on native and Solana targets, and added native roundtrip test.

### CLI/API correctness
- Fixed PDA inference bug in `crates/pina_cli/src/parse/mod.rs` where the first PDA could be selected incorrectly for unrelated fields.
- Added tests for PDA-name inference.

### Security example fixes
- Replaced saturating withdraw/transfer arithmetic with checked math and explicit errors in:
  - `security/00-signer-authorization/secure/src/lib.rs`
  - `security/06-duplicate-mutable-accounts/secure/src/lib.rs`
- Switched secure owner-check path to checked token account cast in:
  - `security/02-owner-checks/secure/src/lib.rs`
- Fixed runtime borrow conflict in insecure type-cosplay sample while preserving intended type-cosplay vulnerability pattern in:
  - `security/03-type-cosplay/insecure/src/lib.rs`

### Prior unresolved review-thread follow-ups
Addressed relevant unresolved comments from older merged PRs, including:
- post-order traversal consistency in `lints/require_empty_before_init/src/lib.rs`,
- the borrow-lifetime issue in the insecure type-cosplay example,
- and ensured previously flagged issues (README canonical link, PDA feature support, missing account validation coverage, checked arithmetic) are reflected in current code.

### Release note metadata
- Added `.changeset/pina-security-and-api-hardening.md` (`pina: patch`).

## Validation
Run locally:
- `devenv shell -c -- fix:format`
- `devenv shell -c -- lint:all`
- `devenv shell -c -- cargo test`

`lint:all` includes the docs verification step:
- `verify:docs` (checks docs structure and runs `mdbook build`).

All commands above pass on this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added safe token account accessor methods with ownership validation.
  * Enhanced balance operation helpers with explicit error handling.

* **Bug Fixes**
  * Improved discriminator handling for short input slices.
  * Strengthened account data validation before operations.

* **Security**
  * Replaced saturating arithmetic with checked math to prevent silent failures.
  * Added safeguards against self-transfers and insufficient balance conditions.
  * Enforced writable preconditions for balance mutations.
  * Unified PDA derivation behavior across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->