### PR TITLE
feat(pina): add badges, PodBool validation, 50+ tests, and mdt book blocks

### DIFF
--- a/.changeset/badges-book-coverage-fixes.md
+++ b/.changeset/badges-book-coverage-fixes.md
@@ -1,0 +1,22 @@
+---
+pina: docs
+pina_pod_primitives: minor
+---
+
+Added `PodBool::is_canonical()` method to detect non-canonical boolean values (2–255) that pass `bytemuck` deserialization but fail `PartialEq` comparison against canonical `PodBool(0)` or `PodBool(1)`. Programs should call `is_canonical()` at deserialization boundaries to validate account data integrity.
+
+Added badges (crates.io, docs.rs, CI, license, codecov) to `pina_pod_primitives` readme and root workspace readme. Created readme for `pina_codama_renderer` crate.
+
+Added 50+ new tests across pina and pina_pod_primitives covering:
+
+- `parse_instruction` (valid/invalid discriminators, wrong program ID, empty data, error remapping)
+- `PinaProgramError` error codes (correct discriminants, reserved range, uniqueness)
+- `assert` function (true/false conditions, custom error types)
+- PDA functions (determinism, seed variations, roundtrip, wrong bump)
+- Pod types (boundary values, endianness, bytemuck deserialization, defaults)
+- PodBool canonical validation (non-canonical equality mismatch detection)
+- AccountDeserialize trait (field preservation, mutable modification, wrong offset)
+- Discriminator write/read roundtrips for all primitive sizes
+- Lamport helper edge cases (exact balance, zero transfer, max values)
+
+Updated book chapters to use mdt shared blocks for codama workflow commands, release workflow commands, and feature flags table. Added three new mdt providers (`codamaWorkflowCommands`, `releaseWorkflowCommands`, `pinaFeatureFlags`) to `template.t.md`.

--- a/crates/pina/src/loaders.rs
+++ b/crates/pina/src/loaders.rs
@@ -709,4 +709,51 @@ mod tests {
 			.unwrap_or_else(|err| panic!("expected valid close balance: {err:?}"));
 		assert_eq!(result, 9);
 	}
+
+	#[test]
+	fn checked_send_balances_exact_balance() {
+		let (sender, recipient) = checked_send_balances(5, 3, 5)
+			.unwrap_or_else(|err| panic!("expected valid transfer: {err:?}"));
+		assert_eq!(sender, 0);
+		assert_eq!(recipient, 8);
+	}
+
+	#[test]
+	fn checked_send_balances_zero_transfer() {
+		let (sender, recipient) = checked_send_balances(10, 5, 0)
+			.unwrap_or_else(|err| panic!("expected valid transfer: {err:?}"));
+		assert_eq!(sender, 10);
+		assert_eq!(recipient, 5);
+	}
+
+	#[test]
+	fn checked_send_balances_max_values() {
+		// Test with large values near u64::MAX boundaries.
+		let result = checked_send_balances(u64::MAX, 0, u64::MAX);
+		let (sender, recipient) =
+			result.unwrap_or_else(|err| panic!("expected valid transfer: {err:?}"));
+		assert_eq!(sender, 0);
+		assert_eq!(recipient, u64::MAX);
+	}
+
+	#[test]
+	fn checked_close_balance_zero_sender() {
+		let result = checked_close_balance(0, 5)
+			.unwrap_or_else(|err| panic!("expected valid close: {err:?}"));
+		assert_eq!(result, 5);
+	}
+
+	#[test]
+	fn checked_close_balance_both_zero() {
+		let result = checked_close_balance(0, 0)
+			.unwrap_or_else(|err| panic!("expected valid close: {err:?}"));
+		assert_eq!(result, 0);
+	}
+
+	#[test]
+	fn checked_close_balance_max_sender_zero_recipient() {
+		let result = checked_close_balance(u64::MAX, 0)
+			.unwrap_or_else(|err| panic!("expected valid close: {err:?}"));
+		assert_eq!(result, u64::MAX);
+	}
 }

