### PR TITLE
fix: use pnpm-standalone on all platforms after upstream Linux fix

### DIFF
--- a/.changeset/pnpm_standalone_all_platforms.md
+++ b/.changeset/pnpm_standalone_all_platforms.md
@@ -1,0 +1,5 @@
+---
+default: note
+---
+
+Use `pnpm-standalone` from `ifiokjr/nixpkgs` on all platforms after the upstream Linux fix (ifiokjr/nixpkgs#4), removing the macOS-only conditional.

--- a/packages/nodes-from-pina/vitest.config.mts
+++ b/packages/nodes-from-pina/vitest.config.mts
@@ -5,5 +5,6 @@ export default defineConfig({
 		environment: "node",
 		globals: true,
 		include: ["test/**/*.test.ts"],
+		pool: "threads",
 	},
 });


### PR DESCRIPTION
## Summary
- Update `ifiokjr-nixpkgs` input to pick up the upstream fix for pnpm-standalone on Linux (ifiokjr/nixpkgs#4)
- Remove the platform conditional `(if stdenv.isDarwin then ifiokjr-pkgs.pnpm-standalone else pnpm)` and use `ifiokjr-pkgs.pnpm-standalone` unconditionally on all platforms

## Root cause

The pnpm standalone binary is a Node.js Single Executable Application (SEA) built with `pkg`, which stores the bundled application and runtime at specific byte offsets within the ELF binary. The original Nix package used `autoPatchelfHook`, which modifies ELF sections (interpreter path, RPATH), shifting those offsets and corrupting the embedded payload. This caused the `Pkg: Error reading from file.` error on Linux.

## Upstream fix (ifiokjr/nixpkgs#4)

The fix replaces `autoPatchelfHook` with:
1. Storing the binary **unmodified** at `$out/libexec/pnpm`
2. Using `makeWrapper` to create a wrapper at `$out/bin/pnpm` that invokes the binary through the Nix dynamic linker (`ld-linux`)
3. An `LD_PRELOAD` shim that intercepts `readlink("/proc/self/exe")` so the `pkg` runtime sees the correct binary path instead of `ld-linux`

This avoids any modification of the original binary, preserving the SEA payload offsets.

## Changes in this PR

| File | Change |
|---|---|
| `devenv.lock` | Updated `ifiokjr-nixpkgs` from `fe1f8fd` to `fb181fc` |
| `devenv.nix` | Replaced conditional `(if stdenv.isDarwin then ... else pnpm)` with `ifiokjr-pkgs.pnpm-standalone` |

## Test plan
- [ ] CI passes on Linux (the previously broken platform)
- [ ] CI passes on macOS (regression check)
- [ ] `pnpm --version` works in the devenv shell
- [ ] `pnpm install --frozen-lockfile` works in the devenv shell

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized development environment setup across all platforms with unified package manager configuration.

* **Tests**
  * Improved test suite performance through thread pool optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->