### PR TITLE
docs: add br tags after headings in sub-crate readmes

### DIFF
--- a/.changeset/sub_crate_readme_improvements.md
+++ b/.changeset/sub_crate_readme_improvements.md
@@ -1,0 +1,5 @@
+---
+default: docs
+---
+
+Add `<br>` tags after h1-h3 headings in all sub-crate, example, security, and lint readme files for improved visual spacing.

--- a/crates/pina/readme.md
+++ b/crates/pina/readme.md
@@ -1,5 +1,7 @@
 # `pina`
 
+<br>
+
 Core runtime crate for building Solana programs on top of [`pinocchio`](https://github.com/anza-xyz/pinocchio).
 
 It provides zero-copy account loaders, discriminator-aware account/instruction/event modeling, account validation traits, and `no_std` entrypoint helpers.
@@ -7,6 +9,8 @@ It provides zero-copy account loaders, discriminator-aware account/instruction/e
 [![Crates.io][crate-image]][crate-link] [![Docs.rs][docs-image]][docs-link] [![CI][ci-status-image]][ci-status-link] [![License][unlicense-image]][unlicense-link] [![codecov][codecov-image]][codecov-link]
 
 ## Installation
+
+<br>
 
 ```bash
 cargo add pina
@@ -20,6 +24,8 @@ cargo add pina --features token
 
 ## What This Crate Includes
 
+<br>
+
 - `nostd_entrypoint!` for `no_std` Solana entrypoint wiring.
 - `#[account]`, `#[instruction]`, `#[event]`, `#[error]`, `#[discriminator]`, and `#[derive(Accounts)]` integration via the default `derive` feature.
 - Validation chains on `AccountView` (`assert_signer`, `assert_writable`, `assert_owner`, PDA checks, sysvar checks, and more).
@@ -28,11 +34,15 @@ cargo add pina --features token
 
 ## Feature Flags
 
+<br>
+
 - `derive` (default): enables `pina_macros` re-exports.
 - `logs` (default): enables Solana log macros via `solana-program-log`.
 - `token`: enables SPL token/token-2022 and ATA helpers.
 
 ## Minimal Program Skeleton
+
+<br>
 
 ```rust
 #![no_std]
@@ -69,11 +79,15 @@ fn process_instruction(
 
 ## Related Crates
 
+<br>
+
 - [`pina_macros`](https://docs.rs/pina_macros): proc-macro implementations for the attributes and derives used here.
 - [`pina_cli`](https://docs.rs/pina_cli): CLI/library used to generate Codama IDLs from Pina programs.
 - [`pina_sdk_ids`](https://docs.rs/pina_sdk_ids): shared Solana program/sysvar IDs.
 
 ## Codama IDLs
+
+<br>
 
 `pina` models are designed to be extracted into Codama IDLs through `pina_cli`.
 

--- a/crates/pina_cli/readme.md
+++ b/crates/pina_cli/readme.md
@@ -1,5 +1,7 @@
 # `pina_cli`
 
+<br>
+
 CLI and library for generating Codama IDLs from Pina programs.
 
 The binary name is `pina`.
@@ -7,6 +9,8 @@ The binary name is `pina`.
 [![Crates.io][crate-image]][crate-link] [![Docs.rs][docs-image]][docs-link] [![CI][ci-status-image]][ci-status-link] [![License][unlicense-image]][unlicense-link] [![codecov][codecov-image]][codecov-link]
 
 ## Installation
+
+<br>
 
 ```bash
 cargo install pina_cli
@@ -20,7 +24,11 @@ cargo run -p pina_cli -- --help
 
 ## Commands
 
+<br>
+
 ### `pina idl`
+
+<br>
 
 Generate a Codama `rootNode` JSON from a Pina program crate.
 
@@ -37,6 +45,8 @@ pina idl --path ./examples/counter_program --name my_program_alias
 
 ### `pina init`
 
+<br>
+
 Scaffold a new Pina program project.
 
 ```bash
@@ -46,6 +56,8 @@ pina init my_program --path ./programs/my_program --force
 
 ### `pina codama generate`
 
+<br>
+
 Generate Codama IDLs and Rust/JS clients from one or more example program crates.
 
 ```bash
@@ -54,6 +66,8 @@ pina codama generate --example counter_program --example todo_program
 ```
 
 ## Library API
+
+<br>
 
 `pina_cli` can also be embedded directly:
 
@@ -67,10 +81,14 @@ println!("{}", serde_json::to_string_pretty(&root)?);
 
 ## Codama Workflow
 
+<br>
+
 1. Generate IDL with `pina idl`.
 2. Feed the JSON into Codama renderers.
 
 ### JavaScript clients in another project
+
+<br>
 
 ```bash
 pina idl --path ./programs/my_program --output ./idls/my_program.json
@@ -87,6 +105,8 @@ await codama.accept(renderJsVisitor("./clients/js/my_program"));
 
 ### Pina-style Rust clients
 
+<br>
+
 This repository includes `crates/pina_codama_renderer`, which renders discriminator-first/bytemuck Rust client models from Codama JSON.
 
 ```bash
@@ -96,6 +116,8 @@ cargo run --manifest-path ./crates/pina_codama_renderer/Cargo.toml -- \
 ```
 
 ## Parser Expectations
+
+<br>
 
 For best IDL extraction fidelity, follow the rules documented in [`crates/pina_cli/rules.md`](./rules.md).
 

--- a/crates/pina_codama_renderer/readme.md
+++ b/crates/pina_codama_renderer/readme.md
@@ -1,5 +1,7 @@
 # `pina_codama_renderer`
 
+<br>
+
 Repository-local Codama Rust renderer that generates Pina-style bytemuck models and discriminator-first layouts from Codama JSON IDLs.
 
 [![CI][ci-status-image]][ci-status-link] [![License][unlicense-image]][unlicense-link]
@@ -7,6 +9,8 @@ Repository-local Codama Rust renderer that generates Pina-style bytemuck models 
 > **Note:** This crate is not published to crates.io. It is used internally by the `pina codama generate` workflow.
 
 ## Usage
+
+<br>
 
 ```bash
 cargo run --manifest-path ./crates/pina_codama_renderer/Cargo.toml -- \
@@ -16,12 +20,16 @@ cargo run --manifest-path ./crates/pina_codama_renderer/Cargo.toml -- \
 
 ## What It Generates
 
+<br>
+
 - Discriminator-first `#[repr(C)]` account/instruction/event structs
 - `bytemuck::Pod` + `bytemuck::Zeroable` derives (no `borsh` serialization)
 - `pina_pod_primitives` types for alignment-safe integer fields
 - Type-safe instruction builders
 
 ## Constraints
+
+<br>
 
 The renderer only supports fixed-size layouts. The following Codama patterns will produce explicit errors:
 

--- a/crates/pina_macros/readme.md
+++ b/crates/pina_macros/readme.md
@@ -1,5 +1,7 @@
 # `pina_macros`
 
+<br>
+
 Procedural macros for building Pina programs with less boilerplate.
 
 This crate powers the attributes/derives re-exported by `pina`.
@@ -7,6 +9,8 @@ This crate powers the attributes/derives re-exported by `pina`.
 [![Crates.io][crate-image]][crate-link] [![Docs.rs][docs-image]][docs-link] [![CI][ci-status-image]][ci-status-link] [![License][unlicense-image]][unlicense-link] [![codecov][codecov-image]][codecov-link]
 
 ## Installation
+
+<br>
 
 Most projects should depend on `pina` and use the re-exported macros.
 
@@ -18,6 +22,8 @@ cargo add pina_macros
 
 ## Macros
 
+<br>
+
 - `#[discriminator]`: defines a typed discriminator enum (`u8`, `u16`, `u32`, `u64`).
 - `#[account]`: defines discriminator-first account POD structs and generated builders.
 - `#[instruction]`: defines discriminator-first instruction data POD structs.
@@ -26,6 +32,8 @@ cargo add pina_macros
 - `#[derive(Accounts)]`: parses `&[AccountView]` into a named struct.
 
 ## Common Usage
+
+<br>
 
 ```rust
 use pina::*;
@@ -56,7 +64,11 @@ pub enum ExampleError {
 
 ## Attribute Options
 
+<br>
+
 ### `#[discriminator(...)]`
+
+<br>
 
 - `primitive = u8|u16|u32|u64`
 - `crate = ::pina` (defaults to `::pina`)
@@ -64,22 +76,30 @@ pub enum ExampleError {
 
 ### `#[account(...)]`, `#[instruction(...)]`, `#[event(...)]`
 
+<br>
+
 - `discriminator = PathToEnum`
 - `variant = EnumVariant` (optional; defaults to inferred struct name)
 - `crate = ::pina` (optional)
 
 ### `#[error(...)]`
 
+<br>
+
 - `crate = ::pina` (optional)
 - `final` (omits `#[non_exhaustive]`)
 
 ### `#[derive(Accounts)]`
+
+<br>
 
 - Supports one lifetime parameter.
 - Supports `#[pina(remaining)]` on a single trailing field to capture remaining accounts.
 - Supports `#[pina(crate = ::pina)]` on the struct to override the crate path.
 
 ## Notes
+
+<br>
 
 - Generated account/instruction/event structs are intended for fixed-size, bytemuck-safe layouts.
 - The macros are designed for `no_std` Solana program crates.

--- a/crates/pina_pod_primitives/readme.md
+++ b/crates/pina_pod_primitives/readme.md
@@ -1,5 +1,7 @@
 # `pina_pod_primitives`
 
+<br>
+
 Alignment-safe primitive POD wrappers used by Pina and generated Codama Rust clients.
 
 [![Crates.io][crate-image]][crate-link] [![Docs.rs][docs-image]][docs-link] [![CI][ci-status-image]][ci-status-link] [![License][unlicense-image]][unlicense-link] [![codecov][codecov-image]][codecov-link]
@@ -8,11 +10,15 @@ This crate provides `PodBool`, `PodU16`, `PodI16`, `PodU32`, `PodI32`, `PodU64`,
 
 ## Installation
 
+<br>
+
 ```bash
 cargo add pina_pod_primitives
 ```
 
 ## Types
+
+<br>
 
 | Type      | Wraps  | Size     |
 | --------- | ------ | -------- |

--- a/crates/pina_sdk_ids/readme.md
+++ b/crates/pina_sdk_ids/readme.md
@@ -1,5 +1,7 @@
 # `pina_sdk_ids`
 
+<br>
+
 Typed constants for well-known Solana program IDs and sysvar IDs.
 
 Each module exposes an `ID` constant declared via `solana_address::declare_id!`.
@@ -8,11 +10,15 @@ Each module exposes an `ID` constant declared via `solana_address::declare_id!`.
 
 ## Installation
 
+<br>
+
 ```bash
 cargo add pina_sdk_ids
 ```
 
 ## Usage
+
+<br>
 
 ```rust
 use pina_sdk_ids::system_program;
@@ -24,6 +30,8 @@ let clock_sysvar_id = sysvar::clock::ID;
 
 ## Included IDs
 
+<br>
+
 - Core programs: `system_program`, `stake`, `vote`, `config`, `feature`, loaders.
 - Signature verification programs: `ed25519_program`, `secp256k1_program`, `secp256r1_program`.
 - Sysvars: `sysvar::clock`, `sysvar::rent`, `sysvar::stake_history`, and more.
@@ -31,11 +39,15 @@ let clock_sysvar_id = sysvar::clock::ID;
 
 ## Why Use This Crate
 
+<br>
+
 - Avoid hard-coded base58 strings across codebases.
 - Keep ID imports centralized and typed.
 - Make account/program validation checks more readable.
 
 ## `no_std`
+
+<br>
 
 `pina_sdk_ids` is `#![no_std]` and safe for on-chain program crates.
 

--- a/examples/anchor_declare_id/readme.md
+++ b/examples/anchor_declare_id/readme.md
@@ -1,8 +1,12 @@
 # anchor_declare_id
 
+<br>
+
 Pina parity port of Anchor's `declare-id` example.
 
 ## What this demonstrates
+
+<br>
 
 - Program ID declaration via `declare_id!`.
 - Instruction decoding with `parse_instruction`.
@@ -10,11 +14,15 @@ Pina parity port of Anchor's `declare-id` example.
 
 ## Differences From Anchor
 
+<br>
+
 - Program ID mismatch validation is handled directly by `parse_instruction(program_id, &ID, data)`.
 - There is no Anchor `Context` type. The instruction entrypoint receives raw account views.
 - The example keeps a minimal `Initialize` instruction and tests behavior directly.
 
 ## Run
+
+<br>
 
 ```sh
 cargo test -p anchor_declare_id

--- a/examples/anchor_declare_program/readme.md
+++ b/examples/anchor_declare_program/readme.md
@@ -1,8 +1,12 @@
 # anchor_declare_program
 
+<br>
+
 Pina parity port of Anchor's `declare-program` behavior.
 
 ## What this demonstrates
+
+<br>
 
 - Modeling external program IDs.
 - Validating executable program accounts.
@@ -10,11 +14,15 @@ Pina parity port of Anchor's `declare-program` behavior.
 
 ## Differences From Anchor
 
+<br>
+
 - External program validation is explicit (`assert_external_program_id`) instead of framework constraints.
 - Account checks are performed manually via chained `AccountView` assertions.
 - Instruction routing is explicit `match`-based dispatch.
 
 ## Run
+
+<br>
 
 ```sh
 cargo test -p anchor_declare_program

--- a/examples/anchor_duplicate_mutable_accounts/readme.md
+++ b/examples/anchor_duplicate_mutable_accounts/readme.md
@@ -1,8 +1,12 @@
 # anchor_duplicate_mutable_accounts
 
+<br>
+
 Pina parity port of Anchor's duplicate mutable account checks.
 
 ## What this demonstrates
+
+<br>
 
 - Detecting duplicate mutable accounts.
 - Returning deterministic custom error codes.
@@ -10,11 +14,15 @@ Pina parity port of Anchor's duplicate mutable account checks.
 
 ## Differences From Anchor
 
+<br>
+
 - Duplicate mutable detection is explicit (`ensure_distinct`) instead of implicit parser behavior.
 - Validation is coded per instruction path so allowed/disallowed cases are clear.
 - Error mapping uses `#[error]` enums and explicit `ProgramError::Custom` values.
 
 ## Run
+
+<br>
 
 ```sh
 cargo test -p anchor_duplicate_mutable_accounts

--- a/examples/anchor_errors/readme.md
+++ b/examples/anchor_errors/readme.md
@@ -1,8 +1,12 @@
 # anchor_errors
 
+<br>
+
 Pina parity port of Anchor's custom error handling patterns.
 
 ## What this demonstrates
+
+<br>
 
 - Stable custom error numbering.
 - Guard helpers (`require_eq`, `require_neq`, etc.).
@@ -10,11 +14,15 @@ Pina parity port of Anchor's custom error handling patterns.
 
 ## Differences From Anchor
 
+<br>
+
 - Error checks are plain Rust helper functions rather than Anchor macros.
 - Instruction behavior is centralized in `process_instruction_variant`.
 - Numeric error-code expectations are asserted in unit tests.
 
 ## Run
+
+<br>
 
 ```sh
 cargo test -p anchor_errors

--- a/examples/anchor_events/readme.md
+++ b/examples/anchor_events/readme.md
@@ -1,8 +1,12 @@
 # anchor_events
 
+<br>
+
 Pina parity port of Anchor's event definitions and serialization semantics.
 
 ## What this demonstrates
+
+<br>
 
 - Event discriminators with `#[event]`.
 - Deterministic event payload encoding/decoding.
@@ -10,11 +14,15 @@ Pina parity port of Anchor's event definitions and serialization semantics.
 
 ## Differences From Anchor
 
+<br>
+
 - This example focuses on event type/data behavior, not Anchor's `emit!`/`emit_cpi!` transport.
 - Event emission is modeled as pure Rust value construction (`build_event`).
 - Tests validate byte-level roundtrips and expected payload values.
 
 ## Run
+
+<br>
 
 ```sh
 cargo test -p anchor_events

--- a/examples/anchor_floats/readme.md
+++ b/examples/anchor_floats/readme.md
@@ -1,8 +1,12 @@
 # anchor_floats
 
+<br>
+
 Pina parity port of Anchor's float account-data patterns.
 
 ## What this demonstrates
+
+<br>
 
 - Float storage in account data using `PodU32`/`PodU64` bit patterns.
 - Authority-gated updates.
@@ -10,11 +14,15 @@ Pina parity port of Anchor's float account-data patterns.
 
 ## Differences From Anchor
 
+<br>
+
 - Float values are explicitly converted with `to_bits`/`from_bits` for `Pod` safety.
 - Authority checks and update rules are explicit in `apply_update`.
 - Account creation is performed with explicit `create_account` + type validation calls.
 
 ## Run
+
+<br>
 
 ```sh
 cargo test -p anchor_floats

--- a/examples/anchor_realloc/readme.md
+++ b/examples/anchor_realloc/readme.md
@@ -1,8 +1,12 @@
 # anchor_realloc
 
+<br>
+
 Pina parity port of Anchor's account reallocation safety checks.
 
 ## What this demonstrates
+
+<br>
 
 - Reallocation growth-limit enforcement.
 - Duplicate realloc target detection.
@@ -10,11 +14,15 @@ Pina parity port of Anchor's account reallocation safety checks.
 
 ## Differences From Anchor
 
+<br>
+
 - Realloc limits are explicit constants (`MAX_PERMITTED_DATA_INCREASE`) and helper guards.
 - Duplicate-account prevention is explicit (`validate_distinct_realloc_targets`).
 - Resizing is done with direct `AccountView::resize` calls after validations.
 
 ## Run
+
+<br>
 
 ```sh
 cargo test -p anchor_realloc

--- a/examples/anchor_system_accounts/readme.md
+++ b/examples/anchor_system_accounts/readme.md
@@ -1,8 +1,12 @@
 # anchor_system_accounts
 
+<br>
+
 Pina parity port of Anchor's system-account ownership checks.
 
 ## What this demonstrates
+
+<br>
 
 - Signer validation for authorities.
 - System-program ownership checks for wallet accounts.
@@ -10,11 +14,15 @@ Pina parity port of Anchor's system-account ownership checks.
 
 ## Differences From Anchor
 
+<br>
+
 - Ownership and signer checks are explicit chained assertions on `AccountView`.
 - The constraint logic is implemented directly in `ProcessAccountInfos`.
 - Tests validate both acceptance and rejection paths for owner checks.
 
 ## Run
+
+<br>
 
 ```sh
 cargo test -p anchor_system_accounts

--- a/examples/anchor_sysvars/readme.md
+++ b/examples/anchor_sysvars/readme.md
@@ -1,8 +1,12 @@
 # anchor_sysvars
 
+<br>
+
 Pina parity port of Anchor's sysvar-address validation checks.
 
 ## What this demonstrates
+
+<br>
 
 - Verifying Clock, Rent, and Stake History sysvar addresses.
 - Routing a dedicated sysvar-check instruction.
@@ -10,11 +14,15 @@ Pina parity port of Anchor's sysvar-address validation checks.
 
 ## Differences From Anchor
 
+<br>
+
 - Sysvar IDs are explicit constants in program code.
 - Validation uses direct `assert_sysvar` checks instead of declarative constraints.
 - Unit tests include direct checks for expected constant separation and parser behavior.
 
 ## Run
+
+<br>
 
 ```sh
 cargo test -p anchor_sysvars

--- a/examples/counter_program/readme.md
+++ b/examples/counter_program/readme.md
@@ -1,8 +1,12 @@
 # `counter_program`
 
+<br>
+
 Reference counter example built with Pina.
 
 ## What it covers
+
+<br>
 
 - PDA-backed account creation.
 - Counter state mutation (`Initialize`, `Increment`).
@@ -10,12 +14,16 @@ Reference counter example built with Pina.
 
 ## Run
 
+<br>
+
 ```bash
 cargo test -p counter_program
 pina idl --path examples/counter_program --output codama/idls/counter_program.json
 ```
 
 ## Optional SBF build
+
+<br>
 
 ```bash
 cargo build --release --target bpfel-unknown-none -p counter_program -Z build-std -F bpf-entrypoint

--- a/examples/escrow_program/readme.md
+++ b/examples/escrow_program/readme.md
@@ -1,8 +1,12 @@
 # `escrow_program`
 
+<br>
+
 Token escrow reference program built with Pina.
 
 ## What it covers
+
+<br>
 
 - Escrow lifecycle with `Make` and `Take` instructions.
 - Vault PDA handling and seed validation.
@@ -10,12 +14,16 @@ Token escrow reference program built with Pina.
 
 ## Run
 
+<br>
+
 ```bash
 cargo test -p escrow_program
 pina idl --path examples/escrow_program --output codama/idls/escrow_program.json
 ```
 
 ## Optional SBF build
+
+<br>
 
 ```bash
 cargo build --release --target bpfel-unknown-none -p escrow_program -Z build-std -F bpf-entrypoint

--- a/examples/hello_solana/readme.md
+++ b/examples/hello_solana/readme.md
@@ -1,8 +1,12 @@
 # `hello_solana`
 
+<br>
+
 Minimal Pina program example.
 
 ## What it covers
+
+<br>
 
 - Basic instruction discriminator and parsing flow.
 - `#[derive(Accounts)]` for account extraction.
@@ -10,12 +14,16 @@ Minimal Pina program example.
 
 ## Run
 
+<br>
+
 ```bash
 cargo test -p hello_solana
 pina idl --path examples/hello_solana --output codama/idls/hello_solana.json
 ```
 
 ## Optional SBF build
+
+<br>
 
 ```bash
 cargo build --release --target bpfel-unknown-none -p hello_solana -Z build-std -F bpf-entrypoint

--- a/examples/pina_bpf/readme.md
+++ b/examples/pina_bpf/readme.md
@@ -1,8 +1,12 @@
 # pina_bpf
 
+<br>
+
 A minimal BPF-targeted example migrated from `pinocchio-bpf-starter` to `pina`.
 
 ## What Changed
+
+<br>
 
 Compared to the original pinocchio starter style:
 
@@ -14,6 +18,8 @@ Compared to the original pinocchio starter style:
   - the generated artifact is a valid ELF binary
 
 ## Build Requirements
+
+<br>
 
 This example must be built with nightly Rust and `build-std` for `core,alloc`.
 
@@ -33,6 +39,8 @@ cargo +nightly-2025-10-15 build-bpf
 ```
 
 ## Tests
+
+<br>
 
 Run normal unit tests:
 

--- a/examples/todo_program/readme.md
+++ b/examples/todo_program/readme.md
@@ -1,8 +1,12 @@
 # `todo_program`
 
+<br>
+
 PDA-backed todo state example.
 
 ## What it covers
+
+<br>
 
 - Creating todo state accounts (`Initialize`).
 - Toggling completion state (`ToggleCompleted`).
@@ -10,12 +14,16 @@ PDA-backed todo state example.
 
 ## Run
 
+<br>
+
 ```bash
 cargo test -p todo_program
 pina idl --path examples/todo_program --output codama/idls/todo_program.json
 ```
 
 ## Optional SBF build
+
+<br>
 
 ```bash
 cargo build --release --target bpfel-unknown-none -p todo_program -Z build-std -F bpf-entrypoint

--- a/examples/transfer_sol/readme.md
+++ b/examples/transfer_sol/readme.md
@@ -1,8 +1,12 @@
 # `transfer_sol`
 
+<br>
+
 SOL transfer example showing two transfer patterns.
 
 ## What it covers
+
+<br>
 
 - CPI transfer through the system program (`CpiTransfer`).
 - Direct lamport mutation for program-owned accounts (`DirectTransfer`).
@@ -10,12 +14,16 @@ SOL transfer example showing two transfer patterns.
 
 ## Run
 
+<br>
+
 ```bash
 cargo test -p transfer_sol
 pina idl --path examples/transfer_sol --output codama/idls/transfer_sol.json
 ```
 
 ## Optional SBF build
+
+<br>
 
 ```bash
 cargo build --release --target bpfel-unknown-none -p transfer_sol -Z build-std -F bpf-entrypoint

--- a/lints/readme.md
+++ b/lints/readme.md
@@ -1,8 +1,12 @@
 # Custom Dylint Lints
 
+<br>
+
 Pina ships three custom [dylint](https://github.com/trailofbits/dylint) lints that catch common Solana smart contract vulnerabilities at compile time. Each lint maps directly to a vulnerability in the [Pina Security Guide](../security/readme.md).
 
 ## Setup
+
+<br>
 
 The lints are registered in the workspace `Cargo.toml`:
 
@@ -23,7 +27,11 @@ cargo dylint --all -- --all-targets
 
 ## Lint Reference
 
+<br>
+
 ### `require_owner_before_token_cast`
+
+<br>
 
 |                       |                                                           |
 | --------------------- | --------------------------------------------------------- |
@@ -77,6 +85,8 @@ fn process(&mut self, _data: &[u8]) -> ProgramResult {
 ---
 
 ### `require_empty_before_init`
+
+<br>
 
 |                       |                                                               |
 | --------------------- | ------------------------------------------------------------- |
@@ -136,6 +146,8 @@ fn process(&mut self, _data: &[u8]) -> ProgramResult {
 ---
 
 ### `require_program_check_before_cpi`
+
+<br>
 
 |                       |                                                             |
 | --------------------- | ----------------------------------------------------------- |

--- a/security/00-signer-authorization/readme.md
+++ b/security/00-signer-authorization/readme.md
@@ -1,14 +1,22 @@
 # 00: Signer Authorization
 
+<br>
+
 ## The Vulnerability
+
+<br>
 
 On Solana, any account can be included in a transaction's account list. Without an explicit signer check, an attacker can submit a transaction that names a victim's account as the "authority" without actually having the victim's private key. The program then trusts the account and performs privileged operations on the attacker's behalf.
 
 ## Insecure Example
 
+<br>
+
 See [`insecure/src/lib.rs`](insecure/src/lib.rs). The `process` function modifies the vault state without calling `assert_signer()` on the authority account. An attacker can pass any address as the authority and the program will accept it.
 
 ## Why This Is Dangerous
+
+<br>
 
 An attacker can:
 
@@ -18,8 +26,12 @@ An attacker can:
 
 ## Secure Example
 
+<br>
+
 See [`secure/src/lib.rs`](secure/src/lib.rs). The authority account is validated with `self.authority.assert_signer()?` before any state mutation.
 
 ## Pina API Reference
+
+<br>
 
 - `AccountInfoValidation::assert_signer()` — verifies `is_signer()` returns `true`, or returns `MissingRequiredSignature`

--- a/security/01-account-data-matching/readme.md
+++ b/security/01-account-data-matching/readme.md
@@ -1,14 +1,22 @@
 # 01: Account Data Matching
 
+<br>
+
 ## The Vulnerability
+
+<br>
 
 A program may store references to other accounts (e.g. a maker's address in an escrow state). If the program doesn't verify that the accounts passed in the transaction match the values stored on-chain, an attacker can substitute different accounts and steal funds.
 
 ## Insecure Example
 
+<br>
+
 See [`insecure/src/lib.rs`](insecure/src/lib.rs). The program reads the escrow state but doesn't verify that the `maker` account passed in the transaction matches the `maker` field stored in the escrow.
 
 ## Why This Is Dangerous
+
+<br>
 
 An attacker can:
 
@@ -17,9 +25,13 @@ An attacker can:
 
 ## Secure Example
 
+<br>
+
 See [`secure/src/lib.rs`](secure/src/lib.rs). After deserializing the escrow state, the program calls `self.maker.assert_address(&escrow.maker)?` to verify the account matches.
 
 ## Pina API Reference
+
+<br>
 
 - `AccountInfoValidation::assert_address()` — verifies the account's address matches the expected value
 - `AccountInfoValidation::assert_addresses()` — verifies the account's address is in a set of expected values

--- a/security/02-owner-checks/readme.md
+++ b/security/02-owner-checks/readme.md
@@ -1,6 +1,10 @@
 # 02: Owner Checks
 
+<br>
+
 ## The Vulnerability
+
+<br>
 
 Every Solana account has an "owner" program. If a program doesn't verify account ownership before deserializing data, an attacker can create a fake account with the same data layout but owned by a different program. The program trusts the data and acts on it.
 
@@ -8,9 +12,13 @@ This is especially critical for token accounts: the `as_token_account()` and `as
 
 ## Insecure Example
 
+<br>
+
 See [`insecure/src/lib.rs`](insecure/src/lib.rs). The program calls `as_token_account()` without first verifying that the account is owned by the SPL Token program. An attacker can craft a fake account with arbitrary token data.
 
 ## Why This Is Dangerous
+
+<br>
 
 An attacker can:
 
@@ -20,9 +28,13 @@ An attacker can:
 
 ## Secure Example
 
+<br>
+
 See [`secure/src/lib.rs`](secure/src/lib.rs). The program calls `assert_owners(&SPL_PROGRAM_IDS)?` before any token deserialization.
 
 ## Pina API Reference
+
+<br>
 
 - `AccountInfoValidation::assert_owner()` — verifies the account is owned by the given program
 - `AccountInfoValidation::assert_owners()` — verifies the account is owned by one of the given programs (useful for SPL Token + Token-2022 compatibility)

--- a/security/03-type-cosplay/readme.md
+++ b/security/03-type-cosplay/readme.md
@@ -1,6 +1,10 @@
 # 03: Type Cosplay
 
+<br>
+
 ## The Vulnerability
+
+<br>
 
 If a program has multiple account types with similar sizes, an attacker can pass one account type where another is expected. Without discriminator validation, the program reinterprets the data as the wrong type, potentially granting unauthorized access.
 
@@ -8,9 +12,13 @@ For example, if a "User" account and an "Admin" account have the same byte size,
 
 ## Insecure Example
 
+<br>
+
 See [`insecure/src/lib.rs`](insecure/src/lib.rs). The program deserializes account data using raw `bytemuck::try_from_bytes` without checking the discriminator. Any account of the right size is accepted.
 
 ## Why This Is Dangerous
+
+<br>
 
 An attacker can:
 
@@ -20,9 +28,13 @@ An attacker can:
 
 ## Secure Example
 
+<br>
+
 See [`secure/src/lib.rs`](secure/src/lib.rs). The program calls `assert_type::<T>(&ID)?` which checks the discriminator, owner, and data size before deserialization.
 
 ## Pina API Reference
+
+<br>
 
 - `AccountInfoValidation::assert_type::<T>(program_id)` — checks owner, discriminator, and data length in one call
 - `AsAccount::as_account::<T>(program_id)` — checks owner and discriminator during deserialization

--- a/security/04-initialization/readme.md
+++ b/security/04-initialization/readme.md
@@ -1,6 +1,10 @@
 # 04: Initialization
 
+<br>
+
 ## The Vulnerability
+
+<br>
 
 If a program doesn't check whether an account has already been initialized before writing initial state, an attacker can reinitialize accounts. This can reset balances, change authorities, or otherwise corrupt state.
 
@@ -8,9 +12,13 @@ The `#[account]` macro does **not** inject reinitialization protection automatic
 
 ## Insecure Example
 
+<br>
+
 See [`insecure/src/lib.rs`](insecure/src/lib.rs). The program creates and initializes an account without calling `assert_empty()` first. An attacker can call the initialize instruction again to overwrite existing state.
 
 ## Why This Is Dangerous
+
+<br>
 
 An attacker can:
 
@@ -20,9 +28,13 @@ An attacker can:
 
 ## Secure Example
 
+<br>
+
 See [`secure/src/lib.rs`](secure/src/lib.rs). The program calls `assert_empty()?.assert_writable()?` before creating the account, ensuring the account hasn't been initialized yet.
 
 ## Pina API Reference
+
+<br>
 
 - `AccountInfoValidation::assert_empty()` — verifies the account has no data, returns `AccountAlreadyInitialized` if non-empty
 - `AccountInfoValidation::assert_not_empty()` — the inverse check for reading existing accounts

--- a/security/05-arbitrary-cpi/readme.md
+++ b/security/05-arbitrary-cpi/readme.md
@@ -1,14 +1,22 @@
 # 05: Arbitrary CPI
 
+<br>
+
 ## The Vulnerability
+
+<br>
 
 Cross-Program Invocations (CPI) execute instructions on other programs. If a program doesn't verify the address of the target program before invoking it, an attacker can substitute a malicious program. The malicious program can then perform arbitrary actions with the authority and accounts passed to the CPI.
 
 ## Insecure Example
 
+<br>
+
 See [`insecure/src/lib.rs`](insecure/src/lib.rs). The program invokes whatever program the caller passes without verifying its address. An attacker can substitute a malicious program.
 
 ## Why This Is Dangerous
+
+<br>
 
 An attacker can:
 
@@ -18,9 +26,13 @@ An attacker can:
 
 ## Secure Example
 
+<br>
+
 See [`secure/src/lib.rs`](secure/src/lib.rs). The program calls `assert_address(&system::ID)?` on the system program account before the CPI.
 
 ## Pina API Reference
+
+<br>
 
 - `AccountInfoValidation::assert_address()` — verifies exact address match
 - `AccountInfoValidation::assert_program()` — verifies address + executable flag in one call

--- a/security/06-duplicate-mutable-accounts/readme.md
+++ b/security/06-duplicate-mutable-accounts/readme.md
@@ -1,14 +1,22 @@
 # 06: Duplicate Mutable Accounts
 
+<br>
+
 ## The Vulnerability
+
+<br>
 
 If a program expects two distinct writable accounts (e.g. source and destination) but doesn't check that they are different, an attacker can pass the same account for both. When the program debits one and credits the other, both operations hit the same account, potentially creating or destroying value.
 
 ## Insecure Example
 
+<br>
+
 See [`insecure/src/lib.rs`](insecure/src/lib.rs). The program transfers value between source and destination without checking they are different accounts. Passing the same account as both source and dest could cause unexpected behavior.
 
 ## Why This Is Dangerous
+
+<br>
 
 An attacker can:
 
@@ -18,9 +26,13 @@ An attacker can:
 
 ## Secure Example
 
+<br>
+
 See [`secure/src/lib.rs`](secure/src/lib.rs). The program checks `source.address() != dest.address()` before processing the transfer.
 
 ## Pina API Reference
+
+<br>
 
 - `AccountView::address()` — returns the account's address for comparison
 - Compare addresses directly: `source.address() != dest.address()`

--- a/security/07-bump-seed-canonicalization/readme.md
+++ b/security/07-bump-seed-canonicalization/readme.md
@@ -1,6 +1,10 @@
 # 07: Bump Seed Canonicalization
 
+<br>
+
 ## The Vulnerability
+
+<br>
 
 Program Derived Addresses (PDAs) are derived with a "bump seed" — the runtime tries bump values from 255 down to 0 and returns the first one that produces a valid PDA. This first-found bump is the "canonical" bump.
 
@@ -8,9 +12,13 @@ If a program accepts any user-provided bump without verifying it's canonical, an
 
 ## Insecure Example
 
+<br>
+
 See [`insecure/src/lib.rs`](insecure/src/lib.rs). The program accepts a user-provided bump and uses `assert_seeds_with_bump` without verifying canonicality. An attacker can use a non-canonical bump to create duplicate state.
 
 ## Why This Is Dangerous
+
+<br>
 
 An attacker can:
 
@@ -20,9 +28,13 @@ An attacker can:
 
 ## Secure Example
 
+<br>
+
 See [`secure/src/lib.rs`](secure/src/lib.rs). The program uses `assert_seeds()` which internally calls `try_find_program_address` to find and verify the canonical bump.
 
 ## Pina API Reference
+
+<br>
 
 - `AccountInfoValidation::assert_seeds()` — finds the canonical bump via `try_find_program_address` and verifies the address matches
 - `AccountInfoValidation::assert_canonical_bump()` — same as `assert_seeds()` but also returns the canonical bump value

--- a/security/08-pda-sharing/readme.md
+++ b/security/08-pda-sharing/readme.md
@@ -1,14 +1,22 @@
 # 08: PDA Sharing
 
+<br>
+
 ## The Vulnerability
+
+<br>
 
 If two different account types use the same PDA seeds, they share the same address space. An attacker can create one type of account and then use it where the other type is expected. This is similar to type cosplay but at the PDA derivation level.
 
 ## Insecure Example
 
+<br>
+
 See [`insecure/src/lib.rs`](insecure/src/lib.rs). Both `UserConfig` and `UserVault` use the identical seeds `&[b"state", user_address]`, meaning they would derive to the same PDA.
 
 ## Why This Is Dangerous
+
+<br>
 
 An attacker can:
 
@@ -18,9 +26,13 @@ An attacker can:
 
 ## Secure Example
 
+<br>
+
 See [`secure/src/lib.rs`](secure/src/lib.rs). Each account type uses type-specific seed prefixes: `&[b"config", user]` vs `&[b"vault", user]`. This ensures each type has its own PDA namespace.
 
 ## Pina API Reference
+
+<br>
 
 - Use distinct seed prefixes for each account type (e.g. `b"config"`, `b"vault"`)
 - `AccountInfoValidation::assert_type::<T>()` — additional defense that checks the discriminator even if PDAs happen to collide

--- a/security/09-closing-accounts/readme.md
+++ b/security/09-closing-accounts/readme.md
@@ -1,14 +1,22 @@
 # 09: Closing Accounts
 
+<br>
+
 ## The Vulnerability
+
+<br>
 
 Closing a Solana account requires more than just zeroing its lamport balance. If the account data isn't zeroed and the account isn't properly closed, a within-transaction attacker can revive the account by adding lamports back before the runtime garbage-collects it. The stale data remains intact and can be reused.
 
 ## Insecure Example
 
+<br>
+
 See [`insecure/src/lib.rs`](insecure/src/lib.rs). The program transfers lamports to the recipient but doesn't zero the account data or properly close the account. The account can be revived within the same transaction.
 
 ## Why This Is Dangerous
+
+<br>
 
 An attacker can:
 
@@ -18,9 +26,13 @@ An attacker can:
 
 ## Secure Example
 
+<br>
+
 See [`secure/src/lib.rs`](secure/src/lib.rs). The program calls `zeroed()` on the account data to clear it, then calls `close_with_recipient()` which zeros lamports, resizes to 0, and closes the account.
 
 ## Pina API Reference
+
+<br>
 
 - `CloseAccountWithRecipient::close_with_recipient()` — transfers lamports to recipient, resizes data to 0, and closes the account
 - Account data `zeroed()` method — zeros all account data before closing to prevent stale data reuse

--- a/security/10-sysvar-address-checking/readme.md
+++ b/security/10-sysvar-address-checking/readme.md
@@ -1,14 +1,22 @@
 # 10: Sysvar Address Checking
 
+<br>
+
 ## The Vulnerability
+
+<br>
 
 Solana sysvars (Rent, Clock, etc.) are special accounts at well-known addresses. If a program reads a sysvar account without verifying both its address and owner, an attacker can create a fake account with spoofed sysvar data. This can manipulate rent calculations, clock readings, or other sysvar-dependent logic.
 
 ## Insecure Example
 
+<br>
+
 See [`insecure/src/lib.rs`](insecure/src/lib.rs). The program reads the rent sysvar account without verifying its address or owner. An attacker can pass a fake account with manipulated rent data.
 
 ## Why This Is Dangerous
+
+<br>
 
 An attacker can:
 
@@ -18,8 +26,12 @@ An attacker can:
 
 ## Secure Example
 
+<br>
+
 See [`secure/src/lib.rs`](secure/src/lib.rs). The program calls `assert_sysvar(&RENT_SYSVAR_ID)?` which checks both the owner (Sysvar program) and the address.
 
 ## Pina API Reference
+
+<br>
 
 - `AccountInfoValidation::assert_sysvar(sysvar_id)` — checks both the owner (Sysvar1111111111111111111111111111111111111) and the address match the expected sysvar

--- a/security/readme.md
+++ b/security/readme.md
@@ -1,5 +1,7 @@
 # Pina Security Guide
 
+<br>
+
 This guide covers the most common Solana smart contract vulnerabilities and how pina mitigates them. Each category includes:
 
 - A **readme** explaining the vulnerability and pina's mitigations
@@ -9,6 +11,8 @@ This guide covers the most common Solana smart contract vulnerabilities and how 
 Based on the [sealevel-attacks](https://github.com/coral-xyz/sealevel-attacks) taxonomy.
 
 ## Categories
+
+<br>
 
 | #                                    | Attack                     | Key Pina Mitigation                                 |
 | ------------------------------------ | -------------------------- | --------------------------------------------------- |
@@ -25,6 +29,8 @@ Based on the [sealevel-attacks](https://github.com/coral-xyz/sealevel-attacks) t
 | [10](10-sysvar-address-checking/)    | Sysvar Address Checking    | `assert_sysvar()`                                   |
 
 ## How to Use
+
+<br>
 
 Each **secure** crate is a workspace member and compiles with `cargo build`. Each **insecure** crate is excluded from the workspace but can be built independently:
 


### PR DESCRIPTION
## Summary

- Add `<br>` tags after every h1, h2, and h3 heading in all sub-crate, example, security, and lint readme files for improved visual spacing and readability.
- Applies the same pattern previously used in the root readme to 34 sub-directory readme files.
- Only h1-h3 headings are affected; h4+ headings and content inside code fences are left untouched.

## Test plan

- [ ] Verify `<br>` tags appear after h1/h2/h3 headings in all modified readme files
- [ ] Verify no `<br>` tags were added inside code fences or after h4+ headings
- [ ] Verify the root `readme.md` is unmodified
- [ ] Verify `dprint check` passes with no formatting issues