### PR TITLE
fix: harden rustup nix override for CI stability

### DIFF
--- a/.changeset/rustup_nix_override_hardening.md
+++ b/.changeset/rustup_nix_override_hardening.md
@@ -1,0 +1,5 @@
+---
+default: note
+---
+
+Harden the rustup nix override to fix intermittent CI failures caused by rustup 1.28+ requiring a `version` field in `settings.toml` during shell completion generation in the install phase.

--- a/devenv.nix
+++ b/devenv.nix
@@ -42,9 +42,16 @@ in
       pkg-config
       protobuf # needed for `solana-test-validator` in tests
       rust-jemalloc-sys
-      # Upstream rustup check suite is network-sensitive (e.g. socks proxy test) and flakes in CI.
-      (rustup.overrideAttrs (_: {
+      # Upstream rustup 1.28+ fails in nix builds: check suite is network-sensitive
+      # and the install phase fails generating shell completions because the sandbox
+      # creates an empty settings.toml missing the required `version` field.
+      (rustup.overrideAttrs (old: {
         doCheck = false;
+        preInstall = (old.preInstall or "") + ''
+          export HOME="$(mktemp -d)"
+          mkdir -p "$HOME/.rustup"
+          echo 'version = "12"' > "$HOME/.rustup/settings.toml"
+        '';
       }))
       shfmt
       zstd


### PR DESCRIPTION
## Summary

- Harden the rustup nix override in `devenv.nix` to prevent intermittent CI failures caused by rustup 1.28+'s new `settings.toml` format requiring a `version` field.
- The existing override only disabled the check phase (`doCheck = false`), but the install phase also fails when generating shell completions because the nix sandbox creates an empty `~/.rustup/settings.toml` missing the required `version` field.
- The fix adds a `preInstall` hook that creates a temporary HOME with a valid `settings.toml` containing the required version field.

## Test plan

- [ ] Verify the devenv shell enters successfully on both macOS and Linux
- [ ] Confirm `rustup` is available and functional inside the dev shell
- [ ] Run a CI build on Linux to confirm the intermittent failure is resolved