### PR TITLE
feat: port anchor examples and add codama idl verification

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -13,6 +13,7 @@ rustflags = [
 ]
 
 [alias]
+build-bpf = "build --release --target bpfel-unknown-none -p pinocchio_bpf_starter -Z build-std"
 build-escrow-program = "build --release --target bpfel-unknown-none -p escrow_program -Z build-std -F bpf-entrypoint"
 dylint = ["bin", "cargo-dylint"]
 insta = ["bin", "cargo-insta"]

--- a/.changeset/pinocchio-starter-and-anchor-porting.md
+++ b/.changeset/pinocchio-starter-and-anchor-porting.md
@@ -1,0 +1,21 @@
+---
+pina: note
+---
+
+Added new example coverage and upstream BPF tooling updates:
+
+- Added `examples/pinocchio_bpf_starter` based on the upstream `pinocchio-bpf-starter` template pattern.
+- Added sequential Anchor parity examples:
+  - `examples/anchor_declare_id`
+  - `examples/anchor_declare_program`
+  - `examples/anchor_duplicate_mutable_accounts`
+  - `examples/anchor_errors`
+  - `examples/anchor_events`
+  - `examples/anchor_floats`
+  - `examples/anchor_system_accounts`
+  - `examples/anchor_sysvars`
+  - `examples/anchor_realloc`
+- Extended `examples/escrow_program` with parity-focused tests aligned with Anchor's escrow coverage.
+- Updated `sbpf-linker` in `[workspace.metadata.bin]` to `0.1.8`.
+- Added a `build-bpf` cargo alias for the starter example and documented Anchor porting progress in the mdBook docs, including explicit notes for suites that are Anchor-CLI-specific.
+- Added Codama IDL fixtures for all `anchor_*` example programs under `codama/idls/` and new Rust/JS IDL verification tests (`test:idl`) that run in CI.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,40 @@ jobs:
       - name: run tests
         run: |
           sudo prlimit --pid $$ --nofile=1000000:1000000
-          cargo test --all-features --locked
+          test:all
         shell: devenv shell -- bash -e {0}
