### PR TITLE
test: add property-based fuzz tests for Pod types and discriminators

### DIFF
--- a/.changeset/fuzz_testing.md
+++ b/.changeset/fuzz_testing.md
@@ -1,0 +1,6 @@
+---
+pina_pod_primitives: patch
+pina: patch
+---
+
+Add property-based fuzz tests using `proptest` for Pod type deserialization, round-trip correctness, and discriminator parsing safety.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1966,6 +1966,7 @@ dependencies = [
  "pinocchio-system",
  "pinocchio-token",
  "pinocchio-token-2022",
+ "proptest",
  "solana-address 2.2.0",
  "solana-program-log",
  "typed-builder",
@@ -2041,6 +2042,7 @@ name = "pina_pod_primitives"
 version = "0.5.0"
 dependencies = [
  "bytemuck",
+ "proptest",
 ]
 
 [[package]]
@@ -2162,6 +2164,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+dependencies = [
+ "bitflags",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
+]
+
+[[package]]
 name = "qualifier_attr"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2212,6 +2229,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2229,6 +2256,16 @@ checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2250,12 +2287,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3851,6 +3906,12 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ pinocchio-system = { default-features = false, version = "^0.5" }
 pinocchio-token = { default-features = false, version = "^0.5" }
 pinocchio-token-2022 = { default-features = false, version = "^0.2" }
 proc-macro2 = { default-features = false, version = "^1" }
+proptest = { default-features = false, version = "^1", features = ["std"] }
 quote = { default-features = false, version = "^1" }
 serde = { default-features = false, version = "^1" }
 serde_json = { default-features = false, version = "^1", features = ["std"] }

--- a/crates/pina/Cargo.toml
+++ b/crates/pina/Cargo.toml
@@ -33,5 +33,8 @@ solana-address = { workspace = true }
 solana-program-log = { workspace = true, optional = true, features = ["macro"] }
 typed-builder = { workspace = true }
 
+[dev-dependencies]
+proptest = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/pina/tests/fuzz_discriminator.rs
+++ b/crates/pina/tests/fuzz_discriminator.rs
@@ -1,0 +1,254 @@
+//! Property-based fuzz tests for discriminator parsing safety and round-trip
+//! correctness across all supported primitive discriminator widths (u8, u16,
+//! u32, u64).
+
+use pina::IntoDiscriminator;
+use proptest::prelude::*;
+
+// ---------------------------------------------------------------------------
+// Arbitrary byte slices never cause panics when parsed as discriminators
+// ---------------------------------------------------------------------------
+
+proptest! {
+	#[test]
+	fn arbitrary_bytes_no_panic_u8(ref bytes in prop::collection::vec(any::<u8>(), 0..64)) {
+		// Must not panic — either Ok or Err.
+		let _ = u8::discriminator_from_bytes(bytes);
+	}
+
+	#[test]
+	fn arbitrary_bytes_no_panic_u16(ref bytes in prop::collection::vec(any::<u8>(), 0..64)) {
+		let _ = u16::discriminator_from_bytes(bytes);
+	}
+
+	#[test]
+	fn arbitrary_bytes_no_panic_u32(ref bytes in prop::collection::vec(any::<u8>(), 0..64)) {
+		let _ = u32::discriminator_from_bytes(bytes);
+	}
+
+	#[test]
+	fn arbitrary_bytes_no_panic_u64(ref bytes in prop::collection::vec(any::<u8>(), 0..64)) {
+		let _ = u64::discriminator_from_bytes(bytes);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Valid discriminator values round-trip correctly (write -> from_bytes)
+// ---------------------------------------------------------------------------
+
+proptest! {
+	#[test]
+	fn roundtrip_u8(val: u8) {
+		let mut bytes = [0u8; 1];
+		val.write_discriminator(&mut bytes);
+		let decoded = u8::discriminator_from_bytes(&bytes)
+			.unwrap_or_else(|_| panic!("discriminator_from_bytes failed for u8 value {val}"));
+		prop_assert_eq!(decoded, val);
+	}
+
+	#[test]
+	fn roundtrip_u16(val: u16) {
+		let mut bytes = [0u8; 2];
+		val.write_discriminator(&mut bytes);
+		let decoded = u16::discriminator_from_bytes(&bytes)
+			.unwrap_or_else(|_| panic!("discriminator_from_bytes failed for u16 value {val}"));
+		prop_assert_eq!(decoded, val);
+	}
+
+	#[test]
+	fn roundtrip_u32(val: u32) {
+		let mut bytes = [0u8; 4];
+		val.write_discriminator(&mut bytes);
+		let decoded = u32::discriminator_from_bytes(&bytes)
+			.unwrap_or_else(|_| panic!("discriminator_from_bytes failed for u32 value {val}"));
+		prop_assert_eq!(decoded, val);
+	}
+
+	#[test]
+	fn roundtrip_u64(val: u64) {
+		let mut bytes = [0u8; 8];
+		val.write_discriminator(&mut bytes);
+		let decoded = u64::discriminator_from_bytes(&bytes)
+			.unwrap_or_else(|_| panic!("discriminator_from_bytes failed for u64 value {val}"));
+		prop_assert_eq!(decoded, val);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// matches_discriminator is consistent with write_discriminator
+// ---------------------------------------------------------------------------
+
+proptest! {
+	#[test]
+	fn matches_after_write_u8(val: u8) {
+		let mut bytes = [0u8; 1];
+		val.write_discriminator(&mut bytes);
+		prop_assert!(val.matches_discriminator(&bytes));
+	}
+
+	#[test]
+	fn matches_after_write_u16(val: u16) {
+		let mut bytes = [0u8; 2];
+		val.write_discriminator(&mut bytes);
+		prop_assert!(val.matches_discriminator(&bytes));
+	}
+
+	#[test]
+	fn matches_after_write_u32(val: u32) {
+		let mut bytes = [0u8; 4];
+		val.write_discriminator(&mut bytes);
+		prop_assert!(val.matches_discriminator(&bytes));
+	}
+
+	#[test]
+	fn matches_after_write_u64(val: u64) {
+		let mut bytes = [0u8; 8];
+		val.write_discriminator(&mut bytes);
+		prop_assert!(val.matches_discriminator(&bytes));
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Short slices always return Err or false, never panic
+// ---------------------------------------------------------------------------
+
+proptest! {
+	#[test]
+	fn short_slice_u16_no_panic(ref bytes in prop::collection::vec(any::<u8>(), 0..2)) {
+		// Fewer than 2 bytes — must be Err.
+		let result = u16::discriminator_from_bytes(bytes);
+		prop_assert!(result.is_err());
+	}
+
+	#[test]
+	fn short_slice_u32_no_panic(ref bytes in prop::collection::vec(any::<u8>(), 0..4)) {
+		let result = u32::discriminator_from_bytes(bytes);
+		prop_assert!(result.is_err());
+	}
+
+	#[test]
+	fn short_slice_u64_no_panic(ref bytes in prop::collection::vec(any::<u8>(), 0..8)) {
+		let result = u64::discriminator_from_bytes(bytes);
+		prop_assert!(result.is_err());
+	}
+
+	#[test]
+	fn matches_short_slice_u16_no_panic(
+		val: u16,
+		ref bytes in prop::collection::vec(any::<u8>(), 0..2),
+	) {
+		// Short data — must return false, never panic.
+		prop_assert!(!val.matches_discriminator(bytes));
+	}
+
+	#[test]
+	fn matches_short_slice_u32_no_panic(
+		val: u32,
+		ref bytes in prop::collection::vec(any::<u8>(), 0..4),
+	) {
+		prop_assert!(!val.matches_discriminator(bytes));
+	}
+
+	#[test]
+	fn matches_short_slice_u64_no_panic(
+		val: u64,
+		ref bytes in prop::collection::vec(any::<u8>(), 0..8),
+	) {
+		prop_assert!(!val.matches_discriminator(bytes));
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Boundary values for all discriminator widths
+// ---------------------------------------------------------------------------
+
+#[test]
+fn boundary_values_u8() {
+	for val in [0u8, 1, 127, 128, 254, 255] {
+		let mut bytes = [0u8; 1];
+		val.write_discriminator(&mut bytes);
+		let decoded = u8::discriminator_from_bytes(&bytes)
+			.unwrap_or_else(|_| panic!("failed for u8 boundary value {val}"));
+		assert_eq!(decoded, val);
+		assert!(val.matches_discriminator(&bytes));
+	}
+}
+
+#[test]
+fn boundary_values_u16() {
+	for val in [0u16, 1, 255, 256, u16::MAX - 1, u16::MAX] {
+		let mut bytes = [0u8; 2];
+		val.write_discriminator(&mut bytes);
+		let decoded = u16::discriminator_from_bytes(&bytes)
+			.unwrap_or_else(|_| panic!("failed for u16 boundary value {val}"));
+		assert_eq!(decoded, val);
+		assert!(val.matches_discriminator(&bytes));
+	}
+}
+
+#[test]
+fn boundary_values_u32() {
+	for val in [0u32, 1, 255, 256, 65535, 65536, u32::MAX - 1, u32::MAX] {
+		let mut bytes = [0u8; 4];
+		val.write_discriminator(&mut bytes);
+		let decoded = u32::discriminator_from_bytes(&bytes)
+			.unwrap_or_else(|_| panic!("failed for u32 boundary value {val}"));
+		assert_eq!(decoded, val);
+		assert!(val.matches_discriminator(&bytes));
+	}
+}
+
+#[test]
+fn boundary_values_u64() {
+	for val in [
+		0u64,
+		1,
+		255,
+		256,
+		65535,
+		65536,
+		u32::MAX as u64,
+		(u32::MAX as u64) + 1,
+		u64::MAX - 1,
+		u64::MAX,
+	] {
+		let mut bytes = [0u8; 8];
+		val.write_discriminator(&mut bytes);
+		let decoded = u64::discriminator_from_bytes(&bytes)
+			.unwrap_or_else(|_| panic!("failed for u64 boundary value {val}"));
+		assert_eq!(decoded, val);
+		assert!(val.matches_discriminator(&bytes));
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Extra-long slices: discriminator_from_bytes reads only the first N bytes
+// ---------------------------------------------------------------------------
+
+proptest! {
+	#[test]
+	fn extra_long_slice_u8(
+		val: u8,
+		ref tail in prop::collection::vec(any::<u8>(), 1..32),
+	) {
+		let mut bytes = vec![0u8; 1];
+		val.write_discriminator(&mut bytes);
+		bytes.extend_from_slice(tail);
+		let decoded = u8::discriminator_from_bytes(&bytes)
+			.unwrap_or_else(|_| panic!("failed for u8 with extra bytes"));
+		prop_assert_eq!(decoded, val);
+	}
+
+	#[test]
+	fn extra_long_slice_u32(
+		val: u32,
+		ref tail in prop::collection::vec(any::<u8>(), 1..32),
+	) {
+		let mut bytes = vec![0u8; 4];
+		val.write_discriminator(&mut bytes[..4]);
+		bytes.extend_from_slice(tail);
+		let decoded = u32::discriminator_from_bytes(&bytes)
+			.unwrap_or_else(|_| panic!("failed for u32 with extra bytes"));
+		prop_assert_eq!(decoded, val);
+	}
+}

--- a/crates/pina_pod_primitives/Cargo.toml
+++ b/crates/pina_pod_primitives/Cargo.toml
@@ -12,5 +12,8 @@ description = "Alignment-safe POD primitive wrappers for Solana account layouts"
 [dependencies]
 bytemuck = { workspace = true, features = ["derive"] }
 
+[dev-dependencies]
+proptest = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/pina_pod_primitives/tests/fuzz_pod.rs
+++ b/crates/pina_pod_primitives/tests/fuzz_pod.rs
@@ -1,0 +1,309 @@
+//! Property-based fuzz tests for Pod type deserialization, round-trip
+//! correctness, and safety under arbitrary byte patterns.
+
+use bytemuck::try_from_bytes;
+use pina_pod_primitives::PodBool;
+use pina_pod_primitives::PodI16;
+use pina_pod_primitives::PodI32;
+use pina_pod_primitives::PodI64;
+use pina_pod_primitives::PodI128;
+use pina_pod_primitives::PodU16;
+use pina_pod_primitives::PodU32;
+use pina_pod_primitives::PodU64;
+use pina_pod_primitives::PodU128;
+use proptest::prelude::*;
+
+// ---------------------------------------------------------------------------
+// Round-trip: from_primitive(x).into() == x
+// ---------------------------------------------------------------------------
+
+proptest! {
+	#[test]
+	fn roundtrip_u16(val: u16) {
+		let pod = PodU16::from_primitive(val);
+		let back: u16 = pod.into();
+		prop_assert_eq!(back, val);
+	}
+
+	#[test]
+	fn roundtrip_i16(val: i16) {
+		let pod = PodI16::from_primitive(val);
+		let back: i16 = pod.into();
+		prop_assert_eq!(back, val);
+	}
+
+	#[test]
+	fn roundtrip_u32(val: u32) {
+		let pod = PodU32::from_primitive(val);
+		let back: u32 = pod.into();
+		prop_assert_eq!(back, val);
+	}
+
+	#[test]
+	fn roundtrip_i32(val: i32) {
+		let pod = PodI32::from_primitive(val);
+		let back: i32 = pod.into();
+		prop_assert_eq!(back, val);
+	}
+
+	#[test]
+	fn roundtrip_u64(val: u64) {
+		let pod = PodU64::from_primitive(val);
+		let back: u64 = pod.into();
+		prop_assert_eq!(back, val);
+	}
+
+	#[test]
+	fn roundtrip_i64(val: i64) {
+		let pod = PodI64::from_primitive(val);
+		let back: i64 = pod.into();
+		prop_assert_eq!(back, val);
+	}
+
+	#[test]
+	fn roundtrip_u128(val: u128) {
+		let pod = PodU128::from_primitive(val);
+		let back: u128 = pod.into();
+		prop_assert_eq!(back, val);
+	}
+
+	#[test]
+	fn roundtrip_i128(val: i128) {
+		let pod = PodI128::from_primitive(val);
+		let back: i128 = pod.into();
+		prop_assert_eq!(back, val);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Arbitrary byte patterns safely interpreted as Pod types via bytemuck
+// ---------------------------------------------------------------------------
+
+proptest! {
+	#[test]
+	fn arbitrary_bytes_as_pod_bool(byte: u8) {
+		let bytes = [byte];
+		let result = try_from_bytes::<PodBool>(&bytes);
+		// Must always succeed — PodBool is repr(transparent) over u8.
+		let pod = result.unwrap_or_else(|e| panic!("try_from_bytes failed for byte {byte}: {e}"));
+		// Conversion to bool must never panic.
+		let _: bool = (*pod).into();
+	}
+
+	#[test]
+	fn arbitrary_bytes_as_pod_u16(bytes: [u8; 2]) {
+		let result = try_from_bytes::<PodU16>(&bytes);
+		let pod = result.unwrap_or_else(|e| {
+			panic!("try_from_bytes failed for bytes {bytes:?}: {e}")
+		});
+		let _: u16 = (*pod).into();
+	}
+
+	#[test]
+	fn arbitrary_bytes_as_pod_i16(bytes: [u8; 2]) {
+		let result = try_from_bytes::<PodI16>(&bytes);
+		let pod = result.unwrap_or_else(|e| {
+			panic!("try_from_bytes failed for bytes {bytes:?}: {e}")
+		});
+		let _: i16 = (*pod).into();
+	}
+
+	#[test]
+	fn arbitrary_bytes_as_pod_u32(bytes: [u8; 4]) {
+		let result = try_from_bytes::<PodU32>(&bytes);
+		let pod = result.unwrap_or_else(|e| {
+			panic!("try_from_bytes failed for bytes {bytes:?}: {e}")
+		});
+		let _: u32 = (*pod).into();
+	}
+
+	#[test]
+	fn arbitrary_bytes_as_pod_i32(bytes: [u8; 4]) {
+		let result = try_from_bytes::<PodI32>(&bytes);
+		let pod = result.unwrap_or_else(|e| {
+			panic!("try_from_bytes failed for bytes {bytes:?}: {e}")
+		});
+		let _: i32 = (*pod).into();
+	}
+
+	#[test]
+	fn arbitrary_bytes_as_pod_u64(bytes: [u8; 8]) {
+		let result = try_from_bytes::<PodU64>(&bytes);
+		let pod = result.unwrap_or_else(|e| {
+			panic!("try_from_bytes failed for bytes {bytes:?}: {e}")
+		});
+		let _: u64 = (*pod).into();
+	}
+
+	#[test]
+	fn arbitrary_bytes_as_pod_i64(bytes: [u8; 8]) {
+		let result = try_from_bytes::<PodI64>(&bytes);
+		let pod = result.unwrap_or_else(|e| {
+			panic!("try_from_bytes failed for bytes {bytes:?}: {e}")
+		});
+		let _: i64 = (*pod).into();
+	}
+
+	#[test]
+	fn arbitrary_bytes_as_pod_u128(bytes: [u8; 16]) {
+		let result = try_from_bytes::<PodU128>(&bytes);
+		let pod = result.unwrap_or_else(|e| {
+			panic!("try_from_bytes failed for bytes {bytes:?}: {e}")
+		});
+		let _: u128 = (*pod).into();
+	}
+
+	#[test]
+	fn arbitrary_bytes_as_pod_i128(bytes: [u8; 16]) {
+		let result = try_from_bytes::<PodI128>(&bytes);
+		let pod = result.unwrap_or_else(|e| {
+			panic!("try_from_bytes failed for bytes {bytes:?}: {e}")
+		});
+		let _: i128 = (*pod).into();
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PodBool: only 0 and 1 are canonical
+// ---------------------------------------------------------------------------
+
+proptest! {
+	#[test]
+	fn pod_bool_canonical_only_zero_and_one(byte: u8) {
+		let pod = PodBool(byte);
+		if byte == 0 || byte == 1 {
+			prop_assert!(pod.is_canonical());
+		} else {
+			prop_assert!(!pod.is_canonical());
+		}
+	}
+
+	#[test]
+	fn pod_bool_from_bool_always_canonical(b: bool) {
+		let pod = PodBool::from_bool(b);
+		prop_assert!(pod.is_canonical());
+		let back: bool = pod.into();
+		prop_assert_eq!(back, b);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Boundary values for all Pod integer types
+// ---------------------------------------------------------------------------
+
+#[test]
+fn boundary_values_u16() {
+	for &val in &[0u16, 1, u16::MAX - 1, u16::MAX] {
+		let pod = PodU16::from_primitive(val);
+		let back: u16 = pod.into();
+		assert_eq!(back, val);
+	}
+}
+
+#[test]
+fn boundary_values_i16() {
+	for &val in &[i16::MIN, i16::MIN + 1, -1i16, 0, 1, i16::MAX - 1, i16::MAX] {
+		let pod = PodI16::from_primitive(val);
+		let back: i16 = pod.into();
+		assert_eq!(back, val);
+	}
+}
+
+#[test]
+fn boundary_values_u32() {
+	for &val in &[0u32, 1, u32::MAX - 1, u32::MAX] {
+		let pod = PodU32::from_primitive(val);
+		let back: u32 = pod.into();
+		assert_eq!(back, val);
+	}
+}
+
+#[test]
+fn boundary_values_i32() {
+	for &val in &[i32::MIN, i32::MIN + 1, -1i32, 0, 1, i32::MAX - 1, i32::MAX] {
+		let pod = PodI32::from_primitive(val);
+		let back: i32 = pod.into();
+		assert_eq!(back, val);
+	}
+}
+
+#[test]
+fn boundary_values_u64() {
+	for &val in &[0u64, 1, u64::MAX - 1, u64::MAX] {
+		let pod = PodU64::from_primitive(val);
+		let back: u64 = pod.into();
+		assert_eq!(back, val);
+	}
+}
+
+#[test]
+fn boundary_values_i64() {
+	for &val in &[i64::MIN, i64::MIN + 1, -1i64, 0, 1, i64::MAX - 1, i64::MAX] {
+		let pod = PodI64::from_primitive(val);
+		let back: i64 = pod.into();
+		assert_eq!(back, val);
+	}
+}
+
+#[test]
+fn boundary_values_u128() {
+	for &val in &[0u128, 1, u128::MAX - 1, u128::MAX] {
+		let pod = PodU128::from_primitive(val);
+		let back: u128 = pod.into();
+		assert_eq!(back, val);
+	}
+}
+
+#[test]
+fn boundary_values_i128() {
+	for &val in &[
+		i128::MIN,
+		i128::MIN + 1,
+		-1i128,
+		0,
+		1,
+		i128::MAX - 1,
+		i128::MAX,
+	] {
+		let pod = PodI128::from_primitive(val);
+		let back: i128 = pod.into();
+		assert_eq!(back, val);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// bytemuck try_from_bytes never panics for correctly-sized aligned data
+// ---------------------------------------------------------------------------
+
+proptest! {
+	/// For any arbitrary byte pattern of the correct size, `try_from_bytes`
+	/// must return `Ok` (Pod types have no alignment or validity constraints
+	/// beyond size) and the resulting value must survive conversion without
+	/// panicking.
+	#[test]
+	fn try_from_bytes_never_panics_u64(bytes: [u8; 8]) {
+		let result = try_from_bytes::<PodU64>(&bytes);
+		// PodU64 is repr(transparent) over [u8; 8], so this must always
+		// succeed for an 8-byte aligned slice.
+		prop_assert!(result.is_ok());
+		let val: u64 = (*result.unwrap_or_else(|e| {
+			panic!("unexpected failure: {e}")
+		}))
+		.into();
+		// Round-trip: encoding back must produce the same bytes.
+		let re_encoded = PodU64::from_primitive(val);
+		prop_assert_eq!(re_encoded.0, bytes);
+	}
+
+	#[test]
+	fn try_from_bytes_never_panics_u128(bytes: [u8; 16]) {
+		let result = try_from_bytes::<PodU128>(&bytes);
+		prop_assert!(result.is_ok());
+		let val: u128 = (*result.unwrap_or_else(|e| {
+			panic!("unexpected failure: {e}")
+		}))
+		.into();
+		let re_encoded = PodU128::from_primitive(val);
+		prop_assert_eq!(re_encoded.0, bytes);
+	}
+}


### PR DESCRIPTION
## Summary

- Add `proptest` as a workspace dev-dependency and wire it into `pina` and `pina_pod_primitives`
- Add 29 property-based fuzz tests for Pod type deserialization in `crates/pina_pod_primitives/tests/fuzz_pod.rs`: round-trip correctness for all Pod integer types, arbitrary byte pattern safety via `bytemuck::try_from_bytes`, `PodBool` canonicality invariants, and boundary value coverage for every integer width
- Add 24 property-based fuzz tests for discriminator parsing in `crates/pina/tests/fuzz_discriminator.rs`: arbitrary byte slice safety for `u8`/`u16`/`u32`/`u64` discriminators, write-then-read round-trip correctness, `matches_discriminator` consistency, short-slice rejection, boundary values, and extra-long-slice tolerance

## Test plan

- [x] `cargo test -p pina_pod_primitives` passes (26 existing + 29 new fuzz tests)
- [x] `cargo test -p pina` passes (all existing tests + 24 new fuzz discriminator tests)
- [x] `dprint check` passes with no formatting issues
- [ ] CI passes on all platforms