### PR TITLE
docs(pina_sdk_ids): expand readme usage docs

### DIFF
--- a/.changeset/pina-sdk-ids-readme-refresh.md
+++ b/.changeset/pina-sdk-ids-readme-refresh.md
@@ -1,0 +1,5 @@
+---
+pina_sdk_ids: docs
+---
+
+Refresh the `pina_sdk_ids` crate README with usage examples, module coverage, and guidance for safer typed program/sysvar ID imports.

--- a/crates/pina_sdk_ids/readme.md
+++ b/crates/pina_sdk_ids/readme.md
@@ -1,8 +1,43 @@
 # `pina_sdk_ids`
 
-> Solana SDK program IDs used by `pina`.
+Typed constants for well-known Solana program IDs and sysvar IDs.
+
+Each module exposes an `ID` constant declared via `solana_address::declare_id!`.
 
 [![Crates.io][crate-image]][crate-link] [![Docs.rs][docs-image]][docs-link] [![CI][ci-status-image]][ci-status-link] [![License][unlicense-image]][unlicense-link] [![codecov][codecov-image]][codecov-link]
+
+## Installation
+
+```bash
+cargo add pina_sdk_ids
+```
+
+## Usage
+
+```rust
+use pina_sdk_ids::system_program;
+use pina_sdk_ids::sysvar;
+
+let system_program_id = system_program::ID;
+let clock_sysvar_id = sysvar::clock::ID;
+```
+
+## Included IDs
+
+- Core programs: `system_program`, `stake`, `vote`, `config`, `feature`, loaders.
+- Signature verification programs: `ed25519_program`, `secp256k1_program`, `secp256r1_program`.
+- Sysvars: `sysvar::clock`, `sysvar::rent`, `sysvar::stake_history`, and more.
+- Utility addresses: `incinerator`, compute budget, lookup table, and zk proof programs.
+
+## Why Use This Crate
+
+- Avoid hard-coded base58 strings across codebases.
+- Keep ID imports centralized and typed.
+- Make account/program validation checks more readable.
+
+## `no_std`
+
+`pina_sdk_ids` is `#![no_std]` and safe for on-chain program crates.
 
 [crate-image]: https://img.shields.io/crates/v/pina_sdk_ids.svg?style=flat-square
 [crate-link]: https://crates.io/crates/pina_sdk_ids


### PR DESCRIPTION
## Summary
- expand `crates/pina_sdk_ids/readme.md` with clear usage examples and module coverage
- document why typed ID imports improve readability/safety over raw base58 literals
- add `no_std` expectations for on-chain crates

## Validation
- `devenv shell -c verify:docs`
