### PR TITLE
docs(book): add codama workflow chapter

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -5,6 +5,7 @@
 - [Getting Started](./getting-started.md)
 - [Core Concepts](./core-concepts.md)
 - [Crates and Features](./crates-and-features.md)
+- [Codama Workflow](./codama-workflow.md)
 - [Examples](./examples.md)
 - [Anchor Test Porting](./anchor-test-porting.md)
 - [Security Model](./security-model.md)

--- a/docs/src/codama-workflow.md
+++ b/docs/src/codama-workflow.md
@@ -1,0 +1,76 @@
+# Codama Workflow
+
+This repository uses Codama as the IDL and client-generation layer for Pina programs.
+
+The flow has three stages:
+
+1. Generate Codama JSON from Rust programs (`pina idl`).
+2. Validate generated JSON against committed fixtures/tests.
+3. Render clients (JS with Codama renderers, Rust with `pina_codama_renderer`).
+
+## In This Repository
+
+Generate and validate the whole workspace flow with `devenv` scripts:
+
+```bash
+# Generate Codama IDLs for all examples.
+codama:idl:all
+
+# Generate Rust + JS clients.
+codama:clients:generate
+
+# Run the complete Codama pipeline.
+codama:test
+
+# Run IDL fixture drift + validation checks used by CI.
+test:idl
+```
+
+Supporting scripts:
+
+- `scripts/generate-codama-idls.sh`: regenerates `codama/idls/anchor_*.json` fixtures.
+- `scripts/verify-codama-idls.sh`: verifies fixtures via Rust and JS tests.
+
+## In a Separate Project
+
+You do not need to copy this entire repository to use Codama with Pina.
+
+### 1. Generate IDL from your program
+
+```bash
+pina idl --path ./programs/my_program --output ./idls/my_program.json
+```
+
+### 2. Generate JS clients with Codama
+
+```bash
+pnpm add -D codama @codama/renderers-js
+```
+
+```js
+import { createFromFile } from "codama";
+import { renderVisitor as renderJsVisitor } from "@codama/renderers-js";
+
+const codama = await createFromFile("./idls/my_program.json");
+await codama.accept(renderJsVisitor("./clients/js/my_program"));
+```
+
+### 3. Generate Pina-style Rust clients (optional)
+
+This repository ships `codama/pina_codama_renderer`, which emits Rust models aligned with Pina's discriminator-first, fixed-size POD layouts.
+
+```bash
+cargo run --manifest-path ./codama/pina_codama_renderer/Cargo.toml -- \
+  --idl ./idls/my_program.json \
+  --output ./clients/rust
+```
+
+You can pass multiple `--idl` flags or `--idl-dir`.
+
+## Renderer Constraints
+
+`pina_codama_renderer` intentionally targets fixed-size layouts. Unsupported patterns produce explicit errors (for example variable-length strings/bytes, unsupported endian/number forms, and non-fixed arrays).
+
+## CI Coverage
+
+Codama checks are enforced in the `ci` workflow via `test:idl`.

--- a/docs/src/crates-and-features.md
+++ b/docs/src/crates-and-features.md
@@ -2,30 +2,56 @@
 
 ## `crates/pina`
 
-Core runtime crate with:
+Core runtime crate for on-chain program logic.
 
-- Validation traits and helper methods
-- PDA and CPI helpers
-- `nostd_entrypoint!` and dispatch helpers
-- Optional token integrations
+Includes:
 
-### Main features
+- `AccountView` and validation chain helpers.
+- Typed account loaders and discriminator checks.
+- CPI/system/token helper utilities.
+- `nostd_entrypoint!` and instruction parsing helpers.
 
-- `derive` (default): enables proc-macro integration
-- `logs` (default): on-chain log support
-- `token`: SPL token/token-2022 helpers and typed conversions
+Feature flags:
+
+- `derive` (default): enables proc macro re-exports from `pina_macros`.
+- `logs` (default): on-chain logging support.
+- `token`: SPL token/token-2022 + ATA helper APIs.
 
 ## `crates/pina_macros`
 
-Proc-macro crate that defines:
+Proc-macro crate used by `pina`.
 
+Provides:
+
+- `#[discriminator]`
 - `#[account]`
 - `#[instruction]`
 - `#[event]`
 - `#[error]`
-- `#[discriminator]`
 - `#[derive(Accounts)]`
+
+## `crates/pina_cli`
+
+Developer CLI and library.
+
+Commands:
+
+- `pina init`: scaffold a new Pina program crate.
+- `pina idl`: parse a Pina program and output Codama JSON.
+
+Library surface:
+
+- `pina_cli::generate_idl(program_path, name_override)`
+- `pina_cli::init_project(path, package_name, force)`
 
 ## `crates/pina_sdk_ids`
 
