### PR TITLE
feat(ci): add SBF binary size tracking workflow

### DIFF
--- a/.changeset/binary_size_tracking.md
+++ b/.changeset/binary_size_tracking.md
@@ -1,0 +1,5 @@
+---
+default: note
+---
+
+Add a `binary-size` CI workflow that builds SBF programs and reports their binary sizes in the GitHub Actions job summary for pull requests.

--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -46,4 +46,4 @@ jobs:
               echo "| \`$name\` | $size | $human |" >> "$GITHUB_STEP_SUMMARY"
             fi
           done
-        shell: devenv shell -c -- bash -e {0}
+        shell: devenv shell -- bash -e {0}

--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -26,8 +26,11 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: build SBF programs
-        run: cargo build-bpf
-        shell: devenv shell -c -- bash -e {0}
+        run: |
+          rm -rf .bin/rust-nightly/sbpf-linker
+          cargo bin --install
+          cargo build-bpf
+        shell: devenv shell -- bash -e {0}
 
       - name: measure binary sizes
         id: sizes

--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -1,0 +1,49 @@
+name: "binary-size"
+permissions:
+  contents: read
+  pull-requests: write
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  measure:
+    timeout-minutes: 30
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v6
+
+      - name: setup
+        uses: ./.github/actions/devenv
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: build SBF programs
+        run: |
+          rustup component add rust-src --toolchain nightly-2025-10-15
+          cargo +nightly-2025-10-15 build-bpf
+        shell: devenv shell -- bash -e {0}
+
+      - name: measure binary sizes
+        id: sizes
+        run: |
+          echo "## SBF Binary Sizes" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Program | Size (bytes) | Size |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| ------- | -----------: | ---: |" >> "$GITHUB_STEP_SUMMARY"
+          for so in target/bpfel-unknown-none/release/*.so; do
+            if [ -f "$so" ]; then
+              name=$(basename "$so" .so)
+              size=$(stat -c%s "$so" 2>/dev/null || stat -f%z "$so")
+              human=$(numfmt --to=iec-i --suffix=B "$size" 2>/dev/null || echo "${size}B")
+              echo "| \`$name\` | $size | $human |" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+        shell: devenv shell -c -- bash -e {0}

--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -26,10 +26,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: build SBF programs
-        run: |
-          rustup component add rust-src --toolchain nightly-2025-10-15
-          cargo +nightly-2025-10-15 build-bpf
-        shell: devenv shell -- bash -e {0}
+        run: cargo build-bpf
+        shell: devenv shell -c -- bash -e {0}
 
       - name: measure binary sizes
         id: sizes


### PR DESCRIPTION
## Summary

- Add a new `binary-size` CI workflow (`.github/workflows/binary-size.yml`) that runs on pull requests targeting `main` and on `workflow_dispatch`
- Builds SBF programs using `cargo +nightly-2025-10-15 build-bpf` within the devenv shell
- Measures `.so` binary sizes from `target/bpfel-unknown-none/release/` and reports them as a markdown table in the GitHub Actions job summary
- Include changeset for the change

## Test plan

- [ ] Verify the workflow YAML is valid by checking the Actions tab after the PR is opened
- [ ] Trigger a manual `workflow_dispatch` run to confirm the full pipeline (checkout, devenv setup, SBF build, size measurement) completes successfully
- [ ] Confirm the job summary contains the expected markdown table with program names and sizes