### PR TITLE
docs(pina): add comprehensive doc comments to public API

### DIFF
--- a/.changeset/api_docs_completeness.md
+++ b/.changeset/api_docs_completeness.md
@@ -1,0 +1,5 @@
+---
+default: docs
+---
+
+Add comprehensive doc comments with examples to public API items in the `pina` crate.

--- a/crates/pina/src/cpi.rs
+++ b/crates/pina/src/cpi.rs
@@ -36,6 +36,15 @@ use crate::ProgramResult;
 ///
 /// Returns errors from rent sysvar access, rent minimum-balance computation,
 /// or the underlying system-program CPI.
+///
+/// # Examples
+///
+/// ```ignore
+/// use pina::cpi::create_account;
+///
+/// // Create a new account with 128 bytes of space owned by `program_id`:
+/// create_account(payer, new_account, 128, &program_id)?;
+/// ```
 #[inline(always)]
 pub fn create_account<'a>(
 	from: &'a AccountView,
@@ -72,6 +81,15 @@ pub fn create_account<'a>(
 ///
 /// Returns `InvalidSeeds` when no valid PDA can be derived, plus any errors
 /// from allocation/assignment steps.
+///
+/// # Examples
+///
+/// ```ignore
+/// // Create a PDA-backed escrow account:
+/// let seeds: &[&[u8]] = &[b"escrow", authority.address().as_ref()];
+/// let (address, bump) =
+/// 	create_program_account::<EscrowState>(escrow_account, payer, &program_id, seeds)?;
+/// ```
 #[inline(always)]
 pub fn create_program_account<'a, T: HasDiscriminator + Pod>(
 	target_account: &'a AccountView,
@@ -105,6 +123,16 @@ pub fn create_program_account<'a, T: HasDiscriminator + Pod>(
 ///
 /// Returns any error produced by [`allocate_account_with_bump`], including
 /// invalid seed layouts and system-program CPI failures.
+///
+/// # Examples
+///
+/// ```ignore
+/// // Create a PDA-backed account when you already know the bump:
+/// let seeds: &[&[u8]] = &[b"escrow", authority.address().as_ref()];
+/// create_program_account_with_bump::<EscrowState>(
+/// 	escrow_account, payer, &program_id, seeds, bump,
+/// )?;
+/// ```
 #[inline(always)]
 pub fn create_program_account_with_bump<'a, T: HasDiscriminator + Pod>(
 	target_account: &'a AccountView,
@@ -137,6 +165,15 @@ pub fn create_program_account_with_bump<'a, T: HasDiscriminator + Pod>(
 ///
 /// Returns `InvalidSeeds` when no canonical PDA can be derived, plus any
 /// allocation errors surfaced by [`allocate_account_with_bump`].
+///
+/// # Examples
+///
+/// ```ignore
+/// // Allocate raw space for manual initialization:
+/// let seeds: &[&[u8]] = &[b"vault"];
+/// let (address, bump) =
+/// 	allocate_account(vault_account, payer, 64, &program_id, seeds)?;
+/// ```
 #[inline(always)]
 pub fn allocate_account<'a>(
 	target_account: &'a AccountView,
@@ -168,6 +205,15 @@ pub fn allocate_account<'a>(
 /// When a bump is required, prefer canonical bump derivation.
 ///
 /// Use explicit bumps when needed.<!-- {/pinaPdaSeedContract} -->
