### PR TITLE
docs(examples): add readmes for all example programs

### DIFF
--- a/.changeset/examples-readmes.md
+++ b/.changeset/examples-readmes.md
@@ -1,0 +1,5 @@
+---
+pina: docs
+---
+
+Add dedicated `readme.md` files to all example program directories with focused coverage notes and local run commands (`cargo test`, `pina idl`, and optional SBF build commands).

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -22,6 +22,8 @@ Use examples as reference implementations for account layout, instruction parsin
 
 Anchor test-suite parity progress is tracked in [Anchor Test Porting](./anchor-test-porting.md).
 
+Every example directory includes a local `readme.md` with purpose, coverage, and run commands.
+
 When adding new examples:
 
 - Keep instruction/account discriminator handling explicit.

--- a/examples/anchor_declare_id/readme.md
+++ b/examples/anchor_declare_id/readme.md
@@ -1,0 +1,21 @@
+# `anchor_declare_id`
+
+Anchor parity example for the `declare-id` test case.
+
+## What it covers
+
+- Program ID verification through `parse_instruction`.
+- Accepting matching `program_id` and rejecting mismatches.
+
+## Run
+
+```bash
+cargo test -p anchor_declare_id
+pina idl --path examples/anchor_declare_id --output codama/idls/anchor_declare_id.json
+```
+
+## Optional SBF build
+
+```bash
+cargo build --release --target bpfel-unknown-none -p anchor_declare_id -Z build-std -F bpf-entrypoint
+```

--- a/examples/anchor_declare_program/readme.md
+++ b/examples/anchor_declare_program/readme.md
@@ -1,0 +1,21 @@
+# `anchor_declare_program`
+
+Anchor parity example for `declare-program` behavior.
+
+## What it covers
+
+- Validating an external program account against an expected ID.
+- Requiring the external program account to be executable.
+
+## Run
+
+```bash
+cargo test -p anchor_declare_program
+pina idl --path examples/anchor_declare_program --output codama/idls/anchor_declare_program.json
+```
+
+## Optional SBF build
+
+```bash
+cargo build --release --target bpfel-unknown-none -p anchor_declare_program -Z build-std -F bpf-entrypoint
+```

--- a/examples/anchor_duplicate_mutable_accounts/readme.md
+++ b/examples/anchor_duplicate_mutable_accounts/readme.md
@@ -1,0 +1,22 @@
+# `anchor_duplicate_mutable_accounts`
+
+Anchor parity example for duplicate mutable account checks.
+
+## What it covers
+
+- Explicit duplicate mutable account detection in program logic.
+- Separate behavior for duplicate read-only accounts.
+- Custom error mapping (`ConstraintDuplicateMutableAccount`).
+
+## Run
+
+```bash
+cargo test -p anchor_duplicate_mutable_accounts
+pina idl --path examples/anchor_duplicate_mutable_accounts --output codama/idls/anchor_duplicate_mutable_accounts.json
+```
+
+## Optional SBF build
+
+```bash
+cargo build --release --target bpfel-unknown-none -p anchor_duplicate_mutable_accounts -Z build-std -F bpf-entrypoint
+```

--- a/examples/anchor_errors/readme.md
+++ b/examples/anchor_errors/readme.md
@@ -1,0 +1,22 @@
+# `anchor_errors`
+
+Anchor parity example for custom error behavior.
+
+## What it covers
+
+- Deterministic custom error code mapping.
+- Guard helper behavior (`require_eq`, `require_neq`, `require_gt`, `require_gte`).
+- Instruction variant to error-code parity checks.
+
+## Run
+
+```bash
+cargo test -p anchor_errors
+pina idl --path examples/anchor_errors --output codama/idls/anchor_errors.json
+```
+
+## Optional SBF build
+
+```bash
+cargo build --release --target bpfel-unknown-none -p anchor_errors -Z build-std -F bpf-entrypoint
+```

--- a/examples/anchor_events/readme.md
+++ b/examples/anchor_events/readme.md
@@ -1,0 +1,22 @@
+# `anchor_events`
+
+Anchor parity example for event modeling.
+
+## What it covers
+
+- Event discriminator definitions.
+- Deterministic event payload construction.
+- Event serialization round-trip checks.
+
+## Run
+
+```bash
+cargo test -p anchor_events
+pina idl --path examples/anchor_events --output codama/idls/anchor_events.json
+```
+
+## Optional SBF build
+
+```bash
+cargo build --release --target bpfel-unknown-none -p anchor_events -Z build-std -F bpf-entrypoint
+```

--- a/examples/anchor_floats/readme.md
+++ b/examples/anchor_floats/readme.md
@@ -1,0 +1,22 @@
+# `anchor_floats`
+
+Anchor parity example for float account fields.
+
+## What it covers
+
+- Creating and updating account state with `f32`/`f64` values.
+- Authority-gated updates.
+- Bit-level conversion through `PodU32`/`PodU64`.
+
+## Run
+
+```bash
+cargo test -p anchor_floats
+pina idl --path examples/anchor_floats --output codama/idls/anchor_floats.json
+```
+
+## Optional SBF build
+
+```bash
+cargo build --release --target bpfel-unknown-none -p anchor_floats -Z build-std -F bpf-entrypoint
+```

--- a/examples/anchor_realloc/readme.md
+++ b/examples/anchor_realloc/readme.md
@@ -1,0 +1,22 @@
+# `anchor_realloc`
+
+Anchor parity example for realloc safety constraints.
+
+## What it covers
+
+- Maximum permitted account data increase checks.
+- Duplicate realloc target detection.
+- Multi-account realloc validation patterns.
+
+## Run
+
+```bash
+cargo test -p anchor_realloc
+pina idl --path examples/anchor_realloc --output codama/idls/anchor_realloc.json
+```
+
+## Optional SBF build
+
+```bash
+cargo build --release --target bpfel-unknown-none -p anchor_realloc -Z build-std -F bpf-entrypoint
+```