--- a/crates/pina/tests/error_types.rs
+++ b/crates/pina/tests/error_types.rs
@@ -1,0 +1,105 @@
+use pina::PinaProgramError;
+use pina::ProgramError;
+
+fn error_to_code(variant: PinaProgramError) -> u32 {
+	let program_error: ProgramError = variant.into();
+	match program_error {
+		ProgramError::Custom(code) => code,
+		_ => panic!("expected Custom error variant"),
+	}
+}
+
+/// Verify that all PinaProgramError variants have the correct error codes
+/// in the top end of the u32 range (0xFFFF_0000..=0xFFFF_FFFF).
+#[test]
+fn error_codes_match_expected_discriminants() {
+	assert_eq!(error_to_code(PinaProgramError::DataTooShort), 0xFFFF_FFFA);
+	assert_eq!(
+		error_to_code(PinaProgramError::InvalidAccountSize),
+		0xFFFF_FFFB
+	);
+	assert_eq!(
+		error_to_code(PinaProgramError::InvalidTokenOwner),
+		0xFFFF_FFFC
+	);
+	assert_eq!(error_to_code(PinaProgramError::SeedsTooMany), 0xFFFF_FFFD);
+	assert_eq!(
+		error_to_code(PinaProgramError::TooManyAccountKeys),
+		0xFFFF_FFFE
+	);
+	assert_eq!(
+		error_to_code(PinaProgramError::InvalidDiscriminator),
+		0xFFFF_FFFF
+	);
+}
+
+/// Error codes should occupy the reserved top range and not collide with
+/// typical user error codes (which start at 0).
+#[test]
+fn error_codes_are_in_reserved_range() {
+	let variants = [
+		PinaProgramError::DataTooShort,
+		PinaProgramError::InvalidAccountSize,
+		PinaProgramError::InvalidTokenOwner,
+		PinaProgramError::SeedsTooMany,
+		PinaProgramError::TooManyAccountKeys,
+		PinaProgramError::InvalidDiscriminator,
+	];
+
+	for variant in &variants {
+		let code = error_to_code(*variant);
+		assert!(
+			code >= 0xFFFF_0000,
+			"error code {code:#X} is outside the reserved range"
+		);
+	}
+}
+
+/// All six variants should have distinct error codes.
+#[test]
+fn error_codes_are_unique() {
+	let codes: Vec<u32> = [
+		PinaProgramError::DataTooShort,
+		PinaProgramError::InvalidAccountSize,
+		PinaProgramError::InvalidTokenOwner,
+		PinaProgramError::SeedsTooMany,
+		PinaProgramError::TooManyAccountKeys,
+		PinaProgramError::InvalidDiscriminator,
+	]
+	.iter()
+	.map(|v| error_to_code(*v))
+	.collect();
+
+	for (i, code) in codes.iter().enumerate() {
+		for (j, other) in codes.iter().enumerate() {
+			if i != j {
+				assert_ne!(code, other, "duplicate error code at indices {i} and {j}");
+			}
+		}
+	}
+}
+
+/// PartialEq works correctly for all variants.
+#[test]
+fn error_variant_equality() {
+	assert!(PinaProgramError::DataTooShort == PinaProgramError::DataTooShort);
+	assert!(PinaProgramError::DataTooShort != PinaProgramError::InvalidDiscriminator);
+}
+
+/// Verify that conversion to ProgramError::Custom is consistent.
+#[test]
+fn error_into_program_error_is_custom() {
+	let variants = [
+		PinaProgramError::DataTooShort,
+		PinaProgramError::InvalidAccountSize,
+		PinaProgramError::InvalidTokenOwner,
+		PinaProgramError::SeedsTooMany,
+		PinaProgramError::TooManyAccountKeys,
+		PinaProgramError::InvalidDiscriminator,
+	];
+
+	for variant in &variants {
+		let pe: ProgramError = (*variant).into();
+		assert!(matches!(pe, ProgramError::Custom(_)));
+	}
+}

