### PR TITLE
[codex] Harden CI setup by disabling flaky rustup package checks

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -35,7 +35,10 @@ in
       pkg-config
       protobuf # needed for `solana-test-validator` in tests
       rust-jemalloc-sys
-      rustup
+      # Upstream rustup check suite is network-sensitive (e.g. socks proxy test) and flakes in CI.
+      (rustup.overrideAttrs (_: {
+        doCheck = false;
+      }))
       shfmt
       zstd
     ]


### PR DESCRIPTION
## Summary
This hardens CI setup by making the `rustup` package in `devenv.nix` deterministic when Nix cache misses occur.

## Problem
Recent CI runs intermittently failed during the shared `setup` step before any repo tests/lints ran. The failure came from Nix building `rustup` and running upstream `rustup` tests in the derivation, where `download::tests::reqwest::socks_proxy_request` failed.

This is external flakiness unrelated to repository code and blocks all jobs (`build`, `test`, `lint`) because each job enters `devenv shell`.

## Fix
- Override `rustup` in `devenv.nix` with `doCheck = false`.
- Keep `rustup` available in the dev environment while removing flaky upstream test execution from CI setup.

## Validation
- `devenv shell -c -- lint:all`
- `devenv shell -c -- cargo test -p pina_cli`

## Expected impact
- CI setup no longer fails due to transient upstream `rustup` test behavior when cache fallback triggers a local build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated development environment toolchain configuration for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->