### PR TITLE
feat(ci): add semver-checks workflow

### DIFF
--- a/.changeset/semver_checks_ci.md
+++ b/.changeset/semver_checks_ci.md
@@ -1,0 +1,5 @@
+---
+default: note
+---
+
+Add a CI workflow that runs `cargo semver-checks` on pull requests to detect accidental semver violations before merge.

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -25,6 +25,53 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: check semver compatibility
-        run: cargo semver-checks check-release --workspace
-        shell: devenv shell -c -- bash -e {0}
+      - name: run semver-checks
+        id: semver
+        run: |
+          set +e
+          cargo semver-checks check-release --workspace 2>&1
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+        shell: devenv shell -c -- bash {0}
+
+      - name: evaluate semver results
+        if: steps.semver.outputs.exit_code != '0'
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          echo "::warning::semver-checks detected breaking changes"
+
+          # Check if PR title contains '!' before ':' (e.g. feat!: or fix!:)
+          title_acknowledged=false
+          if echo "$PR_TITLE" | grep -qE '^[a-zA-Z]+(\(.+\))?!:'; then
+            title_acknowledged=true
+            echo "PR title contains '!' — breaking change acknowledged via title"
+          fi
+
+          # Check if any changeset file contains a major change type
+          changeset_acknowledged=false
+          if ls .changeset/*.md 1>/dev/null 2>&1; then
+            if grep -lE '^[a-zA-Z_]+: major$' .changeset/*.md 1>/dev/null 2>&1; then
+              changeset_acknowledged=true
+              echo "Found major changeset — breaking change acknowledged via changeset"
+            fi
+          fi
+
+          if [ "$title_acknowledged" = true ] || [ "$changeset_acknowledged" = true ]; then
+            echo "::notice::Breaking changes are properly acknowledged. Passing."
+            exit 0
+          fi
+
+          echo "::error::Breaking changes detected but not acknowledged."
+          echo ""
+          echo "To acknowledge breaking changes, do one of the following:"
+          echo ""
+          echo "  1. Add '!' to your PR title (e.g. 'feat!: my breaking change' or 'fix(pina)!: remove deprecated api')"
+          echo ""
+          echo "  2. Add a changeset file with a 'major' change type:"
+          echo "     Run 'knope document-change' or create a file in .changeset/ with:"
+          echo "     ---"
+          echo "     package_name: major"
+          echo "     ---"
+          echo ""
+          exit 1
+        shell: bash

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -27,14 +27,12 @@ jobs:
 
       - name: run semver-checks
         id: semver
-        run: |
-          set +e
-          cargo semver-checks check-release --workspace 2>&1
-          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
-        shell: devenv shell -c -- bash {0}
+        continue-on-error: true
+        run: cargo semver-checks check-release --workspace
+        shell: devenv shell -c -- bash -e {0}
 
       - name: evaluate semver results
-        if: steps.semver.outputs.exit_code != '0'
+        if: steps.semver.outcome == 'failure'
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -1,0 +1,30 @@
+name: "semver"
+permissions:
+  contents: read
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  semver-checks:
+    timeout-minutes: 30
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: setup
+        uses: ./.github/actions/devenv
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: check semver compatibility
+        run: cargo semver-checks check-release --workspace
+        shell: devenv shell -c -- bash -e {0}


### PR DESCRIPTION
## Summary

- Update the semver-checks CI workflow to be informational rather than blocking
- Breaking changes detected by `cargo semver-checks check-release --workspace` no longer automatically fail the workflow
- Instead, the workflow checks for proper acknowledgment of breaking changes:
  - PR title contains `!` before `:` (e.g. `feat!:`, `fix(pina)!:`)
  - Any `.changeset/*.md` file contains a `major` change type
- If breaking changes are acknowledged via either method, the workflow passes with a notice
- If breaking changes are unacknowledged, the workflow fails with a helpful message explaining how to acknowledge them

## Test plan

- [ ] Verify the workflow triggers on PRs to `main`
- [ ] Verify the workflow passes when no semver violations are detected
- [ ] Verify the workflow passes when breaking changes exist and PR title contains `!`
- [ ] Verify the workflow passes when breaking changes exist and a changeset has `major` type
- [ ] Verify the workflow fails with a helpful message when breaking changes are unacknowledged