+
+  anchor-parity:
+    timeout-minutes: 60
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v6
+
+      - name: setup
+        uses: ./.github/actions/devenv
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: run anchor parity tests
+        run: test:anchor-parity
+        shell: devenv shell -c -- bash -e {0}
+
+  idl:
+    timeout-minutes: 60
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v6
+
+      - name: setup
+        uses: ./.github/actions/devenv
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: verify codama idls
+        run: test:idl
+        shell: devenv shell -c -- bash -e {0}
 
   build:
     timeout-minutes: 60

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anchor_declare_id"
+version = "0.0.0"
+dependencies = [
+ "pina",
+]
+
+[[package]]
+name = "anchor_declare_program"
+version = "0.0.0"
+dependencies = [
+ "pina",
+]
+
+[[package]]
+name = "anchor_duplicate_mutable_accounts"
+version = "0.0.0"
+dependencies = [
+ "pina",
+]
+
+[[package]]
+name = "anchor_errors"
+version = "0.0.0"
+dependencies = [
+ "pina",
+]
+
+[[package]]
+name = "anchor_events"
+version = "0.0.0"
+dependencies = [
+ "pina",
+]
+
+[[package]]
+name = "anchor_floats"
+version = "0.0.0"
+dependencies = [
+ "pina",
+]
+
+[[package]]
+name = "anchor_realloc"
+version = "0.0.0"
+dependencies = [
+ "pina",
+]
+
+[[package]]
+name = "anchor_system_accounts"
+version = "0.0.0"
+dependencies = [
+ "pina",
+]
+
+[[package]]
+name = "anchor_sysvars"
+version = "0.0.0"
+dependencies = [
+ "pina",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,7 +1074,7 @@ dependencies = [
 name = "escrow_program"
 version = "0.0.0"
 dependencies = [
- "mollusk-svm",
+ "mollusk-svm 0.8.1",
  "pina",
  "tokio",
 ]
@@ -1434,9 +1497,9 @@ dependencies = [
  "agave-feature-set",
  "agave-syscalls",
  "bincode",
- "mollusk-svm-error",
+ "mollusk-svm-error 0.8.1",
  "mollusk-svm-keys",
- "mollusk-svm-result",
+ "mollusk-svm-result 0.8.1",
  "solana-account",
  "solana-bpf-loader-program",
  "solana-clock",
@@ -1468,10 +1531,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "mollusk-svm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cac6d1c886dc3f907f615e80b66de6400a45d5f8f13f99c0b1c962ef614a5b0"
+dependencies = [
+ "agave-feature-set",
+ "agave-syscalls",
+ "bincode",
+ "mollusk-svm-error 0.10.3",
+ "mollusk-svm-result 0.10.3",
+ "solana-account",
+ "solana-bpf-loader-program",
+ "solana-clock",
+ "solana-compute-budget",
+ "solana-epoch-rewards",
+ "solana-epoch-schedule",
+ "solana-hash 3.1.0",
+ "solana-instruction",
+ "solana-instruction-error",
+ "solana-instructions-sysvar",
+ "solana-loader-v3-interface",
+ "solana-loader-v4-interface",
+ "solana-logger",
+ "solana-message",
+ "solana-precompile-error",
+ "solana-program-error",
+ "solana-program-runtime",
+ "solana-pubkey 4.1.0",
+ "solana-rent",
+ "solana-sdk-ids",
+ "solana-slot-hashes",
+ "solana-stake-interface",
+ "solana-svm-callback",
+ "solana-svm-log-collector",
+ "solana-svm-timings",
+ "solana-svm-transaction",
+ "solana-system-program",
+ "solana-sysvar",
+ "solana-sysvar-id",
+ "solana-transaction-context",
+ "solana-transaction-error",
+]
+
+[[package]]
 name = "mollusk-svm-error"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "602cd9544daaebe5c408925ce6b6a85575f30f177ddbf105638308c2061b3951"
+dependencies = [
+ "solana-pubkey 4.1.0",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "mollusk-svm-error"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d23fa709c14bfe0d8266508eedc2138aa7e6417d6f860d88cdc5cfa5346b357"
 dependencies = [
  "solana-pubkey 4.1.0",
  "thiserror 1.0.69",
@@ -1483,7 +1600,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f96ad1a13cb40fa9edabc805b3ff126f560493036883ac763d77f080e085c0"
 dependencies = [
- "mollusk-svm-error",
+ "mollusk-svm-error 0.8.1",
  "solana-account",
  "solana-instruction",
  "solana-pubkey 4.1.0",
@@ -1501,6 +1618,20 @@ dependencies = [
  "solana-program-error",
  "solana-pubkey 4.1.0",
  "solana-rent",
+]
+
+[[package]]
+name = "mollusk-svm-result"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "088825f3c0c1f820eafd1f10efd3606c58a5edec4accdb68eb1d9ce357d2ecac"
+dependencies = [
+ "solana-account",
+ "solana-instruction",
+ "solana-program-error",
+ "solana-pubkey 4.1.0",
+ "solana-rent",
+ "solana-transaction-error",
 ]
 
 [[package]]
@@ -1766,6 +1897,17 @@ dependencies = [
  "solana-address 2.2.0",
  "solana-instruction-view",
  "solana-program-error",
+]
+
+[[package]]
+name = "pinocchio_bpf_starter"
+version = "0.0.0"
+dependencies = [
+ "mollusk-svm 0.10.3",
+ "pinocchio",
+ "solana-define-syscall 4.0.1",
+ "solana-instruction",
+ "solana-program-log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,19 @@ members = [
 	"crates/pina_cli",
 	"crates/pina_macros",
 	"crates/pina_sdk_ids",
+	"examples/anchor_declare_id",
+	"examples/anchor_declare_program",
+	"examples/anchor_duplicate_mutable_accounts",
+	"examples/anchor_errors",
+	"examples/anchor_events",
+	"examples/anchor_floats",
+	"examples/anchor_realloc",
+	"examples/anchor_system_accounts",
+	"examples/anchor_sysvars",
 	"examples/counter_program",
 	"examples/escrow_program",
 	"examples/hello_solana",
+	"examples/pinocchio_bpf_starter",
 	"examples/todo_program",
 	"examples/transfer_sol",
 	"security/00-signer-authorization/secure",
@@ -101,7 +111,7 @@ cargo-workspaces = { version = "0.4.2" }
 mdt_cli = { version = "0.0.1", git = "https://github.com/ifiokjr/mdt", rev = "036caa93b77c40fe68890416497cefdaf08f96a1", bins = ["mdt"], locked = true }
 dylint-link = { version = "5.0.0", bins = ["dylint-link"] }
 knope = { version = "0.22.3", bins = ["knope"] }
-sbpf-linker = { version = "0.1.5", bins = ["sbpf-linker"] }
+sbpf-linker = { version = "0.1.8", bins = ["sbpf-linker"] }
 solana-verify = { version = "0.4.11", bins = ["solana-verify"] }
 
 [workspace.lints.rust]

--- a/codama/idls/anchor_declare_id.json
+++ b/codama/idls/anchor_declare_id.json
@@ -1,0 +1,17 @@
+{
+	"kind": "rootNode",
+	"standard": "codama",
+	"version": "1.0.0",
+	"program": {
+		"kind": "programNode",
+		"name": "anchorDeclareId",
+		"publicKey": "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
+		"version": "",
+		"accounts": [],
+		"instructions": [],
+		"definedTypes": [],
+		"pdas": [],
+		"errors": []
+	},
+	"additionalPrograms": []
+}

--- a/codama/idls/anchor_declare_program.json
+++ b/codama/idls/anchor_declare_program.json
@@ -1,0 +1,55 @@
+{
+	"kind": "rootNode",
+	"standard": "codama",
+	"version": "1.0.0",
+	"program": {
+		"kind": "programNode",
+		"name": "anchorDeclareProgram",
+		"publicKey": "Dec1areProgram11111111111111111111111111111",
+		"version": "",
+		"accounts": [],
+		"instructions": [
+			{
+				"kind": "instructionNode",
+				"name": "validateExternalProgram",
+				"accounts": [
+					{
+						"kind": "instructionAccountNode",
+						"name": "authority",
+						"isWritable": false,
+						"isSigner": true
+					},
+					{
+						"kind": "instructionAccountNode",
+						"name": "externalProgram",
+						"isWritable": false,
+						"isSigner": false
+					}
+				],
+				"arguments": [],
+				"discriminators": [
+					{
+						"kind": "constantDiscriminatorNode",
+						"offset": 0,
+						"constant": {
+							"kind": "constantValueNode",
+							"type": {
+								"kind": "numberTypeNode",
+								"format": "u8",
+								"endian": "le"
+							},
+							"value": {
+								"kind": "numberValueNode",
+								"number": 0
+							}
+						}
+					}
+				]
+			}
+		],
+		"definedTypes": [],
+		"pdas": [],
+		"errors": []
+	},
+	"additionalPrograms": []
+}

--- a/codama/idls/anchor_duplicate_mutable_accounts.json
+++ b/codama/idls/anchor_duplicate_mutable_accounts.json
@@ -1,0 +1,99 @@
+{
+	"kind": "rootNode",
+	"standard": "codama",
+	"version": "1.0.0",
+	"program": {
+		"kind": "programNode",
+		"name": "anchorDuplicateMutableAccounts",
+		"publicKey": "4D6rvpR7TSPwmFottLGa5gpzMcJ76kN8bimQHV9rogjH",
+		"version": "",
+		"accounts": [],
+		"instructions": [
+			{
+				"kind": "instructionNode",
+				"name": "failsDuplicateMutable",
+				"accounts": [
+					{
+						"kind": "instructionAccountNode",
+						"name": "account1",
+						"isWritable": true,
+						"isSigner": false
+					},
+					{
+						"kind": "instructionAccountNode",
+						"name": "account2",
+						"isWritable": true,
+						"isSigner": false
+					}
+				],
+				"arguments": [],
+				"discriminators": [
+					{
+						"kind": "constantDiscriminatorNode",
+						"offset": 0,
+						"constant": {
+							"kind": "constantValueNode",
+							"type": {
+								"kind": "numberTypeNode",
+								"format": "u8",
+								"endian": "le"
+							},
+							"value": {
+								"kind": "numberValueNode",
+								"number": 0
+							}
+						}
+					}
+				]
+			},
+			{
+				"kind": "instructionNode",
+				"name": "allowsDuplicateReadonly",
+				"accounts": [
+					{
+						"kind": "instructionAccountNode",
+						"name": "account1",
+						"isWritable": false,
+						"isSigner": false
+					},
+					{
+						"kind": "instructionAccountNode",
+						"name": "account2",
+						"isWritable": false,
+						"isSigner": false
+					}
+				],
+				"arguments": [],
+				"discriminators": [
+					{
+						"kind": "constantDiscriminatorNode",
+						"offset": 0,
+						"constant": {
+							"kind": "constantValueNode",
+							"type": {
+								"kind": "numberTypeNode",
+								"format": "u8",
+								"endian": "le"
+							},
+							"value": {
+								"kind": "numberValueNode",
+								"number": 2
+							}
+						}
+					}
+				]
+			}
+		],
+		"definedTypes": [],
+		"pdas": [],
+		"errors": [
+			{
+				"kind": "errorNode",
+				"name": "constraintDuplicateMutableAccount",
+				"code": 2040,
+				"message": ""
+			}
+		]
+	},
+	"additionalPrograms": []
+}

--- a/codama/idls/anchor_errors.json
+++ b/codama/idls/anchor_errors.json
@@ -1,0 +1,66 @@
+{
+	"kind": "rootNode",
+	"standard": "codama",
+	"version": "1.0.0",
+	"program": {
+		"kind": "programNode",
+		"name": "anchorErrors",
+		"publicKey": "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
+		"version": "",
+		"accounts": [],
+		"instructions": [],
+		"definedTypes": [],
+		"pdas": [],
+		"errors": [
+			{
+				"kind": "errorNode",
+				"name": "hello",
+				"code": 6000,
+				"message": ""
+			},
+			{
+				"kind": "errorNode",
+				"name": "helloNoMsg",
+				"code": 6123,
+				"message": ""
+			},
+			{
+				"kind": "errorNode",
+				"name": "helloNext",
+				"code": 6124,
+				"message": ""
+			},
+			{
+				"kind": "errorNode",
+				"name": "helloCustom",
+				"code": 6125,
+				"message": ""
+			},
+			{
+				"kind": "errorNode",
+				"name": "valueMismatch",
+				"code": 6126,
+				"message": ""
+			},
+			{
+				"kind": "errorNode",
+				"name": "valueMatch",
+				"code": 6127,
+				"message": ""
+			},
+			{
+				"kind": "errorNode",
+				"name": "valueLess",
+				"code": 6128,
+				"message": ""
+			},
+			{
+				"kind": "errorNode",
+				"name": "valueLessOrEqual",
+				"code": 6129,
+				"message": ""
+			}
+		]
+	},
+	"additionalPrograms": []
+}

--- a/codama/idls/anchor_events.json
+++ b/codama/idls/anchor_events.json
@@ -1,0 +1,17 @@
+{
+	"kind": "rootNode",
+	"standard": "codama",
+	"version": "1.0.0",
+	"program": {
+		"kind": "programNode",
+		"name": "anchorEvents",
+		"publicKey": "2dhGsWUzy5YKUsjZdLHLmkNpUDAXkNa9MYWsPc4Ziqzy",
+		"version": "",
+		"accounts": [],
+		"instructions": [],
+		"definedTypes": [],
+		"pdas": [],
+		"errors": []
+	},
+	"additionalPrograms": []
+}

--- a/codama/idls/anchor_floats.json
+++ b/codama/idls/anchor_floats.json
@@ -1,0 +1,200 @@
+{
+	"kind": "rootNode",
+	"standard": "codama",
+	"version": "1.0.0",
+	"program": {
+		"kind": "programNode",
+		"name": "anchorFloats",
+		"publicKey": "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
+		"version": "",
+		"accounts": [
+			{
+				"kind": "accountNode",
+				"name": "floatDataAccount",
+				"data": {
+					"kind": "structTypeNode",
+					"fields": [
+						{
+							"kind": "structFieldTypeNode",
+							"name": "dataF64",
+							"type": {
+								"kind": "numberTypeNode",
+								"format": "u64",
+								"endian": "le"
+							}
+						},
+						{
+							"kind": "structFieldTypeNode",
+							"name": "dataF32",
+							"type": {
+								"kind": "numberTypeNode",
+								"format": "u32",
+								"endian": "le"
+							}
+						},
+						{
+							"kind": "structFieldTypeNode",
+							"name": "authority",
+							"type": {
+								"kind": "publicKeyTypeNode"
+							}
+						}
+					]
+				},
+				"discriminators": [
+					{
+						"kind": "constantDiscriminatorNode",
+						"offset": 0,
+						"constant": {
+							"kind": "constantValueNode",
+							"type": {
+								"kind": "numberTypeNode",
+								"format": "u8",
+								"endian": "le"
+							},
+							"value": {
+								"kind": "numberValueNode",
+								"number": 1
+							}
+						}
+					}
+				]
+			}
+		],
+		"instructions": [
+			{
+				"kind": "instructionNode",
+				"name": "create",
+				"accounts": [
+					{
+						"kind": "instructionAccountNode",
+						"name": "account",
+						"isWritable": true,
+						"isSigner": false
+					},
+					{
+						"kind": "instructionAccountNode",
+						"name": "authority",
+						"isWritable": false,
+						"isSigner": true
+					},
+					{
+						"kind": "instructionAccountNode",
+						"name": "systemProgram",
+						"isWritable": false,
+						"isSigner": false,
+						"defaultValue": {
+							"kind": "publicKeyValueNode",
+							"publicKey": "11111111111111111111111111111111"
+						}
+					}
+				],
+				"arguments": [
+					{
+						"kind": "instructionArgumentNode",
+						"name": "dataF32",
+						"type": {
+							"kind": "numberTypeNode",
+							"format": "u32",
+							"endian": "le"
+						}
+					},
+					{
+						"kind": "instructionArgumentNode",
+						"name": "dataF64",
+						"type": {
+							"kind": "numberTypeNode",
+							"format": "u64",
+							"endian": "le"
+						}
+					}
+				],
+				"discriminators": [
+					{
+						"kind": "constantDiscriminatorNode",
+						"offset": 0,
+						"constant": {
+							"kind": "constantValueNode",
+							"type": {
+								"kind": "numberTypeNode",
+								"format": "u8",
+								"endian": "le"
+							},
+							"value": {
+								"kind": "numberValueNode",
+								"number": 0
+							}
+						}
+					}
+				]
+			},
+			{
+				"kind": "instructionNode",
+				"name": "update",
+				"accounts": [
+					{
+						"kind": "instructionAccountNode",
+						"name": "account",
+						"isWritable": true,
+						"isSigner": false
+					},
+					{
+						"kind": "instructionAccountNode",
+						"name": "authority",
+						"isWritable": false,
+						"isSigner": true
+					}
+				],
+				"arguments": [
+					{
+						"kind": "instructionArgumentNode",
+						"name": "dataF32",
+						"type": {
+							"kind": "numberTypeNode",
+							"format": "u32",
+							"endian": "le"
+						}
+					},
+					{
+						"kind": "instructionArgumentNode",
+						"name": "dataF64",
+						"type": {
+							"kind": "numberTypeNode",
+							"format": "u64",
+							"endian": "le"
+						}
+					}
+				],
+				"discriminators": [
+					{
+						"kind": "constantDiscriminatorNode",
+						"offset": 0,
+						"constant": {
+							"kind": "constantValueNode",
+							"type": {
+								"kind": "numberTypeNode",
+								"format": "u8",
+								"endian": "le"
+							},
+							"value": {
+								"kind": "numberValueNode",
+								"number": 1
+							}
+						}
+					}
+				]
+			}
+		],
+		"definedTypes": [],
+		"pdas": [],
+		"errors": [
+			{
+				"kind": "errorNode",
+				"name": "authorityMismatch",
+				"code": 0,
+				"message": ""
+			}
+		]
+	},
+	"additionalPrograms": []
+}

--- a/codama/idls/anchor_realloc.json
+++ b/codama/idls/anchor_realloc.json
@@ -1,0 +1,151 @@
+{
+	"kind": "rootNode",
+	"standard": "codama",
+	"version": "1.0.0",
+	"program": {
+		"kind": "programNode",
+		"name": "anchorRealloc",
+		"publicKey": "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
+		"version": "",
+		"accounts": [],
+		"instructions": [
+			{
+				"kind": "instructionNode",
+				"name": "realloc",
+				"accounts": [
+					{
+						"kind": "instructionAccountNode",
+						"name": "authority",
+						"isWritable": false,
+						"isSigner": true
+					},
+					{
+						"kind": "instructionAccountNode",
+						"name": "sample",
+						"isWritable": true,
+						"isSigner": false
+					},
+					{
+						"kind": "instructionAccountNode",
+						"name": "systemProgram",
+						"isWritable": false,
+						"isSigner": false,
+						"defaultValue": {
+							"kind": "publicKeyValueNode",
+							"publicKey": "11111111111111111111111111111111"
+						}
+					}
+				],
+				"arguments": [
+					{
+						"kind": "instructionArgumentNode",
+						"name": "len",
+						"type": {
+							"kind": "numberTypeNode",
+							"format": "u16",
+							"endian": "le"
+						}
+					}
+				],
+				"discriminators": [
+					{
+						"kind": "constantDiscriminatorNode",
+						"offset": 0,
+						"constant": {
+							"kind": "constantValueNode",
+							"type": {
+								"kind": "numberTypeNode",
+								"format": "u8",
+								"endian": "le"
+							},
+							"value": {
+								"kind": "numberValueNode",
+								"number": 0
+							}
+						}
+					}
+				]
+			},
+			{
+				"kind": "instructionNode",
+				"name": "realloc2",
+				"accounts": [
+					{
+						"kind": "instructionAccountNode",
+						"name": "authority",
+						"isWritable": false,
+						"isSigner": true
+					},
+					{
+						"kind": "instructionAccountNode",
+						"name": "sample1",
+						"isWritable": true,
+						"isSigner": false
+					},
+					{
+						"kind": "instructionAccountNode",
+						"name": "sample2",
+						"isWritable": true,
+						"isSigner": false
+					},
+					{
+						"kind": "instructionAccountNode",
+						"name": "systemProgram",
+						"isWritable": false,
+						"isSigner": false,
+						"defaultValue": {
+							"kind": "publicKeyValueNode",
+							"publicKey": "11111111111111111111111111111111"
+						}
+					}
+				],
+				"arguments": [
+					{
+						"kind": "instructionArgumentNode",
+						"name": "len",
+						"type": {
+							"kind": "numberTypeNode",
+							"format": "u16",
+							"endian": "le"
+						}
+					}
+				],
+				"discriminators": [
+					{
+						"kind": "constantDiscriminatorNode",
+						"offset": 0,
+						"constant": {
+							"kind": "constantValueNode",
+							"type": {
+								"kind": "numberTypeNode",
+								"format": "u8",
+								"endian": "le"
+							},
+							"value": {
+								"kind": "numberValueNode",
+								"number": 1
+							}
+						}
+					}
+				]
+			}
+		],
+		"definedTypes": [],
+		"pdas": [],
+		"errors": [
+			{
+				"kind": "errorNode",
+				"name": "accountReallocExceedsLimit",
+				"code": 3016,
+				"message": ""
+			},
+			{
+				"kind": "errorNode",
+				"name": "accountDuplicateReallocs",
+				"code": 3017,
+				"message": ""
+			}
+		]
+	},
+	"additionalPrograms": []
+}

--- a/codama/idls/anchor_system_accounts.json
+++ b/codama/idls/anchor_system_accounts.json
@@ -1,0 +1,55 @@
+{
+	"kind": "rootNode",
+	"standard": "codama",
+	"version": "1.0.0",
+	"program": {
+		"kind": "programNode",
+		"name": "anchorSystemAccounts",
+		"publicKey": "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
+		"version": "",
+		"accounts": [],
+		"instructions": [
+			{
+				"kind": "instructionNode",
+				"name": "initialize",
+				"accounts": [
+					{
+						"kind": "instructionAccountNode",
+						"name": "authority",
+						"isWritable": false,
+						"isSigner": true
+					},
+					{
+						"kind": "instructionAccountNode",
+						"name": "wallet",
+						"isWritable": false,
+						"isSigner": false
+					}
+				],
+				"arguments": [],
+				"discriminators": [
+					{
+						"kind": "constantDiscriminatorNode",
+						"offset": 0,
+						"constant": {
+							"kind": "constantValueNode",
+							"type": {
+								"kind": "numberTypeNode",
+								"format": "u8",
+								"endian": "le"
+							},
+							"value": {
+								"kind": "numberValueNode",
+								"number": 0
+							}
+						}
+					}
+				]
+			}
+		],
+		"definedTypes": [],
+		"pdas": [],
+		"errors": []
+	},
+	"additionalPrograms": []
+}

--- a/codama/idls/anchor_sysvars.json
+++ b/codama/idls/anchor_sysvars.json
@@ -1,0 +1,61 @@
+{
+	"kind": "rootNode",
+	"standard": "codama",
+	"version": "1.0.0",
+	"program": {
+		"kind": "programNode",
+		"name": "anchorSysvars",
+		"publicKey": "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
+		"version": "",
+		"accounts": [],
+		"instructions": [
+			{
+				"kind": "instructionNode",
+				"name": "sysvars",
+				"accounts": [
+					{
+						"kind": "instructionAccountNode",
+						"name": "clock",
+						"isWritable": false,
+						"isSigner": false
+					},
+					{
+						"kind": "instructionAccountNode",
+						"name": "rent",
+						"isWritable": false,
+						"isSigner": false
+					},
+					{
+						"kind": "instructionAccountNode",
+						"name": "stakeHistory",
+						"isWritable": false,
+						"isSigner": false
+					}
+				],
+				"arguments": [],
+				"discriminators": [
+					{
+						"kind": "constantDiscriminatorNode",
+						"offset": 0,
+						"constant": {
+							"kind": "constantValueNode",
+							"type": {
+								"kind": "numberTypeNode",
+								"format": "u8",
+								"endian": "le"
+							},
+							"value": {
+								"kind": "numberValueNode",
+								"number": 0
+							}
+						}
+					}
+				]
+			}
+		],
+		"definedTypes": [],
+		"pdas": [],
+		"errors": []
+	},
+	"additionalPrograms": []
+}

--- a/codama/tests/js/package.json
+++ b/codama/tests/js/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "pina-codama-idl-tests",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"test": "node validate-anchor-idls.mjs"
+	},
+	"devDependencies": {
+		"codama": "1.5.1"
+	}
+}

--- a/codama/tests/js/pnpm-lock.yaml
+++ b/codama/tests/js/pnpm-lock.yaml
@@ -1,0 +1,362 @@
+lockfileVersion: "9.0"
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+  .:
+    devDependencies:
+      codama:
+        specifier: 1.5.1
+        version: 1.5.1
+
+packages:
+  "@codama/cli@1.5.0":
+    resolution: {
+      integrity: sha512-+q62IvEA6o7ji/mcnGgAvyPWyiFx3cojVGrFNG8NSm0zFXrBk1lT3n/qg+2Ag8C8aHwno9boXgDTxV+P5VCDYw==,
+    }
+    hasBin: true
+
+  "@codama/errors@1.5.1":
+    resolution: {
+      integrity: sha512-kdLk/OSLBt03DoViRU1Xr0M7NZ7J/CSqaXV8fooF9qMRGPRJdgUeW2VkCGlLXDQSaIALrls3HkHmKRKbqqjSOA==,
+    }
+    hasBin: true
+
+  "@codama/node-types@1.5.1":
+    resolution: {
+      integrity: sha512-jMGz93MSszb1iXAAyWWa0i7RQbLxGihLKRZ+zr9aBsjaFFmhXhONfTFeSXzbEfc05cajpd/gW2QI7xmQHlUDKQ==,
+    }
+
+  "@codama/nodes@1.5.1":
+    resolution: {
+      integrity: sha512-6fIoH5Cfa5dFUE1fRxymZloeNg02klOT4fHsWwQavkkRWkoySgiti//w0j1itiZj6j5O+usujrwsZUJqSFjnhQ==,
+    }
+
+  "@codama/validators@1.5.1":
+    resolution: {
+      integrity: sha512-aUXl39AMa091CBWpYiK2XCXP/uyKOOtAT399TzRld3z8dIH9E0fGyu4ocP+IhQKXWXDPsh7V3qPmqsdyevOPcQ==,
+    }
+
+  "@codama/visitors-core@1.5.1":
+    resolution: {
+      integrity: sha512-JotrDJLI7OfPNHulu4KtPfUDF/FYMC3RgEnv9lu47Fiiy0upbGAw1NorgBuoreyJ9Uj0GZyHt7Q5rjrCoa1U0g==,
+    }
+
+  "@codama/visitors@1.5.1":
+    resolution: {
+      integrity: sha512-8WcGP1tJKtqBfZ4mJsBRPjZ/H6+SPLWmiUoDTXRrVePQE4X4Yb04o6BoX2Uc3heZbfEc0rXdM1w8HTFvXBX4/A==,
+    }
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {
+      integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==,
+    }
+    engines: { node: ">= 0.4" }
+
+  call-bind@1.0.8:
+    resolution: {
+      integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==,
+    }
+    engines: { node: ">= 0.4" }
+
+  call-bound@1.0.4:
+    resolution: {
+      integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==,
+    }
+    engines: { node: ">= 0.4" }
+
+  codama@1.5.1:
+    resolution: {
+      integrity: sha512-kZbYgesIxwGNZ1JsYIWFzAsLtBuLZy/S1pCxJZgYaE13NJwDzi+bsEYqRSOUQ9ISN7FJR3SCyAE+vgzvcJpg2A==,
+    }
+    hasBin: true
+
+  commander@14.0.3:
+    resolution: {
+      integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==,
+    }
+    engines: { node: ">=20" }
+
+  define-data-property@1.1.4:
+    resolution: {
+      integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==,
+    }
+    engines: { node: ">= 0.4" }
+
+  dunder-proto@1.0.1:
+    resolution: {
+      integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==,
+    }
+    engines: { node: ">= 0.4" }
+
+  es-define-property@1.0.1:
+    resolution: {
+      integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==,
+    }
+    engines: { node: ">= 0.4" }
+
+  es-errors@1.3.0:
+    resolution: {
+      integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==,
+    }
+    engines: { node: ">= 0.4" }
+
+  es-object-atoms@1.1.1:
+    resolution: {
+      integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==,
+    }
+    engines: { node: ">= 0.4" }
+
+  function-bind@1.1.2:
+    resolution: {
+      integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==,
+    }
+
+  get-intrinsic@1.3.0:
+    resolution: {
+      integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==,
+    }
+    engines: { node: ">= 0.4" }
+
+  get-proto@1.0.1:
+    resolution: {
+      integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==,
+    }
+    engines: { node: ">= 0.4" }
+
+  gopd@1.2.0:
+    resolution: {
+      integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==,
+    }
+    engines: { node: ">= 0.4" }
+
+  has-property-descriptors@1.0.2:
+    resolution: {
+      integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==,
+    }
+
+  has-symbols@1.1.0:
+    resolution: {
+      integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==,
+    }
+    engines: { node: ">= 0.4" }
+
+  hasown@2.0.2:
+    resolution: {
+      integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==,
+    }
+    engines: { node: ">= 0.4" }
+
+  isarray@2.0.5:
+    resolution: {
+      integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==,
+    }
+
+  json-stable-stringify@1.3.0:
+    resolution: {
+      integrity: sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==,
+    }
+    engines: { node: ">= 0.4" }
+
+  jsonify@0.0.1:
+    resolution: {
+      integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==,
+    }
+
+  kleur@3.0.3:
+    resolution: {
+      integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==,
+    }
+    engines: { node: ">=6" }
+
+  math-intrinsics@1.1.0:
+    resolution: {
+      integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==,
+    }
+    engines: { node: ">= 0.4" }
+
+  object-keys@1.1.1:
+    resolution: {
+      integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==,
+    }
+    engines: { node: ">= 0.4" }
+
+  picocolors@1.1.1:
+    resolution: {
+      integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==,
+    }
+
+  prompts@2.4.2:
+    resolution: {
+      integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==,
+    }
+    engines: { node: ">= 6" }
+
+  set-function-length@1.2.2:
+    resolution: {
+      integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==,
+    }
+    engines: { node: ">= 0.4" }
+
+  sisteransi@1.0.5:
+    resolution: {
+      integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==,
+    }
+
+snapshots:
+  "@codama/cli@1.5.0":
+    dependencies:
+      "@codama/nodes": 1.5.1
+      "@codama/visitors": 1.5.1
+      "@codama/visitors-core": 1.5.1
+      commander: 14.0.3
+      picocolors: 1.1.1
+      prompts: 2.4.2
+
+  "@codama/errors@1.5.1":
+    dependencies:
+      "@codama/node-types": 1.5.1
+      commander: 14.0.3
+      picocolors: 1.1.1
+
+  "@codama/node-types@1.5.1": {}
+
+  "@codama/nodes@1.5.1":
+    dependencies:
+      "@codama/errors": 1.5.1
+      "@codama/node-types": 1.5.1
+
+  "@codama/validators@1.5.1":
+    dependencies:
+      "@codama/errors": 1.5.1
+      "@codama/nodes": 1.5.1
+      "@codama/visitors-core": 1.5.1
+
+  "@codama/visitors-core@1.5.1":
+    dependencies:
+      "@codama/errors": 1.5.1
+      "@codama/nodes": 1.5.1
+      json-stable-stringify: 1.3.0
+
+  "@codama/visitors@1.5.1":
+    dependencies:
+      "@codama/errors": 1.5.1
+      "@codama/nodes": 1.5.1
+      "@codama/visitors-core": 1.5.1
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bind@1.0.8:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
+  codama@1.5.1:
+    dependencies:
+      "@codama/cli": 1.5.0
+      "@codama/errors": 1.5.1
+      "@codama/nodes": 1.5.1
+      "@codama/validators": 1.5.1
+      "@codama/visitors": 1.5.1
+
+  commander@14.0.3: {}
+
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  gopd@1.2.0: {}
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
+
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  isarray@2.0.5: {}
+
+  json-stable-stringify@1.3.0:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      isarray: 2.0.5
+      jsonify: 0.0.1
+      object-keys: 1.1.1
+
+  jsonify@0.0.1: {}
+
+  kleur@3.0.3: {}
+
+  math-intrinsics@1.1.0: {}
+
+  object-keys@1.1.1: {}
+
+  picocolors@1.1.1: {}
+
+  prompts@2.4.2:
+    dependencies:
+      kleur: 3.0.3
+      sisteransi: 1.0.5
+
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+
+  sisteransi@1.0.5: {}

--- a/codama/tests/js/validate-anchor-idls.mjs
+++ b/codama/tests/js/validate-anchor-idls.mjs
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { getValidationItemsVisitor, visit } from "codama";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, "../../..");
+const idlDir = path.join(rootDir, "codama", "idls");
+
+const anchorIdlFiles = readdirSync(idlDir)
+	.filter((entry) => entry.startsWith("anchor_") && entry.endsWith(".json"))
+	.sort();
+
+assert.ok(
+	anchorIdlFiles.length > 0,
+	"Expected at least one anchor_*.json IDL fixture.",
+);
+
+for (const filename of anchorIdlFiles) {
+	const idlPath = path.join(idlDir, filename);
+	const idl = JSON.parse(readFileSync(idlPath, "utf8"));
+
+	assert.equal(idl.kind, "rootNode", `${filename}: expected kind=rootNode`);
+	assert.equal(idl.standard, "codama", `${filename}: expected standard=codama`);
+	assert.equal(
+		typeof idl.program?.name,
+		"string",
+		`${filename}: missing program.name`,
+	);
+	assert.notEqual(
+		idl.program.name.length,
+		0,
+		`${filename}: empty program.name`,
+	);
+
+	const validationItems = visit(idl, getValidationItemsVisitor());
+	const validationErrors = validationItems.filter((item) =>
+		item.level === "error"
+	);
+
+	assert.equal(
+		validationErrors.length,
+		0,
+		`${filename}: Codama validation errors\n${
+			validationErrors
+				.map((item) => `- ${item.message}`)
+				.join("\n")
+		}`,
+	);
+}
+
+console.log(
+	`Validated ${anchorIdlFiles.length} anchor IDL fixture(s) with Codama JS.`,
+);

--- a/devenv.nix
+++ b/devenv.nix
@@ -244,6 +244,7 @@ in
           -p anchor_system_accounts \
           -p anchor_sysvars \
           -p escrow_program
+        rustup component add rust-src --toolchain nightly-2025-10-15
         cargo +nightly-2025-10-15 build-bpf
         cargo test --locked -p pinocchio_bpf_starter hello_world -- --ignored
       '';

--- a/devenv.nix
+++ b/devenv.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  llvm = pkgs.llvmPackages_19;
+  llvm = pkgs.llvmPackages_21;
 in
 
 {
@@ -24,6 +24,8 @@ in
       nodejs
       pnpm
       mdbook
+      nodejs
+      pnpm
       llvm.bintools
       llvm.clang
       llvm.clang-tools
@@ -223,8 +225,53 @@ in
     "test:all" = {
       exec = ''
         set -e
+        cargo test --all-features --locked
       '';
       description = "Run all tests across the crates";
+      binary = "bash";
+    };
+    "test:anchor-parity" = {
+      exec = ''
+        set -e
+        cargo test --locked \
+          -p anchor_declare_id \
+          -p anchor_declare_program \
+          -p anchor_duplicate_mutable_accounts \
+          -p anchor_errors \
+          -p anchor_events \
+          -p anchor_floats \
+          -p anchor_realloc \
+          -p anchor_system_accounts \
+          -p anchor_sysvars \
+          -p escrow_program
+        cargo +nightly-2025-10-15 build-bpf
+        cargo test --locked -p pinocchio_bpf_starter hello_world -- --ignored
+      '';
+      description = "Run Anchor parity example tests and starter BPF execution checks.";
+      binary = "bash";
+    };
+    "idl:generate" = {
+      exec = ''
+        set -e
+        "$DEVENV_ROOT/scripts/generate-codama-idls.sh"
+      '';
+      description = "Generate Codama IDLs for all anchor_* examples.";
+      binary = "bash";
+    };
+    "verify:idls" = {
+      exec = ''
+        set -e
+        "$DEVENV_ROOT/scripts/verify-codama-idls.sh"
+      '';
+      description = "Verify Codama IDL fixtures and JS/Rust IDL validation tests.";
+      binary = "bash";
+    };
+    "test:idl" = {
+      exec = ''
+        set -e
+        verify:idls
+      '';
+      description = "Run IDL fixture drift + Rust/JS Codama validation tests.";
       binary = "bash";
     };
     "coverage:all" = {

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -6,6 +6,7 @@
 - [Core Concepts](./core-concepts.md)
 - [Crates and Features](./crates-and-features.md)
 - [Examples](./examples.md)
+- [Anchor Test Porting](./anchor-test-porting.md)
 - [Security Model](./security-model.md)
 - [Development Workflow](./development-workflow.md)
 - [CI and Releases](./ci-and-releases.md)

--- a/docs/src/anchor-test-porting.md
+++ b/docs/src/anchor-test-porting.md
@@ -1,0 +1,50 @@
+# Anchor Test Porting
+
+This page tracks sequential parity ports from `solana-foundation/anchor/tests` into `examples/`, using Rust-first tests (mollusk/native unit tests) instead of TypeScript.
+
+## Port Status
+
+- [ ] `anchor-cli-account` (no direct parity yet; Anchor CLI account decoding over dynamic `Vec`/`String` data is not a direct pina/no-std match)
+- [ ] `anchor-cli-idl` (no direct parity yet; Anchor CLI IDL account lifecycle is Anchor-CLI-specific)
+- [ ] `auction-house`
+- [ ] `bench`
+- [ ] `bpf-upgradeable-state`
+- [ ] `cashiers-check`
+- [ ] `cfo`
+- [ ] `chat`
+- [ ] `composite`
+- [ ] `cpi-returns`
+- [ ] `custom-coder`
+- [ ] `custom-discriminator`
+- [ ] `custom-program`
+- [x] `declare-id` -> `examples/anchor_declare_id`
+- [x] `declare-program` -> `examples/anchor_declare_program` (adapted)
+- [x] `duplicate-mutable-accounts` -> `examples/anchor_duplicate_mutable_accounts` (adapted)
+- [x] `errors` -> `examples/anchor_errors` (adapted)
+- [x] `escrow` -> `examples/escrow_program` (adapted with parity-focused tests)
+- [x] `events` -> `examples/anchor_events` (adapted event schema parity)
+- [x] `floats` -> `examples/anchor_floats`
+- [ ] `idl`
+- [ ] `ido-pool`
+- [ ] `interface-account`
+- [ ] `lazy-account`
+- [ ] `lockup`
+- [ ] `misc`
+- [ ] `multiple-suites`
+- [ ] `multiple-suites-run-single`
+- [ ] `multisig`
+- [ ] `optional`
+- [ ] `pda-derivation`
+- [ ] `pyth`
+- [x] `realloc` -> `examples/anchor_realloc` (adapted)
+- [ ] `relations-derivation`
+- [ ] `safety-checks`
+- [ ] `spl`
+- [ ] `swap`
+- [x] `system-accounts` -> `examples/anchor_system_accounts` (adapted)
+- [x] `sysvars` -> `examples/anchor_sysvars` (adapted)
+- [ ] `test-instruction-validation`
+- [ ] `tictactoe`
+- [ ] `typescript`
+- [ ] `validator-clone`
+- [ ] `zero-copy`

--- a/docs/src/ci-and-releases.md
+++ b/docs/src/ci-and-releases.md
@@ -8,7 +8,9 @@ The GitHub CI workflow verifies:
 - `lint:format`
 - `verify:docs`
 - `verify:security`
-- `cargo test --all-features --locked`
+- `test:all` (`cargo test --all-features --locked`)
+- `test:anchor-parity` (Anchor parity examples + starter `build-bpf` + ignored mollusk execution test)
+- `test:idl` (regenerate + diff `codama/idls/anchor_*.json`, then validate via Codama Rust and JS libraries)
 - `cargo build --locked`
 - `cargo build --all-features --locked`
 

--- a/docs/src/development-workflow.md
+++ b/docs/src/development-workflow.md
@@ -11,6 +11,7 @@ cargo test
 lint:all
 verify:docs
 verify:security
+test:idl
 ```
 
 <!-- {/dailyDevelopmentLoop} -->

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -7,8 +7,20 @@ The `examples/` workspace members demonstrate practical usage patterns:
 - `todo_program`: PDA-backed state with boolean + digest updates.
 - `transfer_sol`: lamport transfers and account checks.
 - `escrow_program`: richer multi-account flow and token-oriented logic.
+- `pinocchio_bpf_starter`: upstream BPF starter-style hello world with `sbpf-linker`.
+- `anchor_declare_id`: first Anchor test parity port, focused on program-id mismatch checks.
+- `anchor_declare_program`: Anchor `declare-program` parity for external-program ID checks.
+- `anchor_duplicate_mutable_accounts`: explicit duplicate mutable account validation pattern.
+- `anchor_errors`: Anchor-style custom error code and guard helper parity.
+- `anchor_events`: event schema parity through deterministic serialization checks.
+- `anchor_floats`: float data account create/update flow with authority validation.
+- `anchor_system_accounts`: system-program owner validation parity.
+- `anchor_sysvars`: clock/rent/stake-history sysvar validation parity.
+- `anchor_realloc`: realloc growth and duplicate-target safety checks.
 
 Use examples as reference implementations for account layout, instruction parsing, and validation ordering.
+
+Anchor test-suite parity progress is tracked in [Anchor Test Porting](./anchor-test-porting.md).
 
 When adding new examples:
 

--- a/examples/anchor_declare_id/Cargo.toml
+++ b/examples/anchor_declare_id/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "anchor_declare_id"
+version = "0.0.0"
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+publish = false
+readme.workspace = true
+repository.workspace = true
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[features]
+bpf-entrypoint = []
+
+[dependencies]
+pina = { workspace = true, features = ["derive"] }
+
+[lints]
+workspace = true

--- a/examples/anchor_declare_id/src/lib.rs
+++ b/examples/anchor_declare_id/src/lib.rs
@@ -1,0 +1,66 @@
+//! Anchor `declare-id` parity example ported to pina.
+//!
+//! Anchor's test validates that a program-id mismatch is rejected. In pina,
+//! that check occurs in `parse_instruction`.
+
+#![allow(clippy::inline_always)]
+#![no_std]
+
+#[cfg(all(
+	not(any(target_os = "solana", target_arch = "bpf")),
+	not(feature = "bpf-entrypoint"),
+	not(test)
+))]
+extern crate std;
+
+use pina::*;
+
+// Same ID value used by anchor's declare-id test program.
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
+#[discriminator]
+pub enum DeclareIdInstruction {
+	Initialize = 0,
+}
+
+#[instruction(discriminator = DeclareIdInstruction, variant = Initialize)]
+pub struct InitializeInstruction {}
+
+#[cfg(feature = "bpf-entrypoint")]
+pub mod entrypoint {
+	use super::*;
+
+	nostd_entrypoint!(process_instruction);
+
+	#[inline(always)]
+	pub fn process_instruction(
+		program_id: &Address,
+		_accounts: &[AccountView],
+		data: &[u8],
+	) -> ProgramResult {
+		let _ = parse_instruction::<DeclareIdInstruction>(program_id, &ID, data)?;
+		let _ = InitializeInstruction::try_from_bytes(data)?;
+		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn parse_instruction_accepts_matching_program_id() {
+		let data = [DeclareIdInstruction::Initialize as u8];
+		let instruction = parse_instruction::<DeclareIdInstruction>(&ID, &ID, &data);
+		assert!(matches!(instruction, Ok(DeclareIdInstruction::Initialize)));
+	}
+
+	#[test]
+	fn parse_instruction_rejects_program_id_mismatch() {
+		let wrong_program_id: Address = [7u8; 32].into();
+		let data = [DeclareIdInstruction::Initialize as u8];
+		let result = parse_instruction::<DeclareIdInstruction>(&wrong_program_id, &ID, &data);
+
+		assert!(matches!(result, Err(ProgramError::IncorrectProgramId)));
+	}
+}

--- a/examples/anchor_declare_program/Cargo.toml
+++ b/examples/anchor_declare_program/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "anchor_declare_program"
+version = "0.0.0"
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+publish = false
+readme.workspace = true
+repository.workspace = true
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[features]
+bpf-entrypoint = []
+
+[dependencies]
+pina = { workspace = true, features = ["derive"] }
+
+[lints]
+workspace = true

--- a/examples/anchor_declare_program/src/lib.rs
+++ b/examples/anchor_declare_program/src/lib.rs
@@ -1,0 +1,120 @@
+//! Anchor `declare-program` parity example ported to pina.
+//!
+//! This adaptation focuses on the core behavior that maps to pina directly:
+//! validating that an "external program" account matches an expected program
+//! ID before executing cross-program logic.
+
+#![allow(clippy::inline_always)]
+#![no_std]
+
+#[cfg(all(
+	not(any(target_os = "solana", target_arch = "bpf")),
+	not(feature = "bpf-entrypoint"),
+	not(test)
+))]
+extern crate std;
+
+use pina::*;
+
+declare_id!("Dec1areProgram11111111111111111111111111111");
+
+pub mod external {
+	use pina::*;
+
+	declare_id!("Externa111111111111111111111111111111111111");
+}
+
+#[discriminator]
+pub enum DeclareProgramInstruction {
+	ValidateExternalProgram = 0,
+}
+
+#[instruction(discriminator = DeclareProgramInstruction, variant = ValidateExternalProgram)]
+pub struct ValidateExternalProgramInstruction {}
+
+#[derive(Accounts, Debug)]
+pub struct ValidateExternalProgramAccounts<'a> {
+	pub authority: &'a AccountView,
+	pub external_program: &'a AccountView,
+}
+
+#[inline]
+fn assert_external_program_id(external_program_id: &Address) -> ProgramResult {
+	if external_program_id != &external::ID {
+		return Err(ProgramError::IncorrectProgramId);
+	}
+
+	Ok(())
+}
+
+impl<'a> ProcessAccountInfos<'a> for ValidateExternalProgramAccounts<'a> {
+	fn process(&self, data: &[u8]) -> ProgramResult {
+		let _ = ValidateExternalProgramInstruction::try_from_bytes(data)?;
+
+		self.authority.assert_signer()?;
+		assert_external_program_id(self.external_program.address())?;
+		self.external_program
+			.assert_address(&external::ID)?
+			.assert_executable()?;
+
+		Ok(())
+	}
+}
+
+#[cfg(feature = "bpf-entrypoint")]
+pub mod entrypoint {
+	use super::*;
+
+	nostd_entrypoint!(process_instruction);
+
+	#[inline(always)]
+	pub fn process_instruction(
+		program_id: &Address,
+		accounts: &[AccountView],
+		data: &[u8],
+	) -> ProgramResult {
+		let instruction: DeclareProgramInstruction = parse_instruction(program_id, &ID, data)?;
+
+		match instruction {
+			DeclareProgramInstruction::ValidateExternalProgram => {
+				ValidateExternalProgramAccounts::try_from(accounts)?.process(data)
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn parse_instruction_accepts_matching_program_id() {
+		let data = [DeclareProgramInstruction::ValidateExternalProgram as u8];
+		let instruction = parse_instruction::<DeclareProgramInstruction>(&ID, &ID, &data);
+		assert!(matches!(
+			instruction,
+			Ok(DeclareProgramInstruction::ValidateExternalProgram)
+		));
+	}
+
+	#[test]
+	fn parse_instruction_rejects_program_id_mismatch() {
+		let wrong_program_id: Address = [9u8; 32].into();
+		let data = [DeclareProgramInstruction::ValidateExternalProgram as u8];
+		let result = parse_instruction::<DeclareProgramInstruction>(&wrong_program_id, &ID, &data);
+		assert!(matches!(result, Err(ProgramError::IncorrectProgramId)));
+	}
+
+	#[test]
+	fn external_program_id_check_rejects_wrong_address() {
+		let wrong: Address = [4u8; 32].into();
+		let result = assert_external_program_id(&wrong);
+		assert!(matches!(result, Err(ProgramError::IncorrectProgramId)));
+	}
+
+	#[test]
+	fn external_program_id_check_accepts_expected_address() {
+		let result = assert_external_program_id(&external::ID);
+		assert!(result.is_ok());
+	}
+}

--- a/examples/anchor_duplicate_mutable_accounts/Cargo.toml
+++ b/examples/anchor_duplicate_mutable_accounts/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "anchor_duplicate_mutable_accounts"
+version = "0.0.0"
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+publish = false
+readme.workspace = true
+repository.workspace = true
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[features]
+bpf-entrypoint = []
+
+[dependencies]
+pina = { workspace = true, features = ["derive"] }
+
+[lints]
+workspace = true

--- a/examples/anchor_duplicate_mutable_accounts/src/lib.rs
+++ b/examples/anchor_duplicate_mutable_accounts/src/lib.rs
@@ -1,0 +1,137 @@
+//! Anchor `duplicate-mutable-accounts` parity example ported to pina.
+//!
+//! Anchor enforces duplicate mutable account constraints in the account parser.
+//! In pina this check should be explicit in program logic.
+
+#![allow(clippy::inline_always)]
+#![no_std]
+
+#[cfg(all(
+	not(any(target_os = "solana", target_arch = "bpf")),
+	not(feature = "bpf-entrypoint"),
+	not(test)
+))]
+extern crate std;
+
+use pina::*;
+
+declare_id!("4D6rvpR7TSPwmFottLGa5gpzMcJ76kN8bimQHV9rogjH");
+
+#[error]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DuplicateMutableError {
+	ConstraintDuplicateMutableAccount = 2040,
+}
+
+#[discriminator]
+pub enum DuplicateMutableInstruction {
+	FailsDuplicateMutable = 0,
+	AllowsDuplicateMutable = 1,
+	AllowsDuplicateReadonly = 2,
+}
+
+#[instruction(discriminator = DuplicateMutableInstruction, variant = FailsDuplicateMutable)]
+pub struct FailsDuplicateMutableInstruction {}
+
+#[instruction(discriminator = DuplicateMutableInstruction, variant = AllowsDuplicateMutable)]
+pub struct AllowsDuplicateMutableInstruction {}
+
+#[instruction(discriminator = DuplicateMutableInstruction, variant = AllowsDuplicateReadonly)]
+pub struct AllowsDuplicateReadonlyInstruction {}
+
+#[derive(Accounts, Debug)]
+pub struct DuplicateMutableAccounts<'a> {
+	pub account1: &'a AccountView,
+	pub account2: &'a AccountView,
+}
+
+#[derive(Accounts, Debug)]
+pub struct DuplicateReadonlyAccounts<'a> {
+	pub account1: &'a AccountView,
+	pub account2: &'a AccountView,
+}
+
+fn ensure_distinct(account1: &Address, account2: &Address) -> ProgramResult {
+	if account1 == account2 {
+		return Err(DuplicateMutableError::ConstraintDuplicateMutableAccount.into());
+	}
+
+	Ok(())
+}
+
+impl<'a> ProcessAccountInfos<'a> for DuplicateMutableAccounts<'a> {
+	fn process(&self, data: &[u8]) -> ProgramResult {
+		let _ = FailsDuplicateMutableInstruction::try_from_bytes(data)?;
+		self.account1.assert_writable()?;
+		self.account2.assert_writable()?;
+		ensure_distinct(self.account1.address(), self.account2.address())
+	}
+}
+
+impl<'a> ProcessAccountInfos<'a> for DuplicateReadonlyAccounts<'a> {
+	fn process(&self, data: &[u8]) -> ProgramResult {
+		let _ = AllowsDuplicateReadonlyInstruction::try_from_bytes(data)?;
+		Ok(())
+	}
+}
+
+#[cfg(feature = "bpf-entrypoint")]
+pub mod entrypoint {
+	use super::*;
+
+	nostd_entrypoint!(process_instruction);
+
+	#[inline(always)]
+	pub fn process_instruction(
+		program_id: &Address,
+		accounts: &[AccountView],
+		data: &[u8],
+	) -> ProgramResult {
+		let instruction: DuplicateMutableInstruction = parse_instruction(program_id, &ID, data)?;
+
+		match instruction {
+			DuplicateMutableInstruction::FailsDuplicateMutable => {
+				DuplicateMutableAccounts::try_from(accounts)?.process(data)
+			}
+			DuplicateMutableInstruction::AllowsDuplicateMutable => {
+				let _ = AllowsDuplicateMutableInstruction::try_from_bytes(data)?;
+				Ok(())
+			}
+			DuplicateMutableInstruction::AllowsDuplicateReadonly => {
+				DuplicateReadonlyAccounts::try_from(accounts)?.process(data)
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn duplicate_mutable_check_rejects_same_account() {
+		let a: Address = [3u8; 32].into();
+		let result = ensure_distinct(&a, &a);
+		assert!(matches!(
+			result,
+			Err(ProgramError::Custom(code))
+				if code == DuplicateMutableError::ConstraintDuplicateMutableAccount as u32
+		));
+	}
+
+	#[test]
+	fn duplicate_mutable_check_accepts_distinct_accounts() {
+		let a: Address = [1u8; 32].into();
+		let b: Address = [2u8; 32].into();
+		assert!(ensure_distinct(&a, &b).is_ok());
+	}
+
+	#[test]
+	fn parse_instruction_rejects_program_id_mismatch() {
+		let wrong_program_id: Address = [7u8; 32].into();
+		let data = [DuplicateMutableInstruction::FailsDuplicateMutable as u8];
+		let result =
+			parse_instruction::<DuplicateMutableInstruction>(&wrong_program_id, &ID, &data);
+		assert!(matches!(result, Err(ProgramError::IncorrectProgramId)));
+	}
+}

--- a/examples/anchor_errors/Cargo.toml
+++ b/examples/anchor_errors/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "anchor_errors"
+version = "0.0.0"
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+publish = false
+readme.workspace = true
+repository.workspace = true
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[features]
+bpf-entrypoint = []
+
+[dependencies]
+pina = { workspace = true, features = ["derive"] }
+
+[lints]
+workspace = true

--- a/examples/anchor_errors/src/lib.rs
+++ b/examples/anchor_errors/src/lib.rs
@@ -1,0 +1,191 @@
+//! Anchor `errors` parity example ported to pina.
+//!
+//! This adaptation keeps the key behavior: deterministic custom error codes
+//! and explicit guard helpers that return those errors.
+
+#![allow(clippy::inline_always)]
+#![no_std]
+
+#[cfg(all(
+	not(any(target_os = "solana", target_arch = "bpf")),
+	not(feature = "bpf-entrypoint"),
+	not(test)
+))]
+extern crate std;
+
+use pina::*;
+
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
+#[error]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MyError {
+	Hello = 6000,
+	HelloNoMsg = 6123,
+	HelloNext = 6124,
+	HelloCustom = 6125,
+	ValueMismatch = 6126,
+	ValueMatch = 6127,
+	ValueLess = 6128,
+	ValueLessOrEqual = 6129,
+}
+
+#[discriminator]
+pub enum ErrorsInstruction {
+	Hello = 0,
+	HelloNoMsg = 1,
+	HelloNext = 2,
+	RequireEq = 3,
+	RequireNeq = 4,
+	RequireGt = 5,
+	RequireGte = 6,
+}
+
+#[instruction(discriminator = ErrorsInstruction, variant = Hello)]
+pub struct HelloInstruction {}
+
+#[instruction(discriminator = ErrorsInstruction, variant = HelloNoMsg)]
+pub struct HelloNoMsgInstruction {}
+
+#[instruction(discriminator = ErrorsInstruction, variant = HelloNext)]
+pub struct HelloNextInstruction {}
+
+#[instruction(discriminator = ErrorsInstruction, variant = RequireEq)]
+pub struct RequireEqInstruction {}
+
+#[instruction(discriminator = ErrorsInstruction, variant = RequireNeq)]
+pub struct RequireNeqInstruction {}
+
+#[instruction(discriminator = ErrorsInstruction, variant = RequireGt)]
+pub struct RequireGtInstruction {}
+
+#[instruction(discriminator = ErrorsInstruction, variant = RequireGte)]
+pub struct RequireGteInstruction {}
+
+#[allow(dead_code)]
+fn require_eq(left: u64, right: u64, error: MyError) -> ProgramResult {
+	if left != right {
+		return Err(error.into());
+	}
+	Ok(())
+}
+
+#[allow(dead_code)]
+fn require_neq(left: u64, right: u64, error: MyError) -> ProgramResult {
+	if left == right {
+		return Err(error.into());
+	}
+	Ok(())
+}
+
+#[allow(dead_code)]
+fn require_gt(left: u64, right: u64, error: MyError) -> ProgramResult {
+	if left <= right {
+		return Err(error.into());
+	}
+	Ok(())
+}
+
+#[allow(dead_code)]
+fn require_gte(left: u64, right: u64, error: MyError) -> ProgramResult {
+	if left < right {
+		return Err(error.into());
+	}
+	Ok(())
+}
+
+#[allow(dead_code)]
+fn process_instruction_variant(instruction: ErrorsInstruction) -> ProgramResult {
+	match instruction {
+		ErrorsInstruction::Hello => Err(MyError::Hello.into()),
+		ErrorsInstruction::HelloNoMsg => Err(MyError::HelloNoMsg.into()),
+		ErrorsInstruction::HelloNext => Err(MyError::HelloNext.into()),
+		ErrorsInstruction::RequireEq => require_eq(5_241, 124_124_124, MyError::ValueMismatch),
+		ErrorsInstruction::RequireNeq => require_neq(500, 500, MyError::ValueMatch),
+		ErrorsInstruction::RequireGt => require_gt(5, 10, MyError::ValueLessOrEqual),
+		ErrorsInstruction::RequireGte => require_gte(5, 10, MyError::ValueLess),
+	}
+}
+
+#[cfg(feature = "bpf-entrypoint")]
+pub mod entrypoint {
+	use super::*;
+
+	nostd_entrypoint!(process_instruction);
+
+	#[inline(always)]
+	pub fn process_instruction(
+		program_id: &Address,
+		_accounts: &[AccountView],
+		data: &[u8],
+	) -> ProgramResult {
+		let instruction: ErrorsInstruction = parse_instruction(program_id, &ID, data)?;
+		process_instruction_variant(instruction)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn assert_custom_code(error: MyError, expected: u32) {
+		let as_program_error: ProgramError = error.into();
+		assert!(matches!(as_program_error, ProgramError::Custom(code) if code == expected));
+	}
+
+	#[test]
+	fn error_codes_match_anchor_expectations() {
+		assert_custom_code(MyError::Hello, 6000);
+		assert_custom_code(MyError::HelloNoMsg, 6123);
+		assert_custom_code(MyError::HelloNext, 6124);
+		assert_custom_code(MyError::HelloCustom, 6125);
+		assert_custom_code(MyError::ValueMismatch, 6126);
+		assert_custom_code(MyError::ValueMatch, 6127);
+		assert_custom_code(MyError::ValueLess, 6128);
+		assert_custom_code(MyError::ValueLessOrEqual, 6129);
+	}
+
+	#[test]
+	fn hello_variants_return_expected_errors() {
+		assert!(matches!(
+			process_instruction_variant(ErrorsInstruction::Hello),
+			Err(ProgramError::Custom(code)) if code == MyError::Hello as u32
+		));
+		assert!(matches!(
+			process_instruction_variant(ErrorsInstruction::HelloNoMsg),
+			Err(ProgramError::Custom(code)) if code == MyError::HelloNoMsg as u32
+		));
+		assert!(matches!(
+			process_instruction_variant(ErrorsInstruction::HelloNext),
+			Err(ProgramError::Custom(code)) if code == MyError::HelloNext as u32
+		));
+	}
+
+	#[test]
+	fn require_helpers_return_expected_errors() {
+		assert!(matches!(
+			process_instruction_variant(ErrorsInstruction::RequireEq),
+			Err(ProgramError::Custom(code)) if code == MyError::ValueMismatch as u32
+		));
+		assert!(matches!(
+			process_instruction_variant(ErrorsInstruction::RequireNeq),
+			Err(ProgramError::Custom(code)) if code == MyError::ValueMatch as u32
+		));
+		assert!(matches!(
+			process_instruction_variant(ErrorsInstruction::RequireGt),
+			Err(ProgramError::Custom(code)) if code == MyError::ValueLessOrEqual as u32
+		));
+		assert!(matches!(
+			process_instruction_variant(ErrorsInstruction::RequireGte),
+			Err(ProgramError::Custom(code)) if code == MyError::ValueLess as u32
+		));
+	}
+
+	#[test]
+	fn parse_instruction_rejects_program_id_mismatch() {
+		let wrong_program_id: Address = [6u8; 32].into();
+		let data = [ErrorsInstruction::Hello as u8];
+		let result = parse_instruction::<ErrorsInstruction>(&wrong_program_id, &ID, &data);
+		assert!(matches!(result, Err(ProgramError::IncorrectProgramId)));
+	}
+}

--- a/examples/anchor_events/Cargo.toml
+++ b/examples/anchor_events/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "anchor_events"
+version = "0.0.0"
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+publish = false
+readme.workspace = true
+repository.workspace = true
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[features]
+bpf-entrypoint = []
+
+[dependencies]
+pina = { workspace = true, features = ["derive"] }
+
+[lints]
+workspace = true

--- a/examples/anchor_events/src/lib.rs
+++ b/examples/anchor_events/src/lib.rs
@@ -1,0 +1,175 @@
+//! Anchor `events` parity example ported to pina.
+//!
+//! Anchor's event transport (`emit!`, `emit_cpi!`) is framework-specific. This
+//! parity port focuses on the event type definitions and deterministic
+//! serialization/discriminator behavior in pina.
+
+#![allow(clippy::inline_always)]
+#![no_std]
+
+#[cfg(all(
+	not(any(target_os = "solana", target_arch = "bpf")),
+	not(feature = "bpf-entrypoint"),
+	not(test)
+))]
+extern crate std;
+
+use pina::*;
+
+declare_id!("2dhGsWUzy5YKUsjZdLHLmkNpUDAXkNa9MYWsPc4Ziqzy");
+
+#[discriminator]
+pub enum EventsInstruction {
+	Initialize = 0,
+	TestEvent = 1,
+	TestEventCpi = 2,
+}
+
+#[instruction(discriminator = EventsInstruction, variant = Initialize)]
+pub struct InitializeInstruction {}
+
+#[instruction(discriminator = EventsInstruction, variant = TestEvent)]
+pub struct TestEventInstruction {}
+
+#[instruction(discriminator = EventsInstruction, variant = TestEventCpi)]
+pub struct TestEventCpiInstruction {}
+
+#[discriminator]
+pub enum EventDiscriminator {
+	MyEvent = 1,
+	MyOtherEvent = 2,
+}
+
+#[event(discriminator = EventDiscriminator)]
+#[derive(Debug)]
+pub struct MyEvent {
+	pub data: PodU64,
+	pub label: [u8; 8],
+}
+
+#[event(discriminator = EventDiscriminator)]
+#[derive(Debug)]
+pub struct MyOtherEvent {
+	pub data: PodU64,
+	pub label: [u8; 8],
+}
+
+#[allow(dead_code)]
+const LABEL_HELLO: [u8; 8] = [b'h', b'e', b'l', b'l', b'o', 0, 0, 0];
+#[allow(dead_code)]
+const LABEL_BYE: [u8; 8] = [b'b', b'y', b'e', 0, 0, 0, 0, 0];
+#[allow(dead_code)]
+const LABEL_CPI: [u8; 8] = [b'c', b'p', b'i', 0, 0, 0, 0, 0];
+
+#[allow(dead_code)]
+pub enum EmittedEvent {
+	MyEvent(MyEvent),
+	MyOtherEvent(MyOtherEvent),
+}
+
+#[allow(dead_code)]
+fn build_event(instruction: EventsInstruction) -> EmittedEvent {
+	match instruction {
+		EventsInstruction::Initialize => {
+			EmittedEvent::MyEvent(
+				MyEvent::builder()
+					.data(PodU64::from_primitive(5))
+					.label(LABEL_HELLO)
+					.build(),
+			)
+		}
+		EventsInstruction::TestEvent => {
+			EmittedEvent::MyOtherEvent(
+				MyOtherEvent::builder()
+					.data(PodU64::from_primitive(6))
+					.label(LABEL_BYE)
+					.build(),
+			)
+		}
+		EventsInstruction::TestEventCpi => {
+			EmittedEvent::MyOtherEvent(
+				MyOtherEvent::builder()
+					.data(PodU64::from_primitive(7))
+					.label(LABEL_CPI)
+					.build(),
+			)
+		}
+	}
+}
+
+#[cfg(feature = "bpf-entrypoint")]
+pub mod entrypoint {
+	use super::*;
+
+	nostd_entrypoint!(process_instruction);
+
+	#[inline(always)]
+	pub fn process_instruction(
+		program_id: &Address,
+		_accounts: &[AccountView],
+		data: &[u8],
+	) -> ProgramResult {
+		let instruction: EventsInstruction = parse_instruction(program_id, &ID, data)?;
+		let _ = build_event(instruction);
+		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn initialize_event_matches_expected_values() {
+		let event = match build_event(EventsInstruction::Initialize) {
+			EmittedEvent::MyEvent(event) => event,
+			EmittedEvent::MyOtherEvent(_) => panic!("expected my event"),
+		};
+
+		assert_eq!(u64::from(event.data), 5);
+		assert_eq!(event.label, LABEL_HELLO);
+	}
+
+	#[test]
+	fn test_event_matches_expected_values() {
+		let event = match build_event(EventsInstruction::TestEvent) {
+			EmittedEvent::MyOtherEvent(event) => event,
+			EmittedEvent::MyEvent(_) => panic!("expected other event"),
+		};
+
+		assert_eq!(u64::from(event.data), 6);
+		assert_eq!(event.label, LABEL_BYE);
+	}
+
+	#[test]
+	fn test_event_cpi_matches_expected_values() {
+		let event = match build_event(EventsInstruction::TestEventCpi) {
+			EmittedEvent::MyOtherEvent(event) => event,
+			EmittedEvent::MyEvent(_) => panic!("expected other event"),
+		};
+
+		assert_eq!(u64::from(event.data), 7);
+		assert_eq!(event.label, LABEL_CPI);
+	}
+
+	#[test]
+	fn my_event_roundtrip_serialization() {
+		let event = MyEvent::builder()
+			.data(PodU64::from_primitive(5))
+			.label(LABEL_HELLO)
+			.build();
+		let bytes = event.to_bytes();
+		let decoded = MyEvent::try_from_bytes(bytes).unwrap_or_else(|e| panic!("decode: {e:?}"));
+
+		assert_eq!(decoded.label, LABEL_HELLO);
+		assert_eq!(u64::from(decoded.data), 5);
+	}
+
+	#[test]
+	fn parse_instruction_rejects_program_id_mismatch() {
+		let wrong_program_id: Address = [8u8; 32].into();
+		let data = [EventsInstruction::Initialize as u8];
+		let result = parse_instruction::<EventsInstruction>(&wrong_program_id, &ID, &data);
+		assert!(matches!(result, Err(ProgramError::IncorrectProgramId)));
+	}
+}

--- a/examples/anchor_floats/Cargo.toml
+++ b/examples/anchor_floats/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "anchor_floats"
+version = "0.0.0"
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+publish = false
+readme.workspace = true
+repository.workspace = true
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[features]
+bpf-entrypoint = []
+
+[dependencies]
+pina = { workspace = true, features = ["derive"] }
+
+[lints]
+workspace = true

--- a/examples/anchor_floats/src/lib.rs
+++ b/examples/anchor_floats/src/lib.rs
@@ -1,0 +1,221 @@
+//! Anchor `floats` parity example ported to pina.
+//!
+//! Demonstrates float fields in account data plus an authority-gated update.
+
+#![allow(clippy::inline_always)]
+#![no_std]
+
+#[cfg(all(
+	not(any(target_os = "solana", target_arch = "bpf")),
+	not(feature = "bpf-entrypoint"),
+	not(test)
+))]
+extern crate std;
+
+use pina::*;
+
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
+#[error]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FloatError {
+	AuthorityMismatch = 0,
+}
+
+#[discriminator]
+pub enum FloatInstruction {
+	Create = 0,
+	Update = 1,
+}
+
+#[discriminator]
+pub enum FloatAccount {
+	FloatDataAccount = 1,
+}
+
+#[account(discriminator = FloatAccount)]
+pub struct FloatDataAccount {
+	pub data_f64: PodU64,
+	pub data_f32: PodU32,
+	pub authority: Address,
+}
+
+#[instruction(discriminator = FloatInstruction, variant = Create)]
+pub struct CreateInstruction {
+	pub data_f32: PodU32,
+	pub data_f64: PodU64,
+}
+
+#[instruction(discriminator = FloatInstruction, variant = Update)]
+pub struct UpdateInstruction {
+	pub data_f32: PodU32,
+	pub data_f64: PodU64,
+}
+
+#[derive(Accounts, Debug)]
+pub struct CreateAccounts<'a> {
+	pub account: &'a AccountView,
+	pub authority: &'a AccountView,
+	pub system_program: &'a AccountView,
+}
+
+#[derive(Accounts, Debug)]
+pub struct UpdateAccounts<'a> {
+	pub account: &'a AccountView,
+	pub authority: &'a AccountView,
+}
+
+fn apply_create(account: &mut FloatDataAccount, authority: &Address, data_f32: f32, data_f64: f64) {
+	account.data_f32 = PodU32::from_primitive(data_f32.to_bits());
+	account.data_f64 = PodU64::from_primitive(data_f64.to_bits());
+	account.authority = *authority;
+}
+
+fn apply_update(
+	account: &mut FloatDataAccount,
+	authority: &Address,
+	data_f32: f32,
+	data_f64: f64,
+) -> ProgramResult {
+	if account.authority != *authority {
+		return Err(FloatError::AuthorityMismatch.into());
+	}
+
+	account.data_f32 = PodU32::from_primitive(data_f32.to_bits());
+	account.data_f64 = PodU64::from_primitive(data_f64.to_bits());
+	Ok(())
+}
+
+impl<'a> ProcessAccountInfos<'a> for CreateAccounts<'a> {
+	fn process(&self, data: &[u8]) -> ProgramResult {
+		let args = CreateInstruction::try_from_bytes(data)?;
+		let data_f32 = f32::from_bits(u32::from(args.data_f32));
+		let data_f64 = f64::from_bits(u64::from(args.data_f64));
+
+		self.authority.assert_signer()?;
+		self.account.assert_empty()?.assert_writable()?;
+		self.system_program.assert_address(&system::ID)?;
+
+		create_account(
+			self.authority,
+			self.account,
+			size_of::<FloatDataAccount>(),
+			&ID,
+		)?;
+
+		let account = self.account.as_account_mut::<FloatDataAccount>(&ID)?;
+		apply_create(account, self.authority.address(), data_f32, data_f64);
+
+		Ok(())
+	}
+}
+
+impl<'a> ProcessAccountInfos<'a> for UpdateAccounts<'a> {
+	fn process(&self, data: &[u8]) -> ProgramResult {
+		let args = UpdateInstruction::try_from_bytes(data)?;
+		let data_f32 = f32::from_bits(u32::from(args.data_f32));
+		let data_f64 = f64::from_bits(u64::from(args.data_f64));
+
+		self.authority.assert_signer()?;
+		self.account
+			.assert_writable()?
+			.assert_type::<FloatDataAccount>(&ID)?;
+
+		let account = self.account.as_account_mut::<FloatDataAccount>(&ID)?;
+		apply_update(account, self.authority.address(), data_f32, data_f64)
+	}
+}
+
+#[cfg(feature = "bpf-entrypoint")]
+pub mod entrypoint {
+	use super::*;
+
+	nostd_entrypoint!(process_instruction);
+
+	#[inline(always)]
+	pub fn process_instruction(
+		program_id: &Address,
+		accounts: &[AccountView],
+		data: &[u8],
+	) -> ProgramResult {
+		let instruction: FloatInstruction = parse_instruction(program_id, &ID, data)?;
+
+		match instruction {
+			FloatInstruction::Create => CreateAccounts::try_from(accounts)?.process(data),
+			FloatInstruction::Update => UpdateAccounts::try_from(accounts)?.process(data),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn create_instruction_roundtrip() {
+		let instruction = CreateInstruction::builder()
+			.data_f32(PodU32::from_primitive(1.0f32.to_bits()))
+			.data_f64(PodU64::from_primitive(2.0f64.to_bits()))
+			.build();
+		let bytes = instruction.to_bytes();
+		let decoded =
+			CreateInstruction::try_from_bytes(bytes).unwrap_or_else(|e| panic!("decode: {e:?}"));
+
+		assert_eq!(f32::from_bits(u32::from(decoded.data_f32)), 1.0);
+		assert_eq!(f64::from_bits(u64::from(decoded.data_f64)), 2.0);
+	}
+
+	#[test]
+	fn update_instruction_roundtrip() {
+		let instruction = UpdateInstruction::builder()
+			.data_f32(PodU32::from_primitive(3.0f32.to_bits()))
+			.data_f64(PodU64::from_primitive(4.0f64.to_bits()))
+			.build();
+		let bytes = instruction.to_bytes();
+		let decoded =
+			UpdateInstruction::try_from_bytes(bytes).unwrap_or_else(|e| panic!("decode: {e:?}"));
+
+		assert_eq!(f32::from_bits(u32::from(decoded.data_f32)), 3.0);
+		assert_eq!(f64::from_bits(u64::from(decoded.data_f64)), 4.0);
+	}
+
+	#[test]
+	fn apply_update_rejects_authority_mismatch() {
+		let authority: Address = [1u8; 32].into();
+		let wrong_authority: Address = [2u8; 32].into();
+		let mut account = FloatDataAccount::builder()
+			.data_f32(PodU32::from_primitive(1.0f32.to_bits()))
+			.data_f64(PodU64::from_primitive(2.0f64.to_bits()))
+			.authority(authority)
+			.build();
+
+		let result = apply_update(&mut account, &wrong_authority, 3.0, 4.0);
+		assert!(matches!(
+			result,
+			Err(ProgramError::Custom(code)) if code == FloatError::AuthorityMismatch as u32
+		));
+	}
+
+	#[test]
+	fn apply_update_updates_values() {
+		let authority: Address = [1u8; 32].into();
+		let mut account = FloatDataAccount::builder()
+			.data_f32(PodU32::from_primitive(1.0f32.to_bits()))
+			.data_f64(PodU64::from_primitive(2.0f64.to_bits()))
+			.authority(authority)
+			.build();
+
+		let result = apply_update(&mut account, &authority, 3.0, 4.0);
+		assert!(result.is_ok());
+		assert_eq!(f32::from_bits(u32::from(account.data_f32)), 3.0);
+		assert_eq!(f64::from_bits(u64::from(account.data_f64)), 4.0);
+	}
+
+	#[test]
+	fn parse_instruction_rejects_program_id_mismatch() {
+		let wrong_program_id: Address = [5u8; 32].into();
+		let data = [FloatInstruction::Create as u8];
+		let result = parse_instruction::<FloatInstruction>(&wrong_program_id, &ID, &data);
+		assert!(matches!(result, Err(ProgramError::IncorrectProgramId)));
+	}
+}

--- a/examples/anchor_realloc/Cargo.toml
+++ b/examples/anchor_realloc/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "anchor_realloc"
+version = "0.0.0"
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+publish = false
+readme.workspace = true
+repository.workspace = true
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[features]
+bpf-entrypoint = []
+
+[dependencies]
+pina = { workspace = true, features = ["derive"] }
+
+[lints]
+workspace = true

--- a/examples/anchor_realloc/src/lib.rs
+++ b/examples/anchor_realloc/src/lib.rs
@@ -1,0 +1,178 @@
+//! Anchor `realloc` parity example ported to pina.
+//!
+//! This adaptation focuses on the key safety checks from Anchor's realloc
+//! tests: maximum permitted growth and duplicate realloc target detection.
+
+#![allow(clippy::inline_always)]
+#![no_std]
+
+#[cfg(all(
+	not(any(target_os = "solana", target_arch = "bpf")),
+	not(feature = "bpf-entrypoint"),
+	not(test)
+))]
+extern crate std;
+
+use pina::*;
+
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
+const MAX_PERMITTED_DATA_INCREASE: usize = 10_240;
+
+#[error]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReallocError {
+	AccountReallocExceedsLimit = 3016,
+	AccountDuplicateReallocs = 3017,
+}
+
+#[discriminator]
+pub enum ReallocInstruction {
+	Realloc = 0,
+	Realloc2 = 1,
+}
+
+#[instruction(discriminator = ReallocInstruction, variant = Realloc)]
+pub struct ReallocIx {
+	pub len: PodU16,
+}
+
+#[instruction(discriminator = ReallocInstruction, variant = Realloc2)]
+pub struct Realloc2Ix {
+	pub len: PodU16,
+}
+
+#[derive(Accounts, Debug)]
+pub struct ReallocAccounts<'a> {
+	pub authority: &'a AccountView,
+	pub sample: &'a AccountView,
+	pub system_program: &'a AccountView,
+}
+
+#[derive(Accounts, Debug)]
+pub struct Realloc2Accounts<'a> {
+	pub authority: &'a AccountView,
+	pub sample1: &'a AccountView,
+	pub sample2: &'a AccountView,
+	pub system_program: &'a AccountView,
+}
+
+fn validate_realloc_delta(current_len: usize, new_len: usize) -> ProgramResult {
+	if new_len > current_len {
+		let delta = new_len - current_len;
+		if delta > MAX_PERMITTED_DATA_INCREASE {
+			return Err(ReallocError::AccountReallocExceedsLimit.into());
+		}
+	}
+
+	Ok(())
+}
+
+fn validate_distinct_realloc_targets(account1: &Address, account2: &Address) -> ProgramResult {
+	if account1 == account2 {
+		return Err(ReallocError::AccountDuplicateReallocs.into());
+	}
+
+	Ok(())
+}
+
+impl<'a> ProcessAccountInfos<'a> for ReallocAccounts<'a> {
+	fn process(&self, data: &[u8]) -> ProgramResult {
+		let args = ReallocIx::try_from_bytes(data)?;
+		let target_len = usize::from(u16::from(args.len));
+
+		self.authority.assert_signer()?;
+		self.sample.assert_writable()?;
+		self.system_program.assert_address(&system::ID)?;
+
+		validate_realloc_delta(self.sample.data_len(), target_len)?;
+		self.sample.resize(target_len)
+	}
+}
+
+impl<'a> ProcessAccountInfos<'a> for Realloc2Accounts<'a> {
+	fn process(&self, data: &[u8]) -> ProgramResult {
+		let args = Realloc2Ix::try_from_bytes(data)?;
+		let base_len = usize::from(u16::from(args.len));
+		let second_target_len = base_len
+			.checked_add(10)
+			.ok_or(ProgramError::ArithmeticOverflow)?;
+
+		self.authority.assert_signer()?;
+		self.sample1.assert_writable()?;
+		self.sample2.assert_writable()?;
+		self.system_program.assert_address(&system::ID)?;
+
+		validate_distinct_realloc_targets(self.sample1.address(), self.sample2.address())?;
+		validate_realloc_delta(self.sample1.data_len(), base_len)?;
+		validate_realloc_delta(self.sample2.data_len(), second_target_len)?;
+
+		self.sample1.resize(base_len)?;
+		self.sample2.resize(second_target_len)
+	}
+}
+
+#[cfg(feature = "bpf-entrypoint")]
+pub mod entrypoint {
+	use super::*;
+
+	nostd_entrypoint!(process_instruction);
+
+	#[inline(always)]
+	pub fn process_instruction(
+		program_id: &Address,
+		accounts: &[AccountView],
+		data: &[u8],
+	) -> ProgramResult {
+		let instruction: ReallocInstruction = parse_instruction(program_id, &ID, data)?;
+		match instruction {
+			ReallocInstruction::Realloc => ReallocAccounts::try_from(accounts)?.process(data),
+			ReallocInstruction::Realloc2 => Realloc2Accounts::try_from(accounts)?.process(data),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn parse_instruction_rejects_program_id_mismatch() {
+		let wrong_program_id: Address = [5u8; 32].into();
+		let data = [ReallocInstruction::Realloc as u8];
+		let result = parse_instruction::<ReallocInstruction>(&wrong_program_id, &ID, &data);
+		assert!(matches!(result, Err(ProgramError::IncorrectProgramId)));
+	}
+
+	#[test]
+	fn realloc_instruction_roundtrip() {
+		let ix = ReallocIx::builder().len(PodU16::from_primitive(5)).build();
+		let bytes = ix.to_bytes();
+		let parsed = ReallocIx::try_from_bytes(bytes).unwrap_or_else(|e| panic!("decode: {e:?}"));
+		assert_eq!(u16::from(parsed.len), 5);
+	}
+
+	#[test]
+	fn validate_realloc_delta_allows_small_growth() {
+		assert!(validate_realloc_delta(100, 200).is_ok());
+	}
+
+	#[test]
+	fn validate_realloc_delta_rejects_growth_beyond_limit() {
+		let result = validate_realloc_delta(100, 100 + MAX_PERMITTED_DATA_INCREASE + 1);
+		assert!(matches!(
+			result,
+			Err(ProgramError::Custom(code)) if code == ReallocError::AccountReallocExceedsLimit as u32
+		));
+	}
+
+	#[test]
+	fn validate_distinct_realloc_targets_rejects_duplicates() {
+		let same: Address = [2u8; 32].into();
+		let result = validate_distinct_realloc_targets(&same, &same);
+		assert!(matches!(
+			result,
+			Err(ProgramError::Custom(code)) if code == ReallocError::AccountDuplicateReallocs as u32
+		));
+	}
+}

--- a/examples/anchor_system_accounts/Cargo.toml
+++ b/examples/anchor_system_accounts/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "anchor_system_accounts"
+version = "0.0.0"
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+publish = false
+readme.workspace = true
+repository.workspace = true
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[features]
+bpf-entrypoint = []
+
+[dependencies]
+pina = { workspace = true, features = ["derive"] }
+
+[lints]
+workspace = true

--- a/examples/anchor_system_accounts/src/lib.rs
+++ b/examples/anchor_system_accounts/src/lib.rs
@@ -1,0 +1,104 @@
+//! Anchor `system-accounts` parity example ported to pina.
+//!
+//! Verifies a signer authority plus a wallet account owned by the system
+//! program.
+
+#![allow(clippy::inline_always)]
+#![no_std]
+
+#[cfg(all(
+	not(any(target_os = "solana", target_arch = "bpf")),
+	not(feature = "bpf-entrypoint"),
+	not(test)
+))]
+extern crate std;
+
+use pina::*;
+
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
+#[discriminator]
+pub enum SystemAccountsInstruction {
+	Initialize = 0,
+}
+
+#[instruction(discriminator = SystemAccountsInstruction, variant = Initialize)]
+pub struct InitializeInstruction {}
+
+#[derive(Accounts, Debug)]
+pub struct InitializeAccounts<'a> {
+	pub authority: &'a AccountView,
+	pub wallet: &'a AccountView,
+}
+
+impl<'a> ProcessAccountInfos<'a> for InitializeAccounts<'a> {
+	fn process(&self, data: &[u8]) -> ProgramResult {
+		let _ = InitializeInstruction::try_from_bytes(data)?;
+		self.authority.assert_signer()?;
+		self.wallet.assert_owner(&system::ID)?;
+		Ok(())
+	}
+}
+
+#[cfg(feature = "bpf-entrypoint")]
+pub mod entrypoint {
+	use super::*;
+
+	nostd_entrypoint!(process_instruction);
+
+	#[inline(always)]
+	pub fn process_instruction(
+		program_id: &Address,
+		accounts: &[AccountView],
+		data: &[u8],
+	) -> ProgramResult {
+		let instruction: SystemAccountsInstruction = parse_instruction(program_id, &ID, data)?;
+		match instruction {
+			SystemAccountsInstruction::Initialize => {
+				InitializeAccounts::try_from(accounts)?.process(data)
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn validate_system_owner(owner: &Address) -> ProgramResult {
+		if owner == &system::ID {
+			Ok(())
+		} else {
+			Err(ProgramError::InvalidAccountOwner)
+		}
+	}
+
+	#[test]
+	fn parse_instruction_accepts_matching_program_id() {
+		let data = [SystemAccountsInstruction::Initialize as u8];
+		let result = parse_instruction::<SystemAccountsInstruction>(&ID, &ID, &data);
+		assert!(matches!(result, Ok(SystemAccountsInstruction::Initialize)));
+	}
+
+	#[test]
+	fn parse_instruction_rejects_program_id_mismatch() {
+		let wrong_program_id: Address = [9u8; 32].into();
+		let data = [SystemAccountsInstruction::Initialize as u8];
+		let result = parse_instruction::<SystemAccountsInstruction>(&wrong_program_id, &ID, &data);
+		assert!(matches!(result, Err(ProgramError::IncorrectProgramId)));
+	}
+
+	#[test]
+	fn validate_system_owner_accepts_system_program() {
+		assert!(validate_system_owner(&system::ID).is_ok());
+	}
+
+	#[test]
+	fn validate_system_owner_rejects_non_system_program() {
+		let wrong_owner: Address = [1u8; 32].into();
+		assert!(matches!(
+			validate_system_owner(&wrong_owner),
+			Err(ProgramError::InvalidAccountOwner)
+		));
+	}
+}

--- a/examples/anchor_sysvars/Cargo.toml
+++ b/examples/anchor_sysvars/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "anchor_sysvars"
+version = "0.0.0"
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+publish = false
+readme.workspace = true
+repository.workspace = true
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[features]
+bpf-entrypoint = []
+
+[dependencies]
+pina = { workspace = true, features = ["derive"] }
+
+[lints]
+workspace = true

--- a/examples/anchor_sysvars/src/lib.rs
+++ b/examples/anchor_sysvars/src/lib.rs
@@ -1,0 +1,95 @@
+//! Anchor `sysvars` parity example ported to pina.
+//!
+//! Verifies that provided clock, rent, and stake-history accounts are the
+//! expected sysvar accounts.
+
+#![allow(clippy::inline_always)]
+#![no_std]
+
+#[cfg(all(
+	not(any(target_os = "solana", target_arch = "bpf")),
+	not(feature = "bpf-entrypoint"),
+	not(test)
+))]
+extern crate std;
+
+use pina::*;
+
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
+const CLOCK_SYSVAR_ID: Address = address!("SysvarC1ock11111111111111111111111111111111");
+const RENT_SYSVAR_ID: Address = address!("SysvarRent111111111111111111111111111111111");
+const STAKE_HISTORY_SYSVAR_ID: Address = address!("SysvarStakeHistory1111111111111111111111111");
+
+#[discriminator]
+pub enum SysvarsInstruction {
+	Sysvars = 0,
+}
+
+#[instruction(discriminator = SysvarsInstruction, variant = Sysvars)]
+pub struct SysvarsCheckInstruction {}
+
+#[derive(Accounts, Debug)]
+pub struct SysvarsAccounts<'a> {
+	pub clock: &'a AccountView,
+	pub rent: &'a AccountView,
+	pub stake_history: &'a AccountView,
+}
+
+impl<'a> ProcessAccountInfos<'a> for SysvarsAccounts<'a> {
+	fn process(&self, data: &[u8]) -> ProgramResult {
+		let _ = SysvarsCheckInstruction::try_from_bytes(data)?;
+
+		self.clock.assert_sysvar(&CLOCK_SYSVAR_ID)?;
+		self.rent.assert_sysvar(&RENT_SYSVAR_ID)?;
+		self.stake_history.assert_sysvar(&STAKE_HISTORY_SYSVAR_ID)?;
+
+		Ok(())
+	}
+}
+
+#[cfg(feature = "bpf-entrypoint")]
+pub mod entrypoint {
+	use super::*;
+
+	nostd_entrypoint!(process_instruction);
+
+	#[inline(always)]
+	pub fn process_instruction(
+		program_id: &Address,
+		accounts: &[AccountView],
+		data: &[u8],
+	) -> ProgramResult {
+		let instruction: SysvarsInstruction = parse_instruction(program_id, &ID, data)?;
+		match instruction {
+			SysvarsInstruction::Sysvars => SysvarsAccounts::try_from(accounts)?.process(data),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn parse_instruction_accepts_matching_program_id() {
+		let data = [SysvarsInstruction::Sysvars as u8];
+		let result = parse_instruction::<SysvarsInstruction>(&ID, &ID, &data);
+		assert!(matches!(result, Ok(SysvarsInstruction::Sysvars)));
+	}
+
+	#[test]
+	fn parse_instruction_rejects_program_id_mismatch() {
+		let wrong_program_id: Address = [7u8; 32].into();
+		let data = [SysvarsInstruction::Sysvars as u8];
+		let result = parse_instruction::<SysvarsInstruction>(&wrong_program_id, &ID, &data);
+		assert!(matches!(result, Err(ProgramError::IncorrectProgramId)));
+	}
+
+	#[test]
+	fn sysvar_constants_are_distinct() {
+		assert_ne!(CLOCK_SYSVAR_ID, RENT_SYSVAR_ID);
+		assert_ne!(CLOCK_SYSVAR_ID, STAKE_HISTORY_SYSVAR_ID);
+		assert_ne!(RENT_SYSVAR_ID, STAKE_HISTORY_SYSVAR_ID);
+	}
+}

--- a/examples/pinocchio_bpf_starter/Cargo.toml
+++ b/examples/pinocchio_bpf_starter/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "pinocchio_bpf_starter"
+version = "0.0.0"
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+publish = false
+readme.workspace = true
+repository.workspace = true
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[dependencies]
+pinocchio = { default-features = false, version = "^0.10.1" }
+solana-define-syscall = { version = "^4.0.1", features = ["unstable-static-syscalls"] }
+solana-program-log = { default-features = false, version = "^1.1.0" }
+
+[dev-dependencies]
+mollusk-svm = { default-features = false, version = "^0.10.0" }
+solana-instruction = { default-features = false, version = "^3.1.0" }
+
+[lints]
+workspace = true

--- a/examples/pinocchio_bpf_starter/src/lib.rs
+++ b/examples/pinocchio_bpf_starter/src/lib.rs
@@ -1,0 +1,49 @@
+#![cfg_attr(target_arch = "bpf", no_std)]
+
+use pinocchio::AccountView;
+use pinocchio::Address;
+use pinocchio::ProgramResult;
+use pinocchio::no_allocator;
+use pinocchio::nostd_panic_handler;
+use pinocchio::program_entrypoint;
+use solana_program_log::log;
+
+nostd_panic_handler!();
+no_allocator!();
+program_entrypoint!(process_instruction);
+
+fn process_instruction(
+	_program_id: &Address,
+	_accounts: &[AccountView],
+	_instruction_data: &[u8],
+) -> ProgramResult {
+	log("Hello, World!");
+	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use mollusk_svm::Mollusk;
+	use mollusk_svm::result::Check;
+	use solana_instruction::Instruction;
+
+	#[test]
+	#[ignore = "requires `cargo +nightly-2025-10-15 build-bpf` artifact"]
+	pub fn hello_world() {
+		let program_id = [2u8; 32].into();
+		let program_path = format!(
+			"{}/../../target/bpfel-unknown-none/release/libpinocchio_bpf_starter",
+			env!("CARGO_MANIFEST_DIR")
+		);
+		let mollusk = Mollusk::new(&program_id, &program_path);
+		mollusk.process_and_validate_instruction(
+			&Instruction {
+				program_id,
+				accounts: vec![],
+				data: vec![],
+			},
+			&[],
+			&[Check::success()],
+		);
+	}
+}

--- a/readme.md
+++ b/readme.md
@@ -74,7 +74,7 @@ Comprehensive project documentation now lives in the mdBook under `docs/`.
 docs:build
 ```
 
-Use `verify:docs` to validate documentation structure and build output in CI.
+Use `verify:docs` to validate documentation structure and build output in CI. Use `test:idl` to verify `codama/idls/anchor_*.json` against fresh output and Codama Rust/JS validators.
 
 ## Quick start
 
@@ -444,12 +444,22 @@ cargo nextest run  # Faster parallel test execution
 
 ## Examples
 
-| Example                                       | Description                                        |
-| --------------------------------------------- | -------------------------------------------------- |
-| [`hello_solana`](examples/hello_solana)       | Minimal program — entrypoint, accounts, logging    |
-| [`counter_program`](examples/counter_program) | PDA state management with initialize and increment |
-| [`transfer_sol`](examples/transfer_sol)       | CPI and direct lamport transfers                   |
-| [`escrow_program`](examples/escrow_program)   | Full token escrow with SPL token operations        |
+| Example                                                                           | Description                                                                 |
+| --------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| [`hello_solana`](examples/hello_solana)                                           | Minimal program — entrypoint, accounts, logging                             |
+| [`counter_program`](examples/counter_program)                                     | PDA state management with initialize and increment                          |
+| [`transfer_sol`](examples/transfer_sol)                                           | CPI and direct lamport transfers                                            |
+| [`escrow_program`](examples/escrow_program)                                       | Full token escrow with SPL token operations                                 |
+| [`pinocchio_bpf_starter`](examples/pinocchio_bpf_starter)                         | Upstream BPF starter-style hello world with `sbpf-linker`                   |
+| [`anchor_declare_id`](examples/anchor_declare_id)                                 | Anchor `declare-id` test parity port for program-id mismatch                |
+| [`anchor_declare_program`](examples/anchor_declare_program)                       | Anchor `declare-program` parity port for external-program ID checks         |
+| [`anchor_duplicate_mutable_accounts`](examples/anchor_duplicate_mutable_accounts) | Anchor duplicate mutable account checks adapted to explicit pina validation |
+| [`anchor_errors`](examples/anchor_errors)                                         | Anchor custom error-code parity and guard helper checks                     |
+| [`anchor_events`](examples/anchor_events)                                         | Anchor event schema parity via deterministic event serialization            |
+| [`anchor_floats`](examples/anchor_floats)                                         | Anchor float account/update behavior with authority checks                  |
+| [`anchor_system_accounts`](examples/anchor_system_accounts)                       | Anchor system-owned account constraint parity                               |
+| [`anchor_sysvars`](examples/anchor_sysvars)                                       | Anchor sysvar account validation parity                                     |
+| [`anchor_realloc`](examples/anchor_realloc)                                       | Anchor realloc constraint parity for growth-limit and duplicate checks      |
 
 ## Security
 

--- a/scripts/generate-codama-idls.sh
+++ b/scripts/generate-codama-idls.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+IDL_DIR="$ROOT/codama/idls"
+mkdir -p "$IDL_DIR"
+
+mapfile -t ANCHOR_EXAMPLES < <(find "$ROOT/examples" -mindepth 1 -maxdepth 1 -type d -name 'anchor_*' | sort)
+
+if [ "${#ANCHOR_EXAMPLES[@]}" -eq 0 ]; then
+	echo "No anchor examples found in $ROOT/examples" >&2
+	exit 1
+fi
+
+for program_dir in "${ANCHOR_EXAMPLES[@]}"; do
+	program_name="$(basename "$program_dir")"
+	output_path="$IDL_DIR/$program_name.json"
+
+	echo "Generating Codama IDL for $program_name"
+	cargo run -p pina_cli --quiet -- idl --path "$program_dir" --output "$output_path"
+done

--- a/scripts/verify-codama-idls.sh
+++ b/scripts/verify-codama-idls.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+IDL_DIR="$ROOT/codama/idls"
+JS_TEST_DIR="$ROOT/codama/tests/js"
+
+if ! find "$IDL_DIR" -mindepth 1 -maxdepth 1 -type f -name 'anchor_*.json' | grep -q .; then
+	echo "No anchor_*.json fixtures found in $IDL_DIR" >&2
+	exit 1
+fi
+
+cargo test -p pina_cli --locked --test codama_anchor_idls
+pnpm --dir "$JS_TEST_DIR" install --frozen-lockfile
+pnpm --dir "$JS_TEST_DIR" test


### PR DESCRIPTION
## Summary
- ported additional Anchor parity examples into `examples/` (declare-id, declare-program, duplicate mutable accounts, errors, events, floats, realloc, system-accounts, sysvars)
- added parity-focused escrow coverage and documented the Anchor test porting status in mdBook docs
- added Codama IDL fixtures for all `anchor_*` examples under `codama/idls/`
- added Rust and JS IDL verification tests (`crates/pina_cli/tests/codama_anchor_idls.rs` and `codama/tests/js/validate-anchor-idls.mjs`)
- added reproducible scripts (`scripts/generate-codama-idls.sh`, `scripts/verify-codama-idls.sh`) plus `test:idl` CI wiring

## Verification
- `devenv shell -c -- test:all`
- `devenv shell -c -- test:anchor-parity`
- `devenv shell -c -- test:idl`
- `devenv shell -c -- lint:format`
- `devenv shell -c -- verify:docs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added 10 Anchor parity example programs and a Pinocchio BPF starter; added IDL fixtures and generation/verification tooling for examples.

* **Tests**
  * Added Anchor parity and IDL verification test suites and CI jobs to run them.

* **Documentation**
  * Added Anchor test‑porting docs and updated examples/CI guides.

* **Chores**
  * Updated LLVM toolchain and sbpf-linker; added a build‑bpf cargo alias for building the starter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->