+///
+/// # Examples
+///
+/// ```ignore
+/// let seeds: &[&[u8]] = &[b"escrow", authority.address().as_ref()];
+/// let bump_bytes = [bump];
+/// let combined = combine_seeds_with_bump(seeds, &bump_bytes)?;
+/// let signer = Signer::from(&combined[..=seeds.len()]);
+/// ```
 pub fn combine_seeds_with_bump<'a>(
 	seeds: &[&'a [u8]],
 	bump: &'a [u8; 1],
@@ -196,8 +242,8 @@ pub fn combine_seeds_with_bump<'a>(
 /// Two paths are taken depending on whether the target account already has
 /// lamports:
 ///
-/// - **Zero balance** — a single `CreateAccount` CPI is issued.
-/// - **Non-zero balance** — a `Transfer` (to top up rent), `Allocate`, and
+/// - **Zero balance** -- a single `CreateAccount` CPI is issued.
+/// - **Non-zero balance** -- a `Transfer` (to top up rent), `Allocate`, and
 ///   `Assign` are issued separately. This covers the case where the account was
 ///   pre-funded (e.g. by a previous failed transaction).
 ///
@@ -214,6 +260,13 @@ pub fn combine_seeds_with_bump<'a>(
 /// Returns seed-validation errors, rent sysvar access errors, and any
 /// system-program CPI failure from `CreateAccount`, `Transfer`, `Allocate`, or
 /// `Assign`.
+///
+/// # Examples
+///
+/// ```ignore
+/// let seeds: &[&[u8]] = &[b"vault"];
+/// allocate_account_with_bump(vault_account, payer, 64, &program_id, seeds, bump)?;
+/// ```
 #[inline(always)]
 pub fn allocate_account_with_bump<'a>(
 	target_account: &'a AccountView,
@@ -293,6 +346,13 @@ pub fn allocate_account_with_bump<'a>(
 ///
 /// Returns errors from lamport transfer, data resize, or account close
 /// operations.
+///
+/// # Examples
+///
+/// ```ignore
+/// // Close the escrow account and return rent to the authority:
+/// close_account(escrow_account, authority)?;
+/// ```
 #[inline(always)]
 pub fn close_account(account_info: &AccountView, recipient: &AccountView) -> ProgramResult {
 	// Return rent lamports.

--- a/crates/pina/src/lib.rs
+++ b/crates/pina/src/lib.rs
@@ -37,50 +37,98 @@ mod pod;
 mod traits;
 mod utils;
 
+/// Re-export of the [`bytemuck`] crate for zero-copy serialization.
 pub use bytemuck;
+/// Marker trait for types that can be safely cast from any byte pattern.
 pub use bytemuck::Pod;
+/// Marker trait for types that can be safely zeroed.
 pub use bytemuck::Zeroable;
+/// Re-export all proc macros from `pina_macros` when the `derive` feature is
+/// enabled.
 #[cfg(feature = "derive")]
 pub use pina_macros::*;
+/// Macro for implementing bidirectional conversion between Pod wrappers and
+/// standard integers.
 pub use pina_pod_primitives::impl_int_conversion;
+/// Re-export of the [`pinocchio`] crate for low-level Solana program
+/// primitives.
 pub use pinocchio;
+/// A Solana account as seen by the runtime during instruction execution.
 pub use pinocchio::AccountView;
+/// A 32-byte Solana public key / address.
 pub use pinocchio::Address;
+/// The result type returned by Solana program entrypoints and instruction
+/// handlers.
 pub use pinocchio::ProgramResult;
+/// Number of bytes in a Solana address (32).
 pub use pinocchio::address::ADDRESS_BYTES;
+/// Maximum length in bytes of a single PDA seed.
 pub use pinocchio::address::MAX_SEED_LEN;
+/// Maximum number of seeds allowed when deriving a PDA.
 pub use pinocchio::address::MAX_SEEDS;
+/// A single seed byte slice used in PDA signing.
 pub use pinocchio::cpi::Seed;
+/// A set of seeds that identifies a PDA signer for CPI calls.
 pub use pinocchio::cpi::Signer;
+/// The Solana program entrypoint attribute.
 pub use pinocchio::entrypoint;
+/// Error type returned by Solana programs.
 pub use pinocchio::error::ProgramError;
+/// An account reference passed as part of an instruction.
 pub use pinocchio::instruction::InstructionAccount;
+/// A view of a cross-program invocation instruction.
 pub use pinocchio::instruction::InstructionView;
+/// Macro for declaring a Solana program entrypoint.
 pub use pinocchio::program_entrypoint;
+/// Solana sysvar access utilities.
 pub use pinocchio::sysvars;
+/// Re-export of `pinocchio_associated_token_account` for ATA operations.
 #[cfg(feature = "token")]
 pub use pinocchio_associated_token_account as associated_token_account;
+/// Re-export of `pinocchio_system` for system program CPI helpers.
 pub use pinocchio_system as system;
+/// Re-export of `pinocchio_token` for SPL Token program CPI helpers.
 #[cfg(feature = "token")]
 pub use pinocchio_token as token;
+/// Re-export of `pinocchio_token_2022` for Token-2022 program CPI helpers.
 #[cfg(feature = "token")]
 pub use pinocchio_token_2022 as token_2022;
+/// Alignment-safe Pod primitive wrappers (`PodBool`, `PodU16`, `PodU64`,
+/// etc.).
 pub use pod::*;
+/// Macro for creating a compile-time [`Address`] from a base-58 string
+/// literal.
 pub use solana_address::address;
+/// Macro for declaring a program ID constant with associated `ID` and `id()`
+/// items.
 pub use solana_address::declare_id;
+/// Re-export of `solana_program_log` for on-chain logging utilities.
 #[cfg(feature = "logs")]
 pub use solana_program_log;
+/// A logger instance for formatting on-chain log messages.
 #[cfg(feature = "logs")]
 pub use solana_program_log::Logger;
+/// Logs the current compute unit usage to the Solana runtime.
 #[cfg(feature = "logs")]
 pub use solana_program_log::log_cu_usage;
+/// Re-export of the [`typed_builder`] crate for compile-time checked builder
+/// patterns.
 pub use typed_builder;
+/// Derive macro that generates a type-safe builder with compile-time field
+/// checking.
 pub use typed_builder::TypedBuilder;
 
+/// CPI helpers for account creation, PDA allocation, and account closure.
 pub use crate::cpi::*;
+/// Built-in framework error types.
 pub use crate::error::*;
+/// PDA (Program Derived Address) derivation and verification functions.
 pub use crate::pda::*;
+/// Core traits for account validation, deserialization, and instruction
+/// processing.
 pub use crate::traits::*;
+/// Utility functions for instruction parsing, assertions, and token address
+/// derivation.
 pub use crate::utils::*;
 
 /// Sets up a `no_std` Solana program entrypoint.

--- a/crates/pina/src/pda.rs
+++ b/crates/pina/src/pda.rs
@@ -15,6 +15,20 @@ use crate::ProgramError;
 ///
 /// This is the preferred PDA derivation API in `pina` because it is explicit
 /// about failure and avoids panics in on-chain code paths.
+///
+/// # Examples
+///
+/// ```
+/// use pina::try_find_program_address;
+///
+/// let program_id = pina::address!("11111111111111111111111111111111");
+/// let seeds: &[&[u8]] = &[b"vault"];
+///
+/// if let Some((pda, bump)) = try_find_program_address(seeds, &program_id) {
+/// 	// `pda` is the derived address, `bump` is the canonical bump seed.
+/// 	assert!(bump <= 255);
+/// }
+/// ```
 #[inline]
 pub fn try_find_program_address(seeds: &[&[u8]], program_id: &Address) -> Option<(Address, u8)> {
 	Address::try_find_program_address(seeds, program_id)
@@ -50,6 +64,26 @@ pub fn find_program_address(seeds: &[&[u8]], program_id: &Address) -> (Address, 
 /// When a bump is required, prefer canonical bump derivation.
 ///
 /// Use explicit bumps when needed.<!-- {/pinaPdaSeedContract} -->
+///
+/// # Examples
+///
+/// ```
+/// use pina::create_program_address;
+/// use pina::try_find_program_address;
+///
+/// let program_id = pina::address!("11111111111111111111111111111111");
+/// let seeds: &[&[u8]] = &[b"vault"];
+///
+/// // First derive the canonical PDA and bump:
+/// let (pda, bump) =
+/// 	try_find_program_address(seeds, &program_id).unwrap_or_else(|| panic!("no valid PDA"));
+///
+/// // Then recreate the address using the known bump:
+/// let bump_seed = [bump];
+/// let recreated = create_program_address(&[b"vault", &bump_seed], &program_id)
+/// 	.unwrap_or_else(|e| panic!("failed to recreate: {e:?}"));
+/// assert_eq!(pda, recreated);
+/// ```
 #[inline]
 pub fn create_program_address(
 	seeds: &[&[u8]],

--- a/crates/pina/src/pod/primitives.rs
+++ b/crates/pina/src/pod/primitives.rs
@@ -3,6 +3,20 @@ use pinocchio::error::ProgramError;
 
 /// Reinterprets a byte slice as `&T` (zero-copy). Returns an error if the
 /// slice has incorrect length or alignment.
+///
+/// # Examples
+///
+/// ```
+/// use pina::PodU64;
+/// use pina::pod_from_bytes;
+///
+/// let bytes = [42u8, 0, 0, 0, 0, 0, 0, 0];
+/// let value = pod_from_bytes::<PodU64>(&bytes).unwrap_or_else(|e| panic!("failed: {e:?}"));
+/// assert_eq!(u64::from(*value), 42);
+///
+/// // Empty or wrong-sized slices produce an error:
+/// assert!(pod_from_bytes::<PodU64>(&[]).is_err());
+/// ```
 pub fn pod_from_bytes<T: Pod>(bytes: &[u8]) -> Result<&T, ProgramError> {
 	bytemuck::try_from_bytes(bytes).map_err(|_| ProgramError::InvalidArgument)
 }


### PR DESCRIPTION
## Summary

- Add doc comments with `# Examples` sections to all major public traits (`AccountDeserialize`, `AccountValidation`, `AccountInfoValidation`, `IntoDiscriminator`, `HasDiscriminator`, `AsAccount`, `LamportTransfer`, `CloseAccountWithRecipient`, `TryFromAccountInfos`, `ProcessAccountInfos`)
- Add doc comments with examples to all public functions (`parse_instruction`, `assert`, `try_find_program_address`, `create_program_address`, `create_account`, `create_program_account`, `create_program_account_with_bump`, `allocate_account`, `allocate_account_with_bump`, `combine_seeds_with_bump`, `close_account`, `pod_from_bytes`, `try_get_associated_token_address`)
- Add doc comments to all re-exports in `lib.rs` explaining what each item is
- Add example to the `MAX_DISCRIMINATOR_SPACE` constant
- Fix doc comment placement on `log_caller` (moved above attributes where rustdoc expects them)
- All runnable examples use `unwrap_or_else` with explicit panic messages (no `expect`)
- All examples are `no_std` compatible using `pinocchio` types
- No logic or behavior changes

## Test plan

- [x] `cargo test -p pina` passes (all unit tests + doc tests)
- [x] `cargo test -p pina --doc` shows 10 passed, 0 failed, 17 ignored
- [x] `dprint check` passes on all modified files
- [ ] CI passes