### PR TITLE
feat(ci): add release preview dry-run workflow

### DIFF
--- a/.changeset/pre_release_dry_run_workflow.md
+++ b/.changeset/pre_release_dry_run_workflow.md
@@ -1,0 +1,5 @@
+---
+default: note
+---
+
+Add a `release-preview` CI workflow that runs `knope release --dry-run` on pull requests and outputs a summary of pending version bumps and changelog entries.

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -47,4 +47,4 @@ jobs:
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           knope release --dry-run 2>&1 | tee -a "$GITHUB_STEP_SUMMARY" || true
           echo '```' >> "$GITHUB_STEP_SUMMARY"
-        shell: devenv shell -c -- bash -e {0}
+        shell: devenv shell -- bash -e {0}

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -1,0 +1,50 @@
+name: "release-preview"
+permissions:
+  contents: read
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    timeout-minutes: 15
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: setup
+        uses: ./.github/actions/devenv
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: preview release
+        run: |
+          echo "## Release Preview" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if ls .changeset/*.md 1>/dev/null 2>&1; then
+            echo "### Changesets found:" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            for f in .changeset/*.md; do
+              echo "--- $f ---" >> "$GITHUB_STEP_SUMMARY"
+              cat "$f" >> "$GITHUB_STEP_SUMMARY"
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+            done
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No changesets found in .changeset/" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Dry-run output:" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          knope release --dry-run 2>&1 | tee -a "$GITHUB_STEP_SUMMARY" || true
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+        shell: devenv shell -c -- bash -e {0}


### PR DESCRIPTION
## Summary

- Add a new `release-preview` GitHub Actions workflow that runs `knope release --dry-run` on pull requests targeting `main` and on manual dispatch
- The workflow lists all changeset files found in `.changeset/` and outputs the dry-run release preview to the GitHub Actions job summary for easy viewing
- Include a changeset file documenting this addition

## Test plan

- [ ] Verify the workflow file is valid YAML and follows the existing CI patterns (blacksmith runner, devenv setup action, `devenv shell -c` invocation)
- [ ] Confirm the workflow triggers on PRs to `main` and on `workflow_dispatch`
- [ ] Check that `knope release --dry-run` output appears in the GitHub Actions step summary after the workflow runs
- [ ] Verify the `|| true` guard prevents workflow failure when no changesets are present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated release preview workflow to validate pending version bumps and changelog entries before publishing.

* **Documentation**
  * Added documentation for the pre-release workflow process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->