### PR TITLE
chore: migrate mdt from cargo-run-bin to nix

### DIFF
--- a/.changeset/migrate_mdt_to_nix.md
+++ b/.changeset/migrate_mdt_to_nix.md
@@ -1,0 +1,5 @@
+---
+default: note
+---
+
+Remove `mdt` from `cargo-run-bin` management (`[workspace.metadata.bin]`) and the devenv script wrapper. `mdt` is now provided directly as a nix package from `ifiokjr-nixpkgs`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,6 @@ cargo-insta = { version = "1.44.3" }
 cargo-llvm-cov = { version = "0.8.4" }
 cargo-nextest = { version = "0.9.129" }
 cargo-semver-checks = { version = "0.46.0" }
-mdt_cli = { version = "0.4.1", bins = ["mdt"] }
 dylint-link = { version = "5.0.0", bins = ["dylint-link"] }
 sbpf-linker = { version = "0.1.8", bins = ["sbpf-linker"] }
 solana-verify = { version = "0.4.11", bins = ["solana-verify"] }

--- a/devenv.nix
+++ b/devenv.nix
@@ -26,6 +26,7 @@ in
       libiconv
       mdbook
       custom.knope
+      custom.mdt
       custom.pnpm-standalone
       llvm.bintools
       llvm.clang
@@ -120,14 +121,6 @@ in
         cargo run --clean -p pina_cli -- $@
       '';
       description = "Run the `pina` CLI from source.";
-      binary = "bash";
-    };
-    "mdt" = {
-      exec = ''
-        set -e
-        cargo bin mdt $@
-      '';
-      description = "Run the pinned `mdt` CLI used for reusable docs.";
       binary = "bash";
     };
     "codama:idl:all" = {


### PR DESCRIPTION
## Summary

- Removed `mdt_cli` entry from `[workspace.metadata.bin]` in `Cargo.toml`, so `mdt` is no longer managed by `cargo-run-bin`.
- Removed the `"mdt"` devenv script wrapper that proxied to `cargo bin mdt`.
- Added `ifiokjr-pkgs.mdt` to the nix packages list in `devenv.nix`, providing `mdt` directly from `ifiokjr/nixpkgs`.

This follows the same pattern as the recent knope migration in #51.

## Test plan

- [ ] Verify `devenv shell` enters without errors and `mdt --version` is available on PATH
- [ ] Run `docs:sync` and `docs:check` to confirm mdt still works correctly
- [ ] Run `install:cargo:bin` to verify it no longer tries to install mdt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MDT package sourcing to use direct nix integration, removing intermediate build configuration and streamlining development environment setup. MDT is now provisioned as a native nix package, improving consistency and reducing setup complexity while maintaining full functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->