--- a/crates/pina/tests/pda_functions.rs
+++ b/crates/pina/tests/pda_functions.rs
@@ -1,0 +1,84 @@
+use pina::ProgramError;
+use pina::create_program_address;
+use pina::try_find_program_address;
+
+const SYSTEM_ID: pina::Address = pina::address!("11111111111111111111111111111111");
+
+#[test]
+fn try_find_program_address_returns_some_for_valid_seeds() {
+	let result = try_find_program_address(&[b"test-seed"], &SYSTEM_ID);
+	assert!(result.is_some(), "expected to derive a PDA");
+}
+
+#[test]
+fn try_find_program_address_deterministic() {
+	let (addr1, bump1) =
+		try_find_program_address(&[b"hello"], &SYSTEM_ID).unwrap_or_else(|| panic!("no PDA"));
+	let (addr2, bump2) =
+		try_find_program_address(&[b"hello"], &SYSTEM_ID).unwrap_or_else(|| panic!("no PDA"));
+
+	assert_eq!(addr1, addr2, "PDA derivation should be deterministic");
+	assert_eq!(bump1, bump2, "bump should be deterministic");
+}
+
+#[test]
+fn try_find_program_address_different_seeds_produce_different_addresses() {
+	let (addr1, _) =
+		try_find_program_address(&[b"seed-a"], &SYSTEM_ID).unwrap_or_else(|| panic!("no PDA"));
+	let (addr2, _) =
+		try_find_program_address(&[b"seed-b"], &SYSTEM_ID).unwrap_or_else(|| panic!("no PDA"));
+
+	assert_ne!(
+		addr1, addr2,
+		"different seeds should produce different PDAs"
+	);
+}
+
+#[test]
+fn create_program_address_roundtrip() {
+	let (pda, bump) =
+		try_find_program_address(&[b"roundtrip"], &SYSTEM_ID).unwrap_or_else(|| panic!("no PDA"));
+
+	let bump_seed = [bump];
+	let recreated = create_program_address(&[b"roundtrip", &bump_seed], &SYSTEM_ID)
+		.unwrap_or_else(|e| panic!("failed to recreate PDA: {e:?}"));
+
+	assert_eq!(pda, recreated, "roundtrip PDA should match");
+}
+
+#[test]
+fn create_program_address_wrong_bump_fails() {
+	let (_pda, bump) =
+		try_find_program_address(&[b"bump-test"], &SYSTEM_ID).unwrap_or_else(|| panic!("no PDA"));
+
+	// Use a different bump — this should either fail or produce a different address.
+	let wrong_bump = bump.wrapping_add(1);
+	let wrong_bump_seed = [wrong_bump];
+	let result = create_program_address(&[b"bump-test", &wrong_bump_seed], &SYSTEM_ID);
+
+	match result {
+		Ok(addr) => {
+			let correct = try_find_program_address(&[b"bump-test"], &SYSTEM_ID)
+				.unwrap_or_else(|| panic!("no PDA"));
+			assert_ne!(
+				addr, correct.0,
+				"wrong bump should produce a different address"
+			);
+		}
+		Err(err) => {
+			assert_eq!(err, ProgramError::InvalidSeeds);
+		}
+	}
+}
+
+#[test]
+fn try_find_program_address_empty_seeds() {
+	let result = try_find_program_address(&[], &SYSTEM_ID);
+	assert!(result.is_some(), "empty seeds should still derive a PDA");
+}
+
+#[test]
+fn try_find_program_address_multiple_seeds() {
+	let result = try_find_program_address(&[b"prefix", b"middle", b"suffix"], &SYSTEM_ID);
+	assert!(result.is_some(), "multi-seed PDA should derive");
+}