--- a/examples/anchor_system_accounts/readme.md
+++ b/examples/anchor_system_accounts/readme.md
@@ -1,0 +1,21 @@
+# `anchor_system_accounts`
+
+Anchor parity example for system-owned account checks.
+
+## What it covers
+
+- Signer validation for authority accounts.
+- Owner validation for system wallet accounts.
+
+## Run
+
+```bash
+cargo test -p anchor_system_accounts
+pina idl --path examples/anchor_system_accounts --output codama/idls/anchor_system_accounts.json
+```
+
+## Optional SBF build
+
+```bash
+cargo build --release --target bpfel-unknown-none -p anchor_system_accounts -Z build-std -F bpf-entrypoint
+```

--- a/examples/anchor_sysvars/readme.md
+++ b/examples/anchor_sysvars/readme.md
@@ -1,0 +1,21 @@
+# `anchor_sysvars`
+
+Anchor parity example for sysvar account validation.
+
+## What it covers
+
+- Clock, rent, and stake-history sysvar address checks.
+- Instruction dispatch and program-id mismatch checks.
+
+## Run
+
+```bash
+cargo test -p anchor_sysvars
+pina idl --path examples/anchor_sysvars --output codama/idls/anchor_sysvars.json
+```
+
+## Optional SBF build
+
+```bash
+cargo build --release --target bpfel-unknown-none -p anchor_sysvars -Z build-std -F bpf-entrypoint
+```

--- a/examples/counter_program/readme.md
+++ b/examples/counter_program/readme.md
@@ -1,0 +1,22 @@
+# `counter_program`
+
+Reference counter example built with Pina.
+
+## What it covers
+
+- PDA-backed account creation.
+- Counter state mutation (`Initialize`, `Increment`).
+- Account validation chains and zero-copy state layout.
+
+## Run
+
+```bash
+cargo test -p counter_program
+pina idl --path examples/counter_program --output codama/idls/counter_program.json
+```
+
+## Optional SBF build
+
+```bash
+cargo build --release --target bpfel-unknown-none -p counter_program -Z build-std -F bpf-entrypoint
+```

--- a/examples/escrow_program/readme.md
+++ b/examples/escrow_program/readme.md
@@ -1,0 +1,22 @@
+# `escrow_program`
+
+Token escrow reference program built with Pina.
+
+## What it covers
+
+- Escrow lifecycle with `Make` and `Take` instructions.
+- Vault PDA handling and seed validation.
+- Token account checks and transfer flow.
+
+## Run
+
+```bash
+cargo test -p escrow_program
+pina idl --path examples/escrow_program --output codama/idls/escrow_program.json
+```
+
+## Optional SBF build
+
+```bash
+cargo build --release --target bpfel-unknown-none -p escrow_program -Z build-std -F bpf-entrypoint
+```

--- a/examples/hello_solana/readme.md
+++ b/examples/hello_solana/readme.md
@@ -1,0 +1,22 @@
+# `hello_solana`
+
+Minimal Pina program example.
+
+## What it covers
+
+- Basic instruction discriminator and parsing flow.
+- `#[derive(Accounts)]` for account extraction.
+- Signer validation plus on-chain log output.
+
+## Run
+
+```bash
+cargo test -p hello_solana
+pina idl --path examples/hello_solana --output codama/idls/hello_solana.json
+```
+
+## Optional SBF build
+
+```bash
+cargo build --release --target bpfel-unknown-none -p hello_solana -Z build-std -F bpf-entrypoint
+```

--- a/examples/todo_program/readme.md
+++ b/examples/todo_program/readme.md
@@ -1,0 +1,22 @@
+# `todo_program`
+
+PDA-backed todo state example.
+
+## What it covers
+
+- Creating todo state accounts (`Initialize`).
+- Toggling completion state (`ToggleCompleted`).
+- Updating fixed-size digest data (`UpdateDigest`).
+
+## Run
+
+```bash
+cargo test -p todo_program
+pina idl --path examples/todo_program --output codama/idls/todo_program.json
+```
+
+## Optional SBF build
+
+```bash
+cargo build --release --target bpfel-unknown-none -p todo_program -Z build-std -F bpf-entrypoint
+```

--- a/examples/transfer_sol/readme.md
+++ b/examples/transfer_sol/readme.md
@@ -1,0 +1,22 @@
+# `transfer_sol`
+
+SOL transfer example showing two transfer patterns.
+
+## What it covers
+
+- CPI transfer through the system program (`CpiTransfer`).
+- Direct lamport mutation for program-owned accounts (`DirectTransfer`).
+- Custom error handling for insufficient funds.
+
+## Run
+
+```bash
+cargo test -p transfer_sol
+pina idl --path examples/transfer_sol --output codama/idls/transfer_sol.json
+```
+
+## Optional SBF build
+
+```bash
+cargo build --release --target bpfel-unknown-none -p transfer_sol -Z build-std -F bpf-entrypoint
+```


### PR DESCRIPTION
## Summary
- add missing `readme.md` files across all example program directories
- document each example's purpose and key behavior coverage
- include per-example run commands (`cargo test`, `pina idl`, optional SBF build)
- update mdBook examples page to reflect that every example now ships with local docs

## Validation
- `devenv shell -c 'dprint fmt .changeset/* --allow-no-files && lint:format && verify:docs'`