-Shared Solana IDs for known programs/sysvars to keep address usage centralized and typed.
+`no_std` crate that exports well-known Solana program/sysvar IDs as typed constants.
+
+Use this crate to avoid hardcoded base58 literals in validation logic.
+
+## `codama/pina_codama_renderer`
+
+Repository-local renderer binary that generates Pina-style Rust client code from Codama JSON.
+
+Use this when you want generated Rust models to match Pina's fixed-size discriminator-first/bytemuck conventions.

--- a/docs/src/development-workflow.md
+++ b/docs/src/development-workflow.md
@@ -33,6 +33,22 @@ test:idl
 update:deps
 ```
 
+## Codama/IDL workflow
+
+```bash
+# Regenerate all example IDLs.
+codama:idl:all
+
+# Generate clients from Codama JSON.
+codama:clients:generate
+
+# Full Codama pipeline (build CLI, generate IDLs, generate clients, checks).
+codama:test
+
+# CI-oriented IDL validation.
+test:idl
+```
+
 ## Dependency security
 
 - `security:deny` runs policy checks (license allow-list, source restrictions, dependency bans).

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -28,6 +28,14 @@ lint:format
 verify:docs
 ```
 
+## Generate a Codama IDL
+
+```bash
+pina idl --path ./examples/counter_program --output ./codama/idls/counter_program.json
+```
+
+See [Codama Workflow](./codama-workflow.md) for end-to-end generation and external-project usage.
+
 ## Build this documentation
 
 ```bash

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -9,6 +9,7 @@ This book is the single place for project documentation. It complements API refe
 - The project's goals and trade-offs.
 - Setup and day-to-day development workflow.
 - Core framework concepts (`#[account]`, `#[instruction]`, `#[derive(Accounts)]`, discriminator model, and validation chains).
+- Codama IDL/client-generation workflow (including external-project invocation).
 - Guidance for examples and security-focused development.
 - CI/release pipeline expectations.
 - A practical recommendations roadmap for improving goal alignment.

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,13 @@ A performant Solana smart contract framework built on top of [pinocchio](https:/
 - **Proc-macro sugar** — `#[account]`, `#[instruction]`, `#[event]`, `#[error]`, `#[discriminator]`, and `#[derive(Accounts)]` eliminate boilerplate.
 - **CPI helpers** — PDA account creation, lamport transfers, and token operations.
 
+## Workspace packages
+
+- `crates/pina` — core runtime crate (`no_std`, account validation/loaders, CPI helpers, entrypoint).
+- `crates/pina_macros` — proc macros (`#[account]`, `#[instruction]`, `#[event]`, `#[error]`, `#[discriminator]`, `#[derive(Accounts)]`).
+- `crates/pina_cli` — CLI/library for IDL generation and project scaffolding (`pina idl`, `pina init`).
+- `crates/pina_sdk_ids` — typed constants for well-known Solana program/sysvar IDs.
+
 ## Installation
 
 ```sh
@@ -59,6 +66,37 @@ End-to-end setup steps:
 3. Generate all IDLs: `codama:idl:all`
 4. Generate clients from the IDLs: `codama:clients:generate`
 5. Run the full validation pipeline: `codama:test`
+
+### Using Codama in separate projects
+
+You can use `pina idl` outside this repository to bootstrap clients in another codebase.
+
+```sh
+# Generate a Codama JSON file from your Pina program crate.
+pina idl --path ./programs/my_program --output ./idls/my_program.json
+```
+
+Then render clients in your destination project:
+
+```sh
+pnpm add -D codama @codama/renderers-js
+```
+
+```js
+import { createFromFile } from "codama";
+import { renderVisitor as renderJsVisitor } from "@codama/renderers-js";
+
+const codama = await createFromFile("./idls/my_program.json");
+await codama.accept(renderJsVisitor("./clients/js/my_program"));
+```
+
+For Pina-style Rust client generation (discriminator-first, bytemuck POD types), use this repository's renderer:
+
+```sh
+cargo run --manifest-path ./codama/pina_codama_renderer/Cargo.toml -- \
+  --idl ./idls/my_program.json \
+  --output ./clients/rust
+```
 
 ### Crate features
 


### PR DESCRIPTION
## Summary
- add a dedicated mdBook chapter for Codama workflow (`docs/src/codama-workflow.md`)
- document how to invoke Codama from this repo and from separate projects
- update getting started, crates/features overview, and project index to include the Codama flow
- extend root README with package map and external Codama usage examples

## Validation
- `devenv shell -c verify:docs`