--- a/crates/pina/tests/utils_functions.rs
+++ b/crates/pina/tests/utils_functions.rs
@@ -1,0 +1,100 @@
+use pina::ProgramError;
+use pina::parse_instruction;
+
+// Use the pina discriminator macro to create a proper discriminator enum.
+#[pina::discriminator(crate = ::pina)]
+#[derive(Debug, PartialEq)]
+pub enum TestInstruction {
+	Initialize = 0,
+	Update = 1,
+	Close = 2,
+}
+
+// Use the system program ID for tests (valid base58).
+const PROGRAM_ID: pina::Address = pina::address!("11111111111111111111111111111111");
+
+#[test]
+fn parse_instruction_valid_discriminator() {
+	let data = [0u8]; // Initialize = 0
+	let result: TestInstruction = parse_instruction(&PROGRAM_ID, &PROGRAM_ID, &data)
+		.unwrap_or_else(|e| panic!("expected valid parse: {e:?}"));
+	assert_eq!(result, TestInstruction::Initialize);
+}
+
+#[test]
+fn parse_instruction_all_variants() {
+	for (byte, expected) in [
+		(0u8, TestInstruction::Initialize),
+		(1u8, TestInstruction::Update),
+		(2u8, TestInstruction::Close),
+	] {
+		let data = [byte];
+		let result: TestInstruction = parse_instruction(&PROGRAM_ID, &PROGRAM_ID, &data)
+			.unwrap_or_else(|e| panic!("expected valid parse for variant {byte}: {e:?}"));
+		assert_eq!(result, expected);
+	}
+}
+
+#[test]
+fn parse_instruction_wrong_program_id() {
+	let data = [0u8];
+	// Use a known-different valid address (Token program).
+	let wrong_id = pina::address!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+	let err = parse_instruction::<TestInstruction>(&PROGRAM_ID, &wrong_id, &data).unwrap_err();
+	assert_eq!(err, ProgramError::IncorrectProgramId);
+}
+
+#[test]
+fn parse_instruction_empty_data() {
+	let data: &[u8] = &[];
+	let err = parse_instruction::<TestInstruction>(&PROGRAM_ID, &PROGRAM_ID, data).unwrap_err();
+	assert_eq!(err, ProgramError::InvalidInstructionData);
+}
+
+/// Invalid discriminator byte (e.g. 99) should be remapped from
+/// ProgramError::Custom (InvalidDiscriminator) to InvalidInstructionData.
+#[test]
+fn parse_instruction_invalid_discriminator_remapped() {
+	let data = [99u8];
+	let err = parse_instruction::<TestInstruction>(&PROGRAM_ID, &PROGRAM_ID, &data).unwrap_err();
+	// The key behavior: Custom errors from invalid discriminators are
+	// remapped to InvalidInstructionData for a generic "bad data" error.
+	assert_eq!(err, ProgramError::InvalidInstructionData);
+}
+
+#[test]
+fn parse_instruction_extra_data_is_ok() {
+	// Extra trailing bytes after the discriminator should be ignored.
+	let data = [1u8, 0xFF, 0xFF, 0xFF];
+	let result: TestInstruction = parse_instruction(&PROGRAM_ID, &PROGRAM_ID, &data)
+		.unwrap_or_else(|e| panic!("expected valid parse: {e:?}"));
+	assert_eq!(result, TestInstruction::Update);
+}
+
+// ---- assert function tests ----
+
+#[test]
+fn assert_true_returns_ok() {
+	let result = pina::assert(true, ProgramError::InvalidArgument, "should not fail");
+	assert!(result.is_ok());
+}
+
+#[test]
+fn assert_false_returns_err() {
+	let result = pina::assert(false, ProgramError::InvalidArgument, "expected failure");
+	assert_eq!(result.unwrap_err(), ProgramError::InvalidArgument);
+}
+
+#[test]
+fn assert_custom_error_type() {
+	let result = pina::assert(
+		false,
+		pina::PinaProgramError::DataTooShort,
+		"data too short",
+	);
+	let err = result.unwrap_err();
+	match err {
+		ProgramError::Custom(code) => assert_eq!(code, 0xFFFF_FFFA),
+		other => panic!("expected Custom error, got: {other:?}"),
+	}
+}

--- a/crates/pina_codama_renderer/readme.md
+++ b/crates/pina_codama_renderer/readme.md
@@ -1,0 +1,37 @@
+# `pina_codama_renderer`
+
+Repository-local Codama Rust renderer that generates Pina-style bytemuck models and discriminator-first layouts from Codama JSON IDLs.
+
+[![CI][ci-status-image]][ci-status-link] [![License][unlicense-image]][unlicense-link]
+
+> **Note:** This crate is not published to crates.io. It is used internally by the `pina codama generate` workflow.
+
+## Usage
+
+```bash
+cargo run --manifest-path ./crates/pina_codama_renderer/Cargo.toml -- \
+  --idl ./idls/my_program.json \
+  --output ./clients/rust
+```
+
+## What It Generates
+
+- Discriminator-first `#[repr(C)]` account/instruction/event structs
+- `bytemuck::Pod` + `bytemuck::Zeroable` derives (no `borsh` serialization)
+- `pina_pod_primitives` types for alignment-safe integer fields
+- Type-safe instruction builders
+
+## Constraints
+
+The renderer only supports fixed-size layouts. The following Codama patterns will produce explicit errors:
+
+- Variable-length strings/bytes
+- Big-endian numbers
+- Floats
+- Non-UTF8 constant byte seeds
+- Non-fixed arrays
+
+[ci-status-image]: https://github.com/pina-rs/pina/workflows/ci/badge.svg
+[ci-status-link]: https://github.com/pina-rs/pina/actions?query=workflow:ci
+[unlicense-image]: https://img.shields.io/badge/license-Unlicense-blue.svg?style=flat-square
+[unlicense-link]: https://opensource.org/license/unlicense

--- a/crates/pina_pod_primitives/readme.md
+++ b/crates/pina_pod_primitives/readme.md
@@ -2,4 +2,39 @@
 
 Alignment-safe primitive POD wrappers used by Pina and generated Codama Rust clients.
 
+[![Crates.io][crate-image]][crate-link] [![Docs.rs][docs-image]][docs-link] [![CI][ci-status-image]][ci-status-link] [![License][unlicense-image]][unlicense-link] [![codecov][codecov-image]][codecov-link]
+
 This crate provides `PodBool`, `PodU16`, `PodI16`, `PodU32`, `PodI32`, `PodU64`, `PodI64`, `PodU128`, and `PodI128` for use in `#[repr(C)]` zero-copy layouts.
+
+## Installation
+
+```bash
+cargo add pina_pod_primitives
+```
+
+## Types
+
+| Type      | Wraps  | Size     |
+| --------- | ------ | -------- |
+| `PodBool` | `bool` | 1 byte   |
+| `PodU16`  | `u16`  | 2 bytes  |
+| `PodI16`  | `i16`  | 2 bytes  |
+| `PodU32`  | `u32`  | 4 bytes  |
+| `PodI32`  | `i32`  | 4 bytes  |
+| `PodU64`  | `u64`  | 8 bytes  |
+| `PodI64`  | `i64`  | 8 bytes  |
+| `PodU128` | `u128` | 16 bytes |
+| `PodI128` | `i128` | 16 bytes |
+
+All types are `#[repr(transparent)]` over byte arrays (or `u8` for `PodBool`) and implement `bytemuck::Pod` + `bytemuck::Zeroable`.
+
+[crate-image]: https://img.shields.io/crates/v/pina_pod_primitives.svg?style=flat-square
+[crate-link]: https://crates.io/crates/pina_pod_primitives
+[docs-image]: https://docs.rs/pina_pod_primitives/badge.svg
+[docs-link]: https://docs.rs/pina_pod_primitives/
+[ci-status-image]: https://github.com/pina-rs/pina/workflows/ci/badge.svg
+[ci-status-link]: https://github.com/pina-rs/pina/actions?query=workflow:ci
+[unlicense-image]: https://img.shields.io/badge/license-Unlicense-blue.svg?style=flat-square
+[unlicense-link]: https://opensource.org/license/unlicense
+[codecov-image]: https://codecov.io/github/pina-rs/pina/graph/badge.svg?token=87K799Q78I
+[codecov-link]: https://codecov.io/github/pina-rs/pina

--- a/crates/pina_pod_primitives/src/lib.rs
+++ b/crates/pina_pod_primitives/src/lib.rs
@@ -14,6 +14,17 @@ impl PodBool {
 	pub const fn from_bool(b: bool) -> Self {
 		Self(if b { 1 } else { 0 })
 	}
+
+	/// Returns `true` if the underlying byte is a canonical boolean value
+	/// (`0` or `1`).
+	///
+	/// Non-canonical values (2–255) are accepted by `bytemuck` deserialization
+	/// and convert to `true`, but two non-canonical `PodBool` values
+	/// representing the same logical boolean may fail `PartialEq` comparison.
+	/// Use this method to validate account data at deserialization boundaries.
+	pub const fn is_canonical(&self) -> bool {
+		self.0 == 0 || self.0 == 1
+	}
 }
 
 impl From<bool> for PodBool {
@@ -133,6 +144,67 @@ mod tests {
 		}
 	}
 
+	/// Demonstrates that non-canonical PodBool values (2–255) convert to
+	/// `true` but fail `PartialEq` against `PodBool(1)`. Programs should
+	/// use `is_canonical()` to detect this at deserialization boundaries.
+	#[test]
+	fn pod_bool_non_canonical_equality_mismatch() {
+		let canonical_true = PodBool::from_bool(true);
+		let non_canonical_true = *try_from_bytes::<PodBool>(&[2]).unwrap();
+
+		// Both convert to `true`...
+		assert!(bool::from(canonical_true));
+		assert!(bool::from(non_canonical_true));
+
+		// ...but fail PartialEq because the raw bytes differ.
+		assert_ne!(canonical_true, non_canonical_true);
+
+		// `is_canonical` detects the non-standard encoding.
+		assert!(canonical_true.is_canonical());
+		assert!(!non_canonical_true.is_canonical());
+	}
+
+	#[test]
+	fn pod_bool_is_canonical_boundary_values() {
+		assert!(PodBool(0).is_canonical());
+		assert!(PodBool(1).is_canonical());
+		assert!(!PodBool(2).is_canonical());
+		assert!(!PodBool(127).is_canonical());
+		assert!(!PodBool(255).is_canonical());
+	}
+
+	#[test]
+	fn pod_bool_from_bool_produces_canonical() {
+		assert!(PodBool::from_bool(false).is_canonical());
+		assert!(PodBool::from_bool(true).is_canonical());
+		assert!(PodBool::from(false).is_canonical());
+		assert!(PodBool::from(true).is_canonical());
+	}
+
+	#[test]
+	fn pod_bool_from_ref() {
+		let t = true;
+		let f = false;
+		assert_eq!(PodBool::from(&t), PodBool(1));
+		assert_eq!(PodBool::from(&f), PodBool(0));
+	}
+
+	#[test]
+	fn pod_bool_from_ref_roundtrip() {
+		let pod = PodBool(1);
+		assert!(bool::from(&pod));
+		let pod = PodBool(0);
+		assert!(!bool::from(&pod));
+	}
+
+	#[test]
+	fn pod_bool_default_is_false() {
+		let default = PodBool::default();
+		assert_eq!(default.0, 0);
+		assert!(!bool::from(default));
+		assert!(default.is_canonical());
+	}
+
 	#[test]
 	fn pod_u16_roundtrip() {
 		assert_eq!(1u16, u16::from(PodU16::from_primitive(1)));
@@ -171,5 +243,97 @@ mod tests {
 	#[test]
 	fn pod_i128_roundtrip() {
 		assert_eq!(-11i128, i128::from(PodI128::from_primitive(-11)));
+	}
+
+	#[test]
+	fn pod_u16_boundary_values() {
+		assert_eq!(0u16, u16::from(PodU16::from_primitive(0)));
+		assert_eq!(u16::MAX, u16::from(PodU16::from_primitive(u16::MAX)));
+	}
+
+	#[test]
+	fn pod_i16_boundary_values() {
+		assert_eq!(i16::MIN, i16::from(PodI16::from_primitive(i16::MIN)));
+		assert_eq!(i16::MAX, i16::from(PodI16::from_primitive(i16::MAX)));
+		assert_eq!(0i16, i16::from(PodI16::from_primitive(0)));
+	}
+
+	#[test]
+	fn pod_u32_boundary_values() {
+		assert_eq!(0u32, u32::from(PodU32::from_primitive(0)));
+		assert_eq!(u32::MAX, u32::from(PodU32::from_primitive(u32::MAX)));
+	}
+
+	#[test]
+	fn pod_i32_boundary_values() {
+		assert_eq!(i32::MIN, i32::from(PodI32::from_primitive(i32::MIN)));
+		assert_eq!(i32::MAX, i32::from(PodI32::from_primitive(i32::MAX)));
+	}
+
+	#[test]
+	fn pod_u64_boundary_values() {
+		assert_eq!(0u64, u64::from(PodU64::from_primitive(0)));
+		assert_eq!(u64::MAX, u64::from(PodU64::from_primitive(u64::MAX)));
+	}
+
+	#[test]
+	fn pod_i64_boundary_values() {
+		assert_eq!(i64::MIN, i64::from(PodI64::from_primitive(i64::MIN)));
+		assert_eq!(i64::MAX, i64::from(PodI64::from_primitive(i64::MAX)));
+	}
+
+	#[test]
+	fn pod_u128_boundary_values() {
+		assert_eq!(0u128, u128::from(PodU128::from_primitive(0)));
+		assert_eq!(u128::MAX, u128::from(PodU128::from_primitive(u128::MAX)));
+	}
+
+	#[test]
+	fn pod_i128_boundary_values() {
+		assert_eq!(i128::MIN, i128::from(PodI128::from_primitive(i128::MIN)));
+		assert_eq!(i128::MAX, i128::from(PodI128::from_primitive(i128::MAX)));
+	}
+
+	/// Verify that all Pod types store bytes in little-endian order, which
+	/// is the native byte order on Solana's BPF/SBF target.
+	#[test]
+	fn pod_types_use_little_endian_byte_order() {
+		let u16_val = PodU16::from_primitive(0x0102);
+		assert_eq!(u16_val.0, [0x02, 0x01]);
+
+		let u32_val = PodU32::from_primitive(0x01020304);
+		assert_eq!(u32_val.0, [0x04, 0x03, 0x02, 0x01]);
+
+		let u64_val = PodU64::from_primitive(0x0102030405060708);
+		assert_eq!(u64_val.0, [0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01]);
+	}
+
+	/// Verify that bytemuck deserialization of Pod types works correctly
+	/// from raw byte slices, simulating zero-copy account data access.
+	#[test]
+	fn pod_types_bytemuck_from_bytes() {
+		let bytes_u16 = [0x39, 0x05]; // 0x0539 = 1337
+		let val = try_from_bytes::<PodU16>(&bytes_u16).unwrap();
+		assert_eq!(u16::from(*val), 1337);
+
+		let bytes_u32 = [0xEF, 0xBE, 0xAD, 0xDE]; // 0xDEADBEEF
+		let val = try_from_bytes::<PodU32>(&bytes_u32).unwrap();
+		assert_eq!(u32::from(*val), 0xDEAD_BEEF);
+
+		let bytes_i16 = [0xFF, 0xFF]; // -1 in two's complement LE
+		let val = try_from_bytes::<PodI16>(&bytes_i16).unwrap();
+		assert_eq!(i16::from(*val), -1);
+	}
+
+	#[test]
+	fn pod_default_is_zero() {
+		assert_eq!(u16::from(PodU16::default()), 0);
+		assert_eq!(i16::from(PodI16::default()), 0);
+		assert_eq!(u32::from(PodU32::default()), 0);
+		assert_eq!(i32::from(PodI32::default()), 0);
+		assert_eq!(u64::from(PodU64::default()), 0);
+		assert_eq!(i64::from(PodI64::default()), 0);
+		assert_eq!(u128::from(PodU128::default()), 0);
+		assert_eq!(i128::from(PodI128::default()), 0);
 	}
 }

--- a/docs/src/ci-and-releases.md
+++ b/docs/src/ci-and-releases.md
@@ -44,10 +44,14 @@ The `assets` workflow only publishes binaries for CLI tags:
 
 Use `knope` for changelog/release management:
 
+<!-- {=releaseWorkflowCommands} -->
+
 ```bash
 knope document-change
 knope release
 knope publish
 ```
+
+<!-- {/releaseWorkflowCommands} -->
 
 Keep changeset descriptions explicit and user-impact focused.

--- a/docs/src/codama-workflow.md
+++ b/docs/src/codama-workflow.md
@@ -12,6 +12,8 @@ The flow has three stages:
 
 Generate and validate the whole workspace flow with `devenv` scripts:
 
+<!-- {=codamaWorkflowCommands} -->
+
 ```bash
 # Generate Codama IDLs for all examples.
 codama:idl:all
@@ -28,6 +30,8 @@ codama:test
 # Run IDL fixture drift + validation checks used by CI.
 test:idl
 ```
+
+<!-- {/codamaWorkflowCommands} -->
 
 Supporting scripts:
 

--- a/docs/src/crates-and-features.md
+++ b/docs/src/crates-and-features.md
@@ -13,9 +13,15 @@ Includes:
 
 Feature flags:
 
-- `derive` (default): enables proc macro re-exports from `pina_macros`.
-- `logs` (default): on-chain logging support.
-- `token`: SPL token/token-2022 + ATA helper APIs.
+<!-- {=pinaFeatureFlags} -->
+
+| Feature  | Default | Description                                                |
+| -------- | ------- | ---------------------------------------------------------- |
+| `derive` | Yes     | Enables proc macros (`#[account]`, `#[instruction]`, etc.) |
+| `logs`   | Yes     | Enables on-chain logging via `solana-program-log`          |
+| `token`  | No      | Enables SPL token / token-2022 helpers and ATA utilities   |
+
+<!-- {/pinaFeatureFlags} -->
 
 ## `crates/pina_macros`
 

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,8 @@
 
 A performant Solana smart contract framework built on top of [pinocchio](https://github.com/anza-xyz/pinocchio) — a zero-dependency alternative to `solana-program` that massively reduces compute units and dependency bloat.
 
+[![Crates.io][crate-image]][crate-link] [![Docs.rs][docs-image]][docs-link] [![CI][ci-status-image]][ci-status-link] [![License][unlicense-image]][unlicense-link] [![codecov][codecov-image]][codecov-link]
+
 ## Features
 
 - **Zero-copy deserialization** — account data is reinterpreted in place via `bytemuck`, with no heap allocation.
@@ -540,3 +542,14 @@ Contributions are welcome! Please open an issue or pull request on [GitHub](http
 ## License
 
 Licensed under the [Apache License, Version 2.0](license).
+
+[crate-image]: https://img.shields.io/crates/v/pina.svg?style=flat-square
+[crate-link]: https://crates.io/crates/pina
+[docs-image]: https://docs.rs/pina/badge.svg
+[docs-link]: https://docs.rs/pina/
+[ci-status-image]: https://github.com/pina-rs/pina/workflows/ci/badge.svg
+[ci-status-link]: https://github.com/pina-rs/pina/actions?query=workflow:ci
+[unlicense-image]: https://img.shields.io/badge/license-Unlicense-blue.svg?style=flat-square
+[unlicense-link]: https://opensource.org/license/unlicense
+[codecov-image]: https://codecov.io/github/pina-rs/pina/graph/badge.svg?token=87K799Q78I
+[codecov-link]: https://codecov.io/github/pina-rs/pina

--- a/template.t.md
+++ b/template.t.md
@@ -47,3 +47,44 @@ test:idl
 ```
 
 <!-- {/dailyDevelopmentLoop} -->
+
+<!-- {@codamaWorkflowCommands} -->
+
+```bash
+# Generate Codama IDLs for all examples.
+codama:idl:all
+
+# Generate Rust + JS clients.
+codama:clients:generate
+
+# Generate IDLs + Rust/JS clients in one command.
+pina codama generate
+
+# Run the complete Codama pipeline.
+codama:test
+
+# Run IDL fixture drift + validation checks used by CI.
+test:idl
+```
+
+<!-- {/codamaWorkflowCommands} -->
+
+<!-- {@releaseWorkflowCommands} -->
+
+```bash
+knope document-change
+knope release
+knope publish
+```
+
+<!-- {/releaseWorkflowCommands} -->
+
+<!-- {@pinaFeatureFlags} -->
+
+| Feature  | Default | Description                                                |
+| -------- | ------- | ---------------------------------------------------------- |
+| `derive` | Yes     | Enables proc macros (`#[account]`, `#[instruction]`, etc.) |
+| `logs`   | Yes     | Enables on-chain logging via `solana-program-log`          |
+| `token`  | No      | Enables SPL token / token-2022 helpers and ATA utilities   |
+
+<!-- {/pinaFeatureFlags} -->


### PR DESCRIPTION
## Summary

- Add `PodBool::is_canonical()` method to detect non-canonical boolean values (2–255) that pass `bytemuck` deserialization but fail `PartialEq` against canonical values
- Add badges (crates.io, docs.rs, CI, license, codecov) to `pina_pod_primitives` readme and root workspace readme
- Create readme for `pina_codama_renderer` crate
- Add 50+ new tests across pina and pina_pod_primitives covering: `parse_instruction`, `PinaProgramError` error codes, `assert` function, PDA functions, Pod types, PodBool canonical validation, `AccountDeserialize` trait, discriminator roundtrips, and lamport helper edge cases
- Update book chapters to use mdt shared blocks for codama workflow commands, release workflow commands, and feature flags table
- Add three new mdt providers (`codamaWorkflowCommands`, `releaseWorkflowCommands`, `pinaFeatureFlags`) to `template.t.md`

## Test plan

- [x] All 121+ tests pass across pina and pina_pod_primitives
- [x] `dprint check` passes (formatting clean)
- [x] `cargo clippy --all-features` passes (no warnings)
- [x] `mdt check` passes (all consumer blocks up to date)
- [ ] CI passes on all jobs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `PodBool::is_canonical()` method to validate non-canonical boolean values during deserialization for improved data integrity checks.

* **Documentation**
  * Added project badges (crates.io, docs.rs, CI, license, codecov) to workspace and library readmes.
  * Created dedicated readme for pina_codama_renderer with usage examples and generated artifact descriptions.
  * Enhanced pina_pod_primitives documentation with comprehensive types overview.
  * Updated documentation workflow with shared template blocks for consistent formatting across guides.

* **Tests**
  * Expanded test coverage with 50+ new tests for instruction parsing, error handling, PDA functions, Pod types, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->