### PR TITLE
docs: fix main formatting regression

### DIFF
--- a/.changeset/main-formatting-fix.md
+++ b/.changeset/main-formatting-fix.md
@@ -1,0 +1,6 @@
+---
+pina: docs
+pina_cli: docs
+---
+
+Fix markdown JS snippet import ordering so `dprint` formatting checks pass in CI.

--- a/crates/pina_cli/readme.md
+++ b/crates/pina_cli/readme.md
@@ -69,8 +69,8 @@ pnpm add -D codama @codama/renderers-js
 ```
 
 ```js
-import { createFromFile } from "codama";
 import { renderVisitor as renderJsVisitor } from "@codama/renderers-js";
+import { createFromFile } from "codama";
 
 const codama = await createFromFile("./idls/my_program.json");
 await codama.accept(renderJsVisitor("./clients/js/my_program"));

--- a/docs/src/codama-workflow.md
+++ b/docs/src/codama-workflow.md
@@ -48,8 +48,8 @@ pnpm add -D codama @codama/renderers-js
 ```
 
 ```js
-import { createFromFile } from "codama";
 import { renderVisitor as renderJsVisitor } from "@codama/renderers-js";
+import { createFromFile } from "codama";
 
 const codama = await createFromFile("./idls/my_program.json");
 await codama.accept(renderJsVisitor("./clients/js/my_program"));

--- a/readme.md
+++ b/readme.md
@@ -83,8 +83,8 @@ pnpm add -D codama @codama/renderers-js
 ```
 
 ```js
-import { createFromFile } from "codama";
 import { renderVisitor as renderJsVisitor } from "@codama/renderers-js";
+import { createFromFile } from "codama";
 
 const codama = await createFromFile("./idls/my_program.json");
 await codama.accept(renderJsVisitor("./clients/js/my_program"));


### PR DESCRIPTION
## Summary
- fix `dprint` formatting failures on `main` caused by import ordering in JS markdown snippets
- update snippet order in:
  - `readme.md`
  - `crates/pina_cli/readme.md`
  - `docs/src/codama-workflow.md`
- add docs changeset for the readme formatting fix

## Validation
- `devenv shell -c 'dprint fmt .changeset/* --allow-no-files && lint:format && verify:docs'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code examples with import statement reordering in documentation files.

* **Style**
  * Fixed markdown formatting in code snippets to meet formatting standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->