### PR TITLE
docs(pina): refresh crate readme

### DIFF
--- a/.changeset/pina-readme-refresh.md
+++ b/.changeset/pina-readme-refresh.md
@@ -1,0 +1,5 @@
+---
+pina: docs
+---
+
+Refresh the `pina` crate README with up-to-date runtime features, feature flags, installation guidance, a minimal program skeleton, and Codama workflow pointers.

--- a/crates/pina/readme.md
+++ b/crates/pina/readme.md
@@ -1,10 +1,10 @@
-# pina
+# `pina`
 
-<br />
+Core runtime crate for building Solana programs on top of [`pinocchio`](https://github.com/anza-xyz/pinocchio).
 
-> A smart contract framework for solana programs.
+It provides zero-copy account loaders, discriminator-aware account/instruction/event modeling, account validation traits, and `no_std` entrypoint helpers.
 
-<br />
+[![Crates.io][crate-image]][crate-link] [![Docs.rs][docs-image]][docs-link] [![CI][ci-status-image]][ci-status-link] [![License][unlicense-image]][unlicense-link] [![codecov][codecov-image]][codecov-link]
 
 ## Installation
 
@@ -12,9 +12,76 @@
 cargo add pina
 ```
 
-## Documentation
+Enable optional token helpers:
 
-[![Crates.io][crate-image]][crate-link] [![Docs.rs][docs-image]][docs-link] [![CI][ci-status-image]][ci-status-link] [![License][unlicense-image]][unlicense-link] [![codecov][codecov-image]][codecov-link]
+```bash
+cargo add pina --features token
+```
+
+## What This Crate Includes
+
+- `nostd_entrypoint!` for `no_std` Solana entrypoint wiring.
+- `#[account]`, `#[instruction]`, `#[event]`, `#[error]`, `#[discriminator]`, and `#[derive(Accounts)]` integration via the default `derive` feature.
+- Validation chains on `AccountView` (`assert_signer`, `assert_writable`, `assert_owner`, PDA checks, sysvar checks, and more).
+- Zero-copy POD wrappers (`PodU*`, `PodI*`, `PodBool`) for stable on-chain layouts.
+- CPI helpers for system/token operations.
+
+## Feature Flags
+
+- `derive` (default): enables `pina_macros` re-exports.
+- `logs` (default): enables Solana log macros via `solana-program-log`.
+- `token`: enables SPL token/token-2022 and ATA helpers.
+
+## Minimal Program Skeleton
+
+```rust
+#![no_std]
+
+use pina::*;
+
+declare_id!("YourProgramId11111111111111111111111111111111");
+
+#[discriminator]
+pub enum Instruction {
+	Initialize = 0,
+}
+
+#[instruction(discriminator = Instruction, variant = Initialize)]
+pub struct InitializeInstruction {}
+
+nostd_entrypoint!(process_instruction);
+
+fn process_instruction(
+	program_id: &Address,
+	accounts: &[AccountView],
+	data: &[u8],
+) -> ProgramResult {
+	let ix: Instruction = parse_instruction(program_id, &ID, data)?;
+	match ix {
+		Instruction::Initialize => {
+			let _ = InitializeInstruction::try_from_bytes(data)?;
+			let _ = accounts;
+			Ok(())
+		}
+	}
+}
+```
+
+## Related Crates
+
+- [`pina_macros`](https://docs.rs/pina_macros): proc-macro implementations for the attributes and derives used here.
+- [`pina_cli`](https://docs.rs/pina_cli): CLI/library used to generate Codama IDLs from Pina programs.
+- [`pina_sdk_ids`](https://docs.rs/pina_sdk_ids): shared Solana program/sysvar IDs.
+
+## Codama IDLs
+
+`pina` models are designed to be extracted into Codama IDLs through `pina_cli`.
+
+```bash
+pina idl --path ./my_program --output ./idls/my_program.json
+```
+
+From there you can generate JS clients with Codama renderers, or Pina-style Rust clients using this repository's `pina_codama_renderer` tool.
 
 [crate-image]: https://img.shields.io/crates/v/pina.svg?style=flat-square
 [crate-link]: https://crates.io/crates/pina


### PR DESCRIPTION
## Summary
- rewrite `crates/pina/readme.md` with current runtime capabilities and feature flags
- add a minimal `no_std` program skeleton showing discriminator and entrypoint flow
- document how `pina` fits into the Codama workflow via `pina idl`

## Validation
- `devenv shell -c verify:docs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Significantly expanded the pina README with comprehensive documentation including an updated feature overview, installation and setup guidance with available feature flag options, core capability descriptions and integrations, a practical minimal no_std program skeleton example, and detailed information about related crates and Codama IDL generation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->