### PR TITLE
test(pina_macros): expand snapshot test coverage

### DIFF
--- a/.changeset/expand_snapshot_tests.md
+++ b/.changeset/expand_snapshot_tests.md
@@ -1,0 +1,5 @@
+---
+pina_macros: patch
+---
+
+Expand snapshot test coverage for proc macros including edge cases for `#[account]`, `#[instruction]`, `#[event]`, `#[error]`, `#[discriminator]`, and `#[derive(Accounts)]`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2077,7 +2077,9 @@ version = "0.5.0"
 dependencies = [
  "darling",
  "heck",
+ "insta",
  "pina",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/crates/pina_macros/Cargo.toml
+++ b/crates/pina_macros/Cargo.toml
@@ -20,7 +20,9 @@ quote = { workspace = true, default-features = true }
 syn = { workspace = true, default-features = true, features = ["full"] }
 
 [dev-dependencies]
+insta = { workspace = true }
 pina = { workspace = true, default-features = true }
+prettyplease = "0.2"
 
 [lints]
 workspace = true

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__account_basic.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__account_basic.snap
@@ -1,0 +1,121 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+#[repr(C)]
+#[derive(
+    ::pina::TypedBuilder,
+    ::pina::Pod,
+    ::pina::Zeroable,
+    ::core::clone::Clone,
+    ::core::marker::Copy,
+    ::core::cmp::PartialEq,
+    ::core::cmp::Eq
+)]
+#[builder(builder_method(vis = "", name = __builder))]
+#[bytemuck(crate = "::pina::bytemuck")]
+pub struct ConfigState {
+    discriminator: [u8; MyAccount::BYTES],
+    pub version: u8,
+    pub bump: u8,
+}
+#[allow(dead_code)]
+type ConfigStateBuilderType = ConfigStateBuilder<(([u8; MyAccount::BYTES],), (), ())>;
+const __CONFIGSTATE_ALIGNMENT_ASSERTIONS__: () = {
+    ::core::assert!(
+        ::core::mem::align_of:: < [u8; MyAccount::BYTES] > () == 1,
+        concat!("The alignment of field `", "discriminator", "` with type `",
+        stringify!([u8; MyAccount::BYTES]),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < u8 > () == 1, concat!("The alignment of field `",
+        "version", "` with type `", stringify!(u8),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < u8 > () == 1, concat!("The alignment of field `",
+        "bump", "` with type `", stringify!(u8),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+};
+impl ConfigState {
+    /// Zero out all bytes in the struct including padding bytes. This can be useful when closing an account.
+    pub fn zeroed(&mut self) {
+        ::pina::bytemuck::write_zeroes(self);
+    }
+    pub fn to_bytes(&self) -> &[u8] {
+        ::pina::bytemuck::bytes_of(self)
+    }
+    pub fn builder() -> ConfigStateBuilderType {
+        let mut bytes = [0u8; MyAccount::BYTES];
+        <Self as ::pina::HasDiscriminator>::VALUE.write_discriminator(&mut bytes);
+        Self::__builder().discriminator(bytes)
+    }
+}
+impl ::pina::HasDiscriminator for ConfigState {
+    type Type = MyAccount;
+    const VALUE: Self::Type = MyAccount::ConfigState;
+}
+impl ::pina::AccountValidation for ConfigState {
+    #[track_caller]
+    fn assert<F>(&self, condition: F) -> Result<&Self, ::pina::ProgramError>
+    where
+        F: Fn(&Self) -> bool,
+    {
+        if condition(self) {
+            return Ok(self);
+        }
+        ::pina::log!("Account is invalid");
+        ::pina::log_caller();
+        Err(::pina::ProgramError::InvalidAccountData)
+    }
+    #[track_caller]
+    fn assert_msg<F>(
+        &self,
+        condition: F,
+        msg: &str,
+    ) -> Result<&Self, ::pina::ProgramError>
+    where
+        F: Fn(&Self) -> bool,
+    {
+        match ::pina::assert(
+            condition(self),
+            ::pina::ProgramError::InvalidAccountData,
+            msg,
+        ) {
+            Err(err) => Err(err),
+            Ok(()) => Ok(self),
+        }
+    }
+    #[track_caller]
+    fn assert_mut<F>(&mut self, condition: F) -> Result<&mut Self, ::pina::ProgramError>
+    where
+        F: Fn(&Self) -> bool,
+    {
+        if condition(self) {
+            return Ok(self);
+        }
+        ::pina::log!("Account is invalid");
+        ::pina::log_caller();
+        Err(::pina::ProgramError::InvalidAccountData)
+    }
+    #[track_caller]
+    fn assert_mut_msg<F>(
+        &mut self,
+        condition: F,
+        msg: &str,
+    ) -> Result<&mut Self, ::pina::ProgramError>
+    where
+        F: Fn(&Self) -> bool,
+    {
+        match ::pina::assert(
+            condition(self),
+            ::pina::ProgramError::InvalidAccountData,
+            msg,
+        ) {
+            Err(err) => Err(err),
+            Ok(()) => Ok(self),
+        }
+    }
+}

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__account_many_fields.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__account_many_fields.snap
@@ -1,0 +1,159 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+#[repr(C)]
+#[derive(
+    ::pina::TypedBuilder,
+    ::pina::Pod,
+    ::pina::Zeroable,
+    ::core::clone::Clone,
+    ::core::marker::Copy,
+    ::core::cmp::PartialEq,
+    ::core::cmp::Eq
+)]
+#[builder(builder_method(vis = "", name = __builder))]
+#[bytemuck(crate = "::pina::bytemuck")]
+pub struct LargeState {
+    discriminator: [u8; MyAccount::BYTES],
+    pub authority: [u8; 32],
+    pub bump: u8,
+    pub treasury_bump: u8,
+    pub mint_bump: u8,
+    pub version: u8,
+    pub padding: [u8; 3],
+    pub total_supply: PodU64,
+    pub name: [u8; 32],
+}
+#[allow(dead_code)]
+type LargeStateBuilderType = LargeStateBuilder<
+    (([u8; MyAccount::BYTES],), (), (), (), (), (), (), (), ()),
+>;
+const __LARGESTATE_ALIGNMENT_ASSERTIONS__: () = {
+    ::core::assert!(
+        ::core::mem::align_of:: < [u8; MyAccount::BYTES] > () == 1,
+        concat!("The alignment of field `", "discriminator", "` with type `",
+        stringify!([u8; MyAccount::BYTES]),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < [u8; 32] > () == 1, concat!("The alignment of field `",
+        "authority", "` with type `", stringify!([u8; 32]),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < u8 > () == 1, concat!("The alignment of field `",
+        "bump", "` with type `", stringify!(u8),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < u8 > () == 1, concat!("The alignment of field `",
+        "treasury_bump", "` with type `", stringify!(u8),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < u8 > () == 1, concat!("The alignment of field `",
+        "mint_bump", "` with type `", stringify!(u8),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < u8 > () == 1, concat!("The alignment of field `",
+        "version", "` with type `", stringify!(u8),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < [u8; 3] > () == 1, concat!("The alignment of field `",
+        "padding", "` with type `", stringify!([u8; 3]),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < PodU64 > () == 1, concat!("The alignment of field `",
+        "total_supply", "` with type `", stringify!(PodU64),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < [u8; 32] > () == 1, concat!("The alignment of field `",
+        "name", "` with type `", stringify!([u8; 32]),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+};
+impl LargeState {
+    /// Zero out all bytes in the struct including padding bytes. This can be useful when closing an account.
+    pub fn zeroed(&mut self) {
+        ::pina::bytemuck::write_zeroes(self);
+    }
+    pub fn to_bytes(&self) -> &[u8] {
+        ::pina::bytemuck::bytes_of(self)
+    }
+    pub fn builder() -> LargeStateBuilderType {
+        let mut bytes = [0u8; MyAccount::BYTES];
+        <Self as ::pina::HasDiscriminator>::VALUE.write_discriminator(&mut bytes);
+        Self::__builder().discriminator(bytes)
+    }
+}
+impl ::pina::HasDiscriminator for LargeState {
+    type Type = MyAccount;
+    const VALUE: Self::Type = MyAccount::LargeState;
+}
+impl ::pina::AccountValidation for LargeState {
+    #[track_caller]
+    fn assert<F>(&self, condition: F) -> Result<&Self, ::pina::ProgramError>
+    where
+        F: Fn(&Self) -> bool,
+    {
+        if condition(self) {
+            return Ok(self);
+        }
+        ::pina::log!("Account is invalid");
+        ::pina::log_caller();
+        Err(::pina::ProgramError::InvalidAccountData)
+    }
+    #[track_caller]
+    fn assert_msg<F>(
+        &self,
+        condition: F,
+        msg: &str,
+    ) -> Result<&Self, ::pina::ProgramError>
+    where
+        F: Fn(&Self) -> bool,
+    {
+        match ::pina::assert(
+            condition(self),
+            ::pina::ProgramError::InvalidAccountData,
+            msg,
+        ) {
+            Err(err) => Err(err),
+            Ok(()) => Ok(self),
+        }
+    }
+    #[track_caller]
+    fn assert_mut<F>(&mut self, condition: F) -> Result<&mut Self, ::pina::ProgramError>
+    where
+        F: Fn(&Self) -> bool,
+    {
+        if condition(self) {
+            return Ok(self);
+        }
+        ::pina::log!("Account is invalid");
+        ::pina::log_caller();
+        Err(::pina::ProgramError::InvalidAccountData)
+    }
+    #[track_caller]
+    fn assert_mut_msg<F>(
+        &mut self,
+        condition: F,
+        msg: &str,
+    ) -> Result<&mut Self, ::pina::ProgramError>
+    where
+        F: Fn(&Self) -> bool,
+    {
+        match ::pina::assert(
+            condition(self),
+            ::pina::ProgramError::InvalidAccountData,
+            msg,
+        ) {
+            Err(err) => Err(err),
+            Ok(()) => Ok(self),
+        }
+    }
+}

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__account_with_array_fields.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__account_with_array_fields.snap
@@ -1,0 +1,129 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+#[repr(C)]
+#[derive(
+    ::pina::TypedBuilder,
+    ::pina::Pod,
+    ::pina::Zeroable,
+    ::core::clone::Clone,
+    ::core::marker::Copy,
+    ::core::cmp::PartialEq,
+    ::core::cmp::Eq
+)]
+#[builder(builder_method(vis = "", name = __builder))]
+#[bytemuck(crate = "::pina::bytemuck")]
+pub struct DataAccount {
+    discriminator: [u8; AccountDiscriminator::BYTES],
+    pub authority: [u8; 32],
+    pub data: [u8; 64],
+    pub flags: [u8; 4],
+}
+#[allow(dead_code)]
+type DataAccountBuilderType = DataAccountBuilder<
+    (([u8; AccountDiscriminator::BYTES],), (), (), ()),
+>;
+const __DATAACCOUNT_ALIGNMENT_ASSERTIONS__: () = {
+    ::core::assert!(
+        ::core::mem::align_of:: < [u8; AccountDiscriminator::BYTES] > () == 1,
+        concat!("The alignment of field `", "discriminator", "` with type `",
+        stringify!([u8; AccountDiscriminator::BYTES]),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < [u8; 32] > () == 1, concat!("The alignment of field `",
+        "authority", "` with type `", stringify!([u8; 32]),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < [u8; 64] > () == 1, concat!("The alignment of field `",
+        "data", "` with type `", stringify!([u8; 64]),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < [u8; 4] > () == 1, concat!("The alignment of field `",
+        "flags", "` with type `", stringify!([u8; 4]),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+};
+impl DataAccount {
+    /// Zero out all bytes in the struct including padding bytes. This can be useful when closing an account.
+    pub fn zeroed(&mut self) {
+        ::pina::bytemuck::write_zeroes(self);
+    }
+    pub fn to_bytes(&self) -> &[u8] {
+        ::pina::bytemuck::bytes_of(self)
+    }
+    pub fn builder() -> DataAccountBuilderType {
+        let mut bytes = [0u8; AccountDiscriminator::BYTES];
+        <Self as ::pina::HasDiscriminator>::VALUE.write_discriminator(&mut bytes);
+        Self::__builder().discriminator(bytes)
+    }
+}
+impl ::pina::HasDiscriminator for DataAccount {
+    type Type = AccountDiscriminator;
+    const VALUE: Self::Type = AccountDiscriminator::DataAccount;
+}
+impl ::pina::AccountValidation for DataAccount {
+    #[track_caller]
+    fn assert<F>(&self, condition: F) -> Result<&Self, ::pina::ProgramError>
+    where
+        F: Fn(&Self) -> bool,
+    {
+        if condition(self) {
+            return Ok(self);
+        }
+        ::pina::log!("Account is invalid");
+        ::pina::log_caller();
+        Err(::pina::ProgramError::InvalidAccountData)
+    }
+    #[track_caller]
+    fn assert_msg<F>(
+        &self,
+        condition: F,
+        msg: &str,
+    ) -> Result<&Self, ::pina::ProgramError>
+    where
+        F: Fn(&Self) -> bool,
+    {
+        match ::pina::assert(
+            condition(self),
+            ::pina::ProgramError::InvalidAccountData,
+            msg,
+        ) {
+            Err(err) => Err(err),
+            Ok(()) => Ok(self),
+        }
+    }
+    #[track_caller]
+    fn assert_mut<F>(&mut self, condition: F) -> Result<&mut Self, ::pina::ProgramError>
+    where
+        F: Fn(&Self) -> bool,
+    {
+        if condition(self) {
+            return Ok(self);
+        }
+        ::pina::log!("Account is invalid");
+        ::pina::log_caller();
+        Err(::pina::ProgramError::InvalidAccountData)
+    }
+    #[track_caller]
+    fn assert_mut_msg<F>(
+        &mut self,
+        condition: F,
+        msg: &str,
+    ) -> Result<&mut Self, ::pina::ProgramError>
+    where
+        F: Fn(&Self) -> bool,
+    {
+        match ::pina::assert(
+            condition(self),
+            ::pina::ProgramError::InvalidAccountData,
+            msg,
+        ) {
+            Err(err) => Err(err),
+            Ok(()) => Ok(self),
+        }
+    }
+}

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__account_with_custom_variant.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__account_with_custom_variant.snap
@@ -1,0 +1,115 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+#[repr(C)]
+#[derive(
+    ::pina::TypedBuilder,
+    ::pina::Pod,
+    ::pina::Zeroable,
+    ::core::clone::Clone,
+    ::core::marker::Copy,
+    ::core::cmp::PartialEq,
+    ::core::cmp::Eq
+)]
+#[builder(builder_method(vis = "", name = __builder))]
+#[bytemuck(crate = "::pina::bytemuck")]
+pub struct MyStruct {
+    discriminator: [u8; AcctDisc::BYTES],
+    pub value: u8,
+}
+#[allow(dead_code)]
+type MyStructBuilderType = MyStructBuilder<(([u8; AcctDisc::BYTES],), ())>;
+const __MYSTRUCT_ALIGNMENT_ASSERTIONS__: () = {
+    ::core::assert!(
+        ::core::mem::align_of:: < [u8; AcctDisc::BYTES] > () == 1,
+        concat!("The alignment of field `", "discriminator", "` with type `",
+        stringify!([u8; AcctDisc::BYTES]),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < u8 > () == 1, concat!("The alignment of field `",
+        "value", "` with type `", stringify!(u8),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+};
+impl MyStruct {
+    /// Zero out all bytes in the struct including padding bytes. This can be useful when closing an account.
+    pub fn zeroed(&mut self) {
+        ::pina::bytemuck::write_zeroes(self);
+    }
+    pub fn to_bytes(&self) -> &[u8] {
+        ::pina::bytemuck::bytes_of(self)
+    }
+    pub fn builder() -> MyStructBuilderType {
+        let mut bytes = [0u8; AcctDisc::BYTES];
+        <Self as ::pina::HasDiscriminator>::VALUE.write_discriminator(&mut bytes);
+        Self::__builder().discriminator(bytes)
+    }
+}
+impl ::pina::HasDiscriminator for MyStruct {
+    type Type = AcctDisc;
+    const VALUE: Self::Type = AcctDisc::Custom;
+}
+impl ::pina::AccountValidation for MyStruct {
+    #[track_caller]
+    fn assert<F>(&self, condition: F) -> Result<&Self, ::pina::ProgramError>
+    where
+        F: Fn(&Self) -> bool,
+    {
+        if condition(self) {
+            return Ok(self);
+        }
+        ::pina::log!("Account is invalid");
+        ::pina::log_caller();
+        Err(::pina::ProgramError::InvalidAccountData)
+    }
+    #[track_caller]
+    fn assert_msg<F>(
+        &self,
+        condition: F,
+        msg: &str,
+    ) -> Result<&Self, ::pina::ProgramError>
+    where
+        F: Fn(&Self) -> bool,
+    {
+        match ::pina::assert(
+            condition(self),
+            ::pina::ProgramError::InvalidAccountData,
+            msg,
+        ) {
+            Err(err) => Err(err),
+            Ok(()) => Ok(self),
+        }
+    }
+    #[track_caller]
+    fn assert_mut<F>(&mut self, condition: F) -> Result<&mut Self, ::pina::ProgramError>
+    where
+        F: Fn(&Self) -> bool,
+    {
+        if condition(self) {
+            return Ok(self);
+        }
+        ::pina::log!("Account is invalid");
+        ::pina::log_caller();
+        Err(::pina::ProgramError::InvalidAccountData)
+    }
+    #[track_caller]
+    fn assert_mut_msg<F>(
+        &mut self,
+        condition: F,
+        msg: &str,
+    ) -> Result<&mut Self, ::pina::ProgramError>
+    where
+        F: Fn(&Self) -> bool,
+    {
+        match ::pina::assert(
+            condition(self),
+            ::pina::ProgramError::InvalidAccountData,
+            msg,
+        ) {
+            Err(err) => Err(err),
+            Ok(()) => Ok(self),
+        }
+    }
+}

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__account_with_existing_derives.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__account_with_existing_derives.snap
@@ -1,0 +1,122 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+#[derive(
+    Debug,
+    ::pina::TypedBuilder,
+    ::pina::Pod,
+    ::pina::Zeroable,
+    ::core::clone::Clone,
+    ::core::marker::Copy,
+    ::core::cmp::PartialEq,
+    ::core::cmp::Eq
+)]
+#[repr(C)]
+#[builder(builder_method(vis = "", name = __builder))]
+#[bytemuck(crate = "::pina::bytemuck")]
+pub struct GameState {
+    discriminator: [u8; MyAccount::BYTES],
+    pub score: u8,
+    pub level: u8,
+}
+#[allow(dead_code)]
+type GameStateBuilderType = GameStateBuilder<(([u8; MyAccount::BYTES],), (), ())>;
+const __GAMESTATE_ALIGNMENT_ASSERTIONS__: () = {
+    ::core::assert!(
+        ::core::mem::align_of:: < [u8; MyAccount::BYTES] > () == 1,
+        concat!("The alignment of field `", "discriminator", "` with type `",
+        stringify!([u8; MyAccount::BYTES]),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < u8 > () == 1, concat!("The alignment of field `",
+        "score", "` with type `", stringify!(u8),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < u8 > () == 1, concat!("The alignment of field `",
+        "level", "` with type `", stringify!(u8),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+};
+impl GameState {
+    /// Zero out all bytes in the struct including padding bytes. This can be useful when closing an account.
+    pub fn zeroed(&mut self) {
+        ::pina::bytemuck::write_zeroes(self);
+    }
+    pub fn to_bytes(&self) -> &[u8] {
+        ::pina::bytemuck::bytes_of(self)
+    }
+    pub fn builder() -> GameStateBuilderType {
+        let mut bytes = [0u8; MyAccount::BYTES];
+        <Self as ::pina::HasDiscriminator>::VALUE.write_discriminator(&mut bytes);
+        Self::__builder().discriminator(bytes)
+    }
+}
+impl ::pina::HasDiscriminator for GameState {
+    type Type = MyAccount;
+    const VALUE: Self::Type = MyAccount::GameState;
+}
+impl ::pina::AccountValidation for GameState {
+    #[track_caller]
+    fn assert<F>(&self, condition: F) -> Result<&Self, ::pina::ProgramError>
+    where
+        F: Fn(&Self) -> bool,
+    {
+        if condition(self) {
+            return Ok(self);
+        }
+        ::pina::log!("Account is invalid");
+        ::pina::log_caller();
+        Err(::pina::ProgramError::InvalidAccountData)
+    }
+    #[track_caller]
+    fn assert_msg<F>(
+        &self,
+        condition: F,
+        msg: &str,
+    ) -> Result<&Self, ::pina::ProgramError>
+    where
+        F: Fn(&Self) -> bool,
+    {
+        match ::pina::assert(
+            condition(self),
+            ::pina::ProgramError::InvalidAccountData,
+            msg,
+        ) {
+            Err(err) => Err(err),
+            Ok(()) => Ok(self),
+        }
+    }
+    #[track_caller]
+    fn assert_mut<F>(&mut self, condition: F) -> Result<&mut Self, ::pina::ProgramError>
+    where
+        F: Fn(&Self) -> bool,
+    {
+        if condition(self) {
+            return Ok(self);
+        }
+        ::pina::log!("Account is invalid");
+        ::pina::log_caller();
+        Err(::pina::ProgramError::InvalidAccountData)
+    }
+    #[track_caller]
+    fn assert_mut_msg<F>(
+        &mut self,
+        condition: F,
+        msg: &str,
+    ) -> Result<&mut Self, ::pina::ProgramError>
+    where
+        F: Fn(&Self) -> bool,
+    {
+        match ::pina::assert(
+            condition(self),
+            ::pina::ProgramError::InvalidAccountData,
+            msg,
+        ) {
+            Err(err) => Err(err),
+            Ok(()) => Ok(self),
+        }
+    }
+}

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__account_with_pod_types.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__account_with_pod_types.snap
@@ -1,0 +1,135 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+#[repr(C)]
+#[derive(
+    ::pina::TypedBuilder,
+    ::pina::Pod,
+    ::pina::Zeroable,
+    ::core::clone::Clone,
+    ::core::marker::Copy,
+    ::core::cmp::PartialEq,
+    ::core::cmp::Eq
+)]
+#[builder(builder_method(vis = "", name = __builder))]
+#[bytemuck(crate = "::pina::bytemuck")]
+pub struct BalanceAccount {
+    discriminator: [u8; MyDiscriminator::BYTES],
+    pub owner: [u8; 32],
+    pub amount: PodU64,
+    pub decimals: u8,
+    pub is_frozen: PodBool,
+}
+#[allow(dead_code)]
+type BalanceAccountBuilderType = BalanceAccountBuilder<
+    (([u8; MyDiscriminator::BYTES],), (), (), (), ()),
+>;
+const __BALANCEACCOUNT_ALIGNMENT_ASSERTIONS__: () = {
+    ::core::assert!(
+        ::core::mem::align_of:: < [u8; MyDiscriminator::BYTES] > () == 1,
+        concat!("The alignment of field `", "discriminator", "` with type `",
+        stringify!([u8; MyDiscriminator::BYTES]),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < [u8; 32] > () == 1, concat!("The alignment of field `",
+        "owner", "` with type `", stringify!([u8; 32]),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < PodU64 > () == 1, concat!("The alignment of field `",
+        "amount", "` with type `", stringify!(PodU64),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < u8 > () == 1, concat!("The alignment of field `",
+        "decimals", "` with type `", stringify!(u8),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < PodBool > () == 1, concat!("The alignment of field `",
+        "is_frozen", "` with type `", stringify!(PodBool),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+};
+impl BalanceAccount {
+    /// Zero out all bytes in the struct including padding bytes. This can be useful when closing an account.
+    pub fn zeroed(&mut self) {
+        ::pina::bytemuck::write_zeroes(self);
+    }
+    pub fn to_bytes(&self) -> &[u8] {
+        ::pina::bytemuck::bytes_of(self)
+    }
+    pub fn builder() -> BalanceAccountBuilderType {
+        let mut bytes = [0u8; MyDiscriminator::BYTES];
+        <Self as ::pina::HasDiscriminator>::VALUE.write_discriminator(&mut bytes);
+        Self::__builder().discriminator(bytes)
+    }
+}
+impl ::pina::HasDiscriminator for BalanceAccount {
+    type Type = MyDiscriminator;
+    const VALUE: Self::Type = MyDiscriminator::BalanceAccount;
+}
+impl ::pina::AccountValidation for BalanceAccount {
+    #[track_caller]
+    fn assert<F>(&self, condition: F) -> Result<&Self, ::pina::ProgramError>
+    where
+        F: Fn(&Self) -> bool,
+    {
+        if condition(self) {
+            return Ok(self);
+        }
+        ::pina::log!("Account is invalid");
+        ::pina::log_caller();
+        Err(::pina::ProgramError::InvalidAccountData)
+    }
+    #[track_caller]
+    fn assert_msg<F>(
+        &self,
+        condition: F,
+        msg: &str,
+    ) -> Result<&Self, ::pina::ProgramError>
+    where
+        F: Fn(&Self) -> bool,
+    {
+        match ::pina::assert(
+            condition(self),
+            ::pina::ProgramError::InvalidAccountData,
+            msg,
+        ) {
+            Err(err) => Err(err),
+            Ok(()) => Ok(self),
+        }
+    }
+    #[track_caller]
+    fn assert_mut<F>(&mut self, condition: F) -> Result<&mut Self, ::pina::ProgramError>
+    where
+        F: Fn(&Self) -> bool,
+    {
+        if condition(self) {
+            return Ok(self);
+        }
+        ::pina::log!("Account is invalid");
+        ::pina::log_caller();
+        Err(::pina::ProgramError::InvalidAccountData)
+    }
+    #[track_caller]
+    fn assert_mut_msg<F>(
+        &mut self,
+        condition: F,
+        msg: &str,
+    ) -> Result<&mut Self, ::pina::ProgramError>
+    where
+        F: Fn(&Self) -> bool,
+    {
+        match ::pina::assert(
+            condition(self),
+            ::pina::ProgramError::InvalidAccountData,
+            msg,
+        ) {
+            Err(err) => Err(err),
+            Ok(()) => Ok(self),
+        }
+    }
+}

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__accounts_derive_basic.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__accounts_derive_basic.snap
@@ -1,0 +1,33 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+impl<'a> ::pina::TryFromAccountInfos<'a> for InitAccounts<'a> {
+    fn try_from_account_infos(
+        accounts: &'a [::pina::AccountView],
+    ) -> ::core::result::Result<Self, ::pina::ProgramError> {
+        if accounts.len() > 3usize {
+            return ::core::result::Result::Err(
+                ::pina::PinaProgramError::TooManyAccountKeys.into(),
+            );
+        }
+        let [payer, config, system_program] = accounts else {
+            return ::core::result::Result::Err(
+                ::pina::ProgramError::NotEnoughAccountKeys,
+            );
+        };
+        Ok(Self {
+            payer,
+            config,
+            system_program,
+        })
+    }
+}
+impl<'a> ::core::convert::TryFrom<&'a [::pina::AccountView]> for InitAccounts<'a> {
+    type Error = ::pina::ProgramError;
+    fn try_from(
+        accounts: &'a [::pina::AccountView],
+    ) -> ::core::result::Result<Self, Self::Error> {
+        <Self as ::pina::TryFromAccountInfos>::try_from_account_infos(accounts)
+    }
+}

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__accounts_derive_default_crate.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__accounts_derive_default_crate.snap
@@ -1,0 +1,30 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+impl<'a> ::pina::TryFromAccountInfos<'a> for DefaultCrateAccounts<'a> {
+    fn try_from_account_infos(
+        accounts: &'a [::pina::AccountView],
+    ) -> ::core::result::Result<Self, ::pina::ProgramError> {
+        if accounts.len() > 2usize {
+            return ::core::result::Result::Err(
+                ::pina::PinaProgramError::TooManyAccountKeys.into(),
+            );
+        }
+        let [authority, data] = accounts else {
+            return ::core::result::Result::Err(
+                ::pina::ProgramError::NotEnoughAccountKeys,
+            );
+        };
+        Ok(Self { authority, data })
+    }
+}
+impl<'a> ::core::convert::TryFrom<&'a [::pina::AccountView]>
+for DefaultCrateAccounts<'a> {
+    type Error = ::pina::ProgramError;
+    fn try_from(
+        accounts: &'a [::pina::AccountView],
+    ) -> ::core::result::Result<Self, Self::Error> {
+        <Self as ::pina::TryFromAccountInfos>::try_from_account_infos(accounts)
+    }
+}

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__accounts_derive_many_fields.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__accounts_derive_many_fields.snap
@@ -1,0 +1,40 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+impl<'a> ::pina::TryFromAccountInfos<'a> for EscrowAccounts<'a> {
+    fn try_from_account_infos(
+        accounts: &'a [::pina::AccountView],
+    ) -> ::core::result::Result<Self, ::pina::ProgramError> {
+        if accounts.len() > 9usize {
+            return ::core::result::Result::Err(
+                ::pina::PinaProgramError::TooManyAccountKeys.into(),
+            );
+        }
+        let [maker, escrow, mint_a, mint_b, maker_ata_a, vault, token_program,
+        associated_token_program, system_program] = accounts else {
+            return ::core::result::Result::Err(
+                ::pina::ProgramError::NotEnoughAccountKeys,
+            );
+        };
+        Ok(Self {
+            maker,
+            escrow,
+            mint_a,
+            mint_b,
+            maker_ata_a,
+            vault,
+            token_program,
+            associated_token_program,
+            system_program,
+        })
+    }
+}
+impl<'a> ::core::convert::TryFrom<&'a [::pina::AccountView]> for EscrowAccounts<'a> {
+    type Error = ::pina::ProgramError;
+    fn try_from(
+        accounts: &'a [::pina::AccountView],
+    ) -> ::core::result::Result<Self, Self::Error> {
+        <Self as ::pina::TryFromAccountInfos>::try_from_account_infos(accounts)
+    }
+}

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__accounts_derive_single_field.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__accounts_derive_single_field.snap
@@ -1,0 +1,29 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+impl<'a> ::pina::TryFromAccountInfos<'a> for SingleAccount<'a> {
+    fn try_from_account_infos(
+        accounts: &'a [::pina::AccountView],
+    ) -> ::core::result::Result<Self, ::pina::ProgramError> {
+        if accounts.len() > 1usize {
+            return ::core::result::Result::Err(
+                ::pina::PinaProgramError::TooManyAccountKeys.into(),
+            );
+        }
+        let [account] = accounts else {
+            return ::core::result::Result::Err(
+                ::pina::ProgramError::NotEnoughAccountKeys,
+            );
+        };
+        Ok(Self { account })
+    }
+}
+impl<'a> ::core::convert::TryFrom<&'a [::pina::AccountView]> for SingleAccount<'a> {
+    type Error = ::pina::ProgramError;
+    fn try_from(
+        accounts: &'a [::pina::AccountView],
+    ) -> ::core::result::Result<Self, Self::Error> {
+        <Self as ::pina::TryFromAccountInfos>::try_from_account_infos(accounts)
+    }
+}

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__accounts_derive_with_remaining.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__accounts_derive_with_remaining.snap
@@ -1,0 +1,29 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+impl<'a> ::pina::TryFromAccountInfos<'a> for TransferAccounts<'a> {
+    fn try_from_account_infos(
+        accounts: &'a [::pina::AccountView],
+    ) -> ::core::result::Result<Self, ::pina::ProgramError> {
+        let [authority, source, destination, extra @ ..] = accounts else {
+            return ::core::result::Result::Err(
+                ::pina::ProgramError::NotEnoughAccountKeys,
+            );
+        };
+        Ok(Self {
+            authority,
+            source,
+            destination,
+            extra,
+        })
+    }
+}
+impl<'a> ::core::convert::TryFrom<&'a [::pina::AccountView]> for TransferAccounts<'a> {
+    type Error = ::pina::ProgramError;
+    fn try_from(
+        accounts: &'a [::pina::AccountView],
+    ) -> ::core::result::Result<Self, Self::Error> {
+        <Self as ::pina::TryFromAccountInfos>::try_from_account_infos(accounts)
+    }
+}

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__discriminator_final_attribute.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__discriminator_final_attribute.snap
@@ -1,0 +1,42 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+#[derive(
+    Debug,
+    ::core::clone::Clone,
+    ::core::marker::Copy,
+    ::core::cmp::PartialEq,
+    ::core::cmp::Eq
+)]
+#[repr(u8)]
+pub enum FinalDiscriminator {
+    Only = 0,
+}
+impl ::core::convert::From<FinalDiscriminator> for u8 {
+    #[inline]
+    fn from(enum_value: FinalDiscriminator) -> Self {
+        enum_value as Self
+    }
+}
+impl ::core::convert::TryFrom<u8> for FinalDiscriminator {
+    type Error = ::pina::ProgramError;
+    #[inline]
+    fn try_from(number: u8) -> ::core::result::Result<Self, ::pina::ProgramError> {
+        #![allow(non_upper_case_globals)]
+        const __ONLY: u8 = 0;
+        #[deny(unreachable_patterns)]
+        match number {
+            __ONLY => ::core::result::Result::Ok(Self::Only),
+            #[allow(unreachable_patterns)]
+            _ => {
+                ::core::result::Result::Err(
+                    ::pina::PinaProgramError::InvalidDiscriminator.into(),
+                )
+            }
+        }
+    }
+}
+unsafe impl ::pina::Zeroable for FinalDiscriminator {}
+unsafe impl ::pina::Pod for FinalDiscriminator {}
+::pina::into_discriminator!(FinalDiscriminator, u8);

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__discriminator_many_variants.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__discriminator_many_variants.snap
@@ -1,0 +1,64 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+#[derive(
+    Debug,
+    ::core::clone::Clone,
+    ::core::marker::Copy,
+    ::core::cmp::PartialEq,
+    ::core::cmp::Eq
+)]
+#[repr(u16)]
+#[non_exhaustive]
+pub enum ManyVariants {
+    Create = 0,
+    Read = 1,
+    Update = 2,
+    Delete = 3,
+    List = 4,
+    Search = 5,
+    Export = 6,
+    Import = 7,
+}
+impl ::core::convert::From<ManyVariants> for u16 {
+    #[inline]
+    fn from(enum_value: ManyVariants) -> Self {
+        enum_value as Self
+    }
+}
+impl ::core::convert::TryFrom<u16> for ManyVariants {
+    type Error = ::pina::ProgramError;
+    #[inline]
+    fn try_from(number: u16) -> ::core::result::Result<Self, ::pina::ProgramError> {
+        #![allow(non_upper_case_globals)]
+        const __CREATE: u16 = 0;
+        const __READ: u16 = 1;
+        const __UPDATE: u16 = 2;
+        const __DELETE: u16 = 3;
+        const __LIST: u16 = 4;
+        const __SEARCH: u16 = 5;
+        const __EXPORT: u16 = 6;
+        const __IMPORT: u16 = 7;
+        #[deny(unreachable_patterns)]
+        match number {
+            __CREATE => ::core::result::Result::Ok(Self::Create),
+            __READ => ::core::result::Result::Ok(Self::Read),
+            __UPDATE => ::core::result::Result::Ok(Self::Update),
+            __DELETE => ::core::result::Result::Ok(Self::Delete),
+            __LIST => ::core::result::Result::Ok(Self::List),
+            __SEARCH => ::core::result::Result::Ok(Self::Search),
+            __EXPORT => ::core::result::Result::Ok(Self::Export),
+            __IMPORT => ::core::result::Result::Ok(Self::Import),
+            #[allow(unreachable_patterns)]
+            _ => {
+                ::core::result::Result::Err(
+                    ::pina::PinaProgramError::InvalidDiscriminator.into(),
+                )
+            }
+        }
+    }
+}
+unsafe impl ::pina::Zeroable for ManyVariants {}
+unsafe impl ::pina::Pod for ManyVariants {}
+::pina::into_discriminator!(ManyVariants, u16);

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__discriminator_single_variant.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__discriminator_single_variant.snap
@@ -1,0 +1,42 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+#[repr(u8)]
+#[non_exhaustive]
+#[derive(
+    ::core::clone::Clone,
+    ::core::marker::Copy,
+    ::core::cmp::PartialEq,
+    ::core::cmp::Eq
+)]
+pub enum SingleVariant {
+    Singleton = 42,
+}
+impl ::core::convert::From<SingleVariant> for u8 {
+    #[inline]
+    fn from(enum_value: SingleVariant) -> Self {
+        enum_value as Self
+    }
+}
+impl ::core::convert::TryFrom<u8> for SingleVariant {
+    type Error = ::pina::ProgramError;
+    #[inline]
+    fn try_from(number: u8) -> ::core::result::Result<Self, ::pina::ProgramError> {
+        #![allow(non_upper_case_globals)]
+        const __SINGLETON: u8 = 42;
+        #[deny(unreachable_patterns)]
+        match number {
+            __SINGLETON => ::core::result::Result::Ok(Self::Singleton),
+            #[allow(unreachable_patterns)]
+            _ => {
+                ::core::result::Result::Err(
+                    ::pina::PinaProgramError::InvalidDiscriminator.into(),
+                )
+            }
+        }
+    }
+}
+unsafe impl ::pina::Zeroable for SingleVariant {}
+unsafe impl ::pina::Pod for SingleVariant {}
+::pina::into_discriminator!(SingleVariant, u8);

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__discriminator_u16_primitive.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__discriminator_u16_primitive.snap
@@ -1,0 +1,45 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+#[repr(u16)]
+#[non_exhaustive]
+#[derive(
+    ::core::clone::Clone,
+    ::core::marker::Copy,
+    ::core::cmp::PartialEq,
+    ::core::cmp::Eq
+)]
+pub enum WideDiscriminator {
+    Alpha = 100,
+    Beta = 200,
+}
+impl ::core::convert::From<WideDiscriminator> for u16 {
+    #[inline]
+    fn from(enum_value: WideDiscriminator) -> Self {
+        enum_value as Self
+    }
+}
+impl ::core::convert::TryFrom<u16> for WideDiscriminator {
+    type Error = ::pina::ProgramError;
+    #[inline]
+    fn try_from(number: u16) -> ::core::result::Result<Self, ::pina::ProgramError> {
+        #![allow(non_upper_case_globals)]
+        const __ALPHA: u16 = 100;
+        const __BETA: u16 = 200;
+        #[deny(unreachable_patterns)]
+        match number {
+            __ALPHA => ::core::result::Result::Ok(Self::Alpha),
+            __BETA => ::core::result::Result::Ok(Self::Beta),
+            #[allow(unreachable_patterns)]
+            _ => {
+                ::core::result::Result::Err(
+                    ::pina::PinaProgramError::InvalidDiscriminator.into(),
+                )
+            }
+        }
+    }
+}
+unsafe impl ::pina::Zeroable for WideDiscriminator {}
+unsafe impl ::pina::Pod for WideDiscriminator {}
+::pina::into_discriminator!(WideDiscriminator, u16);

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__discriminator_u32_primitive.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__discriminator_u32_primitive.snap
@@ -1,0 +1,48 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(
+    ::core::clone::Clone,
+    ::core::marker::Copy,
+    ::core::cmp::PartialEq,
+    ::core::cmp::Eq
+)]
+pub enum U32Discriminator {
+    A = 0,
+    B = 1000,
+    C = 2000,
+}
+impl ::core::convert::From<U32Discriminator> for u32 {
+    #[inline]
+    fn from(enum_value: U32Discriminator) -> Self {
+        enum_value as Self
+    }
+}
+impl ::core::convert::TryFrom<u32> for U32Discriminator {
+    type Error = ::pina::ProgramError;
+    #[inline]
+    fn try_from(number: u32) -> ::core::result::Result<Self, ::pina::ProgramError> {
+        #![allow(non_upper_case_globals)]
+        const __A: u32 = 0;
+        const __B: u32 = 1000;
+        const __C: u32 = 2000;
+        #[deny(unreachable_patterns)]
+        match number {
+            __A => ::core::result::Result::Ok(Self::A),
+            __B => ::core::result::Result::Ok(Self::B),
+            __C => ::core::result::Result::Ok(Self::C),
+            #[allow(unreachable_patterns)]
+            _ => {
+                ::core::result::Result::Err(
+                    ::pina::PinaProgramError::InvalidDiscriminator.into(),
+                )
+            }
+        }
+    }
+}
+unsafe impl ::pina::Zeroable for U32Discriminator {}
+unsafe impl ::pina::Pod for U32Discriminator {}
+::pina::into_discriminator!(U32Discriminator, u32);

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__discriminator_u64_primitive.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__discriminator_u64_primitive.snap
@@ -1,0 +1,45 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+#[repr(u64)]
+#[non_exhaustive]
+#[derive(
+    ::core::clone::Clone,
+    ::core::marker::Copy,
+    ::core::cmp::PartialEq,
+    ::core::cmp::Eq
+)]
+pub enum HugeDiscriminator {
+    Mint = 0,
+    Transfer = 1,
+}
+impl ::core::convert::From<HugeDiscriminator> for u64 {
+    #[inline]
+    fn from(enum_value: HugeDiscriminator) -> Self {
+        enum_value as Self
+    }
+}
+impl ::core::convert::TryFrom<u64> for HugeDiscriminator {
+    type Error = ::pina::ProgramError;
+    #[inline]
+    fn try_from(number: u64) -> ::core::result::Result<Self, ::pina::ProgramError> {
+        #![allow(non_upper_case_globals)]
+        const __MINT: u64 = 0;
+        const __TRANSFER: u64 = 1;
+        #[deny(unreachable_patterns)]
+        match number {
+            __MINT => ::core::result::Result::Ok(Self::Mint),
+            __TRANSFER => ::core::result::Result::Ok(Self::Transfer),
+            #[allow(unreachable_patterns)]
+            _ => {
+                ::core::result::Result::Err(
+                    ::pina::PinaProgramError::InvalidDiscriminator.into(),
+                )
+            }
+        }
+    }
+}
+unsafe impl ::pina::Zeroable for HugeDiscriminator {}
+unsafe impl ::pina::Pod for HugeDiscriminator {}
+::pina::into_discriminator!(HugeDiscriminator, u64);

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__discriminator_u8_default.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__discriminator_u8_default.snap
@@ -1,0 +1,49 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+#[derive(
+    Debug,
+    ::core::clone::Clone,
+    ::core::marker::Copy,
+    ::core::cmp::PartialEq,
+    ::core::cmp::Eq
+)]
+#[repr(u8)]
+#[non_exhaustive]
+pub enum MyDiscriminator {
+    First = 0,
+    Second = 1,
+    Third = 2,
+}
+impl ::core::convert::From<MyDiscriminator> for u8 {
+    #[inline]
+    fn from(enum_value: MyDiscriminator) -> Self {
+        enum_value as Self
+    }
+}
+impl ::core::convert::TryFrom<u8> for MyDiscriminator {
+    type Error = ::pina::ProgramError;
+    #[inline]
+    fn try_from(number: u8) -> ::core::result::Result<Self, ::pina::ProgramError> {
+        #![allow(non_upper_case_globals)]
+        const __FIRST: u8 = 0;
+        const __SECOND: u8 = 1;
+        const __THIRD: u8 = 2;
+        #[deny(unreachable_patterns)]
+        match number {
+            __FIRST => ::core::result::Result::Ok(Self::First),
+            __SECOND => ::core::result::Result::Ok(Self::Second),
+            __THIRD => ::core::result::Result::Ok(Self::Third),
+            #[allow(unreachable_patterns)]
+            _ => {
+                ::core::result::Result::Err(
+                    ::pina::PinaProgramError::InvalidDiscriminator.into(),
+                )
+            }
+        }
+    }
+}
+unsafe impl ::pina::Zeroable for MyDiscriminator {}
+unsafe impl ::pina::Pod for MyDiscriminator {}
+::pina::into_discriminator!(MyDiscriminator, u8);

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__error_basic.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__error_basic.snap
@@ -1,0 +1,16 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+#[non_exhaustive]
+pub enum MyError {
+    Invalid = 0,
+    Duplicate = 1,
+}
+impl ::core::convert::From<MyError> for ::pina::ProgramError {
+    fn from(e: MyError) -> Self {
+        ::pina::ProgramError::Custom(e as u32)
+    }
+}

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__error_default_crate_path.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__error_default_crate_path.snap
@@ -1,0 +1,14 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+#[repr(u32)]
+#[non_exhaustive]
+pub enum DefaultCrateError {
+    Something = 0,
+}
+impl ::core::convert::From<DefaultCrateError> for ::pina::ProgramError {
+    fn from(e: DefaultCrateError) -> Self {
+        ::pina::ProgramError::Custom(e as u32)
+    }
+}

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__error_final.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__error_final.snap
@@ -1,0 +1,14 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+#[derive(Debug)]
+#[repr(u32)]
+pub enum FinalError {
+    Unauthorized = 0,
+}
+impl ::core::convert::From<FinalError> for ::pina::ProgramError {
+    fn from(e: FinalError) -> Self {
+        ::pina::ProgramError::Custom(e as u32)
+    }
+}

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__error_many_variants.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__error_many_variants.snap
@@ -1,0 +1,24 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+#[derive(Debug)]
+#[repr(u32)]
+#[non_exhaustive]
+pub enum DetailedError {
+    /// Not enough funds to complete the transaction.
+    InsufficientFunds = 0,
+    /// The account has already been initialized.
+    AlreadyInitialized = 1,
+    /// The provided authority does not match.
+    InvalidAuthority = 2,
+    /// The mint does not match.
+    InvalidMint = 3,
+    /// Arithmetic overflow occurred.
+    Overflow = 4,
+}
+impl ::core::convert::From<DetailedError> for ::pina::ProgramError {
+    fn from(e: DetailedError) -> Self {
+        ::pina::ProgramError::Custom(e as u32)
+    }
+}

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__event_basic.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__event_basic.snap
@@ -1,0 +1,68 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+#[repr(C)]
+#[builder(builder_method(vis = "", name = __builder))]
+#[derive(
+    ::pina::TypedBuilder,
+    ::pina::Pod,
+    ::pina::Zeroable,
+    ::core::clone::Clone,
+    ::core::marker::Copy,
+    ::core::cmp::PartialEq,
+    ::core::cmp::Eq,
+    ::core::fmt::Debug
+)]
+#[bytemuck(crate = "::pina::bytemuck")]
+pub struct TransferEvent {
+    discriminator: [u8; EventDisc::BYTES],
+    pub from: [u8; 32],
+    pub to: [u8; 32],
+    pub amount: PodU64,
+}
+#[allow(dead_code)]
+type TransferEventBuilderType = TransferEventBuilder<
+    (([u8; EventDisc::BYTES],), (), (), ()),
+>;
+const __TRANSFEREVENT_ALIGNMENT_ASSERTIONS__: () = {
+    ::core::assert!(
+        ::core::mem::align_of:: < [u8; EventDisc::BYTES] > () == 1,
+        concat!("The alignment of field `", "discriminator", "` with type `",
+        stringify!([u8; EventDisc::BYTES]),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < [u8; 32] > () == 1, concat!("The alignment of field `",
+        "from", "` with type `", stringify!([u8; 32]),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < [u8; 32] > () == 1, concat!("The alignment of field `",
+        "to", "` with type `", stringify!([u8; 32]),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < PodU64 > () == 1, concat!("The alignment of field `",
+        "amount", "` with type `", stringify!(PodU64),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+};
+impl TransferEvent {
+    pub fn to_bytes(&self) -> &[u8] {
+        ::pina::bytemuck::bytes_of(self)
+    }
+    pub fn try_from_bytes(data: &[u8]) -> Result<&Self, ::pina::ProgramError> {
+        ::pina::bytemuck::try_from_bytes::<Self>(data)
+            .or(Err(::pina::ProgramError::InvalidInstructionData))
+    }
+    pub fn builder() -> TransferEventBuilderType {
+        let mut bytes = [0u8; EventDisc::BYTES];
+        <Self as ::pina::HasDiscriminator>::VALUE.write_discriminator(&mut bytes);
+        Self::__builder().discriminator(bytes)
+    }
+}
+impl ::pina::HasDiscriminator for TransferEvent {
+    type Type = EventDisc;
+    const VALUE: Self::Type = EventDisc::TransferEvent;
+}

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__event_minimal.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__event_minimal.snap
@@ -1,0 +1,48 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+#[repr(C)]
+#[builder(builder_method(vis = "", name = __builder))]
+#[derive(
+    ::pina::TypedBuilder,
+    ::pina::Pod,
+    ::pina::Zeroable,
+    ::core::clone::Clone,
+    ::core::marker::Copy,
+    ::core::cmp::PartialEq,
+    ::core::cmp::Eq,
+    ::core::fmt::Debug
+)]
+#[bytemuck(crate = "::pina::bytemuck")]
+pub struct EmptyEvent {
+    discriminator: [u8; EventDisc::BYTES],
+}
+#[allow(dead_code)]
+type EmptyEventBuilderType = EmptyEventBuilder<(([u8; EventDisc::BYTES],),)>;
+const __EMPTYEVENT_ALIGNMENT_ASSERTIONS__: () = {
+    ::core::assert!(
+        ::core::mem::align_of:: < [u8; EventDisc::BYTES] > () == 1,
+        concat!("The alignment of field `", "discriminator", "` with type `",
+        stringify!([u8; EventDisc::BYTES]),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+};
+impl EmptyEvent {
+    pub fn to_bytes(&self) -> &[u8] {
+        ::pina::bytemuck::bytes_of(self)
+    }
+    pub fn try_from_bytes(data: &[u8]) -> Result<&Self, ::pina::ProgramError> {
+        ::pina::bytemuck::try_from_bytes::<Self>(data)
+            .or(Err(::pina::ProgramError::InvalidInstructionData))
+    }
+    pub fn builder() -> EmptyEventBuilderType {
+        let mut bytes = [0u8; EventDisc::BYTES];
+        <Self as ::pina::HasDiscriminator>::VALUE.write_discriminator(&mut bytes);
+        Self::__builder().discriminator(bytes)
+    }
+}
+impl ::pina::HasDiscriminator for EmptyEvent {
+    type Type = EventDisc;
+    const VALUE: Self::Type = EventDisc::EmptyEvent;
+}

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__event_with_existing_derive.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__event_with_existing_derive.snap
@@ -1,0 +1,60 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+#[derive(
+    Debug,
+    ::pina::TypedBuilder,
+    ::pina::Pod,
+    ::pina::Zeroable,
+    ::core::clone::Clone,
+    ::core::marker::Copy,
+    ::core::cmp::PartialEq,
+    ::core::cmp::Eq
+)]
+#[repr(C)]
+#[builder(builder_method(vis = "", name = __builder))]
+#[bytemuck(crate = "::pina::bytemuck")]
+pub struct AuditEvent {
+    discriminator: [u8; EvtDisc::BYTES],
+    pub action: u8,
+    pub timestamp: PodU64,
+}
+#[allow(dead_code)]
+type AuditEventBuilderType = AuditEventBuilder<(([u8; EvtDisc::BYTES],), (), ())>;
+const __AUDITEVENT_ALIGNMENT_ASSERTIONS__: () = {
+    ::core::assert!(
+        ::core::mem::align_of:: < [u8; EvtDisc::BYTES] > () == 1,
+        concat!("The alignment of field `", "discriminator", "` with type `",
+        stringify!([u8; EvtDisc::BYTES]),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < u8 > () == 1, concat!("The alignment of field `",
+        "action", "` with type `", stringify!(u8),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < PodU64 > () == 1, concat!("The alignment of field `",
+        "timestamp", "` with type `", stringify!(PodU64),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+};
+impl AuditEvent {
+    pub fn to_bytes(&self) -> &[u8] {
+        ::pina::bytemuck::bytes_of(self)
+    }
+    pub fn try_from_bytes(data: &[u8]) -> Result<&Self, ::pina::ProgramError> {
+        ::pina::bytemuck::try_from_bytes::<Self>(data)
+            .or(Err(::pina::ProgramError::InvalidInstructionData))
+    }
+    pub fn builder() -> AuditEventBuilderType {
+        let mut bytes = [0u8; EvtDisc::BYTES];
+        <Self as ::pina::HasDiscriminator>::VALUE.write_discriminator(&mut bytes);
+        Self::__builder().discriminator(bytes)
+    }
+}
+impl ::pina::HasDiscriminator for AuditEvent {
+    type Type = EvtDisc;
+    const VALUE: Self::Type = EvtDisc::AuditEvent;
+}

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__event_with_variant.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__event_with_variant.snap
@@ -1,0 +1,56 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+#[repr(C)]
+#[builder(builder_method(vis = "", name = __builder))]
+#[derive(
+    ::pina::TypedBuilder,
+    ::pina::Pod,
+    ::pina::Zeroable,
+    ::core::clone::Clone,
+    ::core::marker::Copy,
+    ::core::cmp::PartialEq,
+    ::core::cmp::Eq,
+    ::core::fmt::Debug
+)]
+#[bytemuck(crate = "::pina::bytemuck")]
+pub struct InitializeEvent {
+    discriminator: [u8; EventKind::BYTES],
+    pub choice: u8,
+}
+#[allow(dead_code)]
+type InitializeEventBuilderType = InitializeEventBuilder<
+    (([u8; EventKind::BYTES],), ()),
+>;
+const __INITIALIZEEVENT_ALIGNMENT_ASSERTIONS__: () = {
+    ::core::assert!(
+        ::core::mem::align_of:: < [u8; EventKind::BYTES] > () == 1,
+        concat!("The alignment of field `", "discriminator", "` with type `",
+        stringify!([u8; EventKind::BYTES]),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < u8 > () == 1, concat!("The alignment of field `",
+        "choice", "` with type `", stringify!(u8),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+};
+impl InitializeEvent {
+    pub fn to_bytes(&self) -> &[u8] {
+        ::pina::bytemuck::bytes_of(self)
+    }
+    pub fn try_from_bytes(data: &[u8]) -> Result<&Self, ::pina::ProgramError> {
+        ::pina::bytemuck::try_from_bytes::<Self>(data)
+            .or(Err(::pina::ProgramError::InvalidInstructionData))
+    }
+    pub fn builder() -> InitializeEventBuilderType {
+        let mut bytes = [0u8; EventKind::BYTES];
+        <Self as ::pina::HasDiscriminator>::VALUE.write_discriminator(&mut bytes);
+        Self::__builder().discriminator(bytes)
+    }
+}
+impl ::pina::HasDiscriminator for InitializeEvent {
+    type Type = EventKind;
+    const VALUE: Self::Type = EventKind::Init;
+}

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__instruction_many_fields.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__instruction_many_fields.snap
@@ -1,0 +1,74 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+#[repr(C)]
+#[derive(
+    ::pina::TypedBuilder,
+    ::pina::Pod,
+    ::pina::Zeroable,
+    ::core::clone::Clone,
+    ::core::marker::Copy,
+    ::core::cmp::PartialEq,
+    ::core::cmp::Eq,
+    ::core::fmt::Debug
+)]
+#[builder(builder_method(vis = "", name = __builder))]
+#[bytemuck(crate = "::pina::bytemuck")]
+pub struct FlipBit {
+    discriminator: [u8; MyInstruction::BYTES],
+    pub section_index: u8,
+    pub array_index: u8,
+    pub offset: u8,
+    pub value: u8,
+}
+#[allow(dead_code)]
+type FlipBitBuilderType = FlipBitBuilder<
+    (([u8; MyInstruction::BYTES],), (), (), (), ()),
+>;
+const __FLIPBIT_ALIGNMENT_ASSERTIONS__: () = {
+    ::core::assert!(
+        ::core::mem::align_of:: < [u8; MyInstruction::BYTES] > () == 1,
+        concat!("The alignment of field `", "discriminator", "` with type `",
+        stringify!([u8; MyInstruction::BYTES]),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < u8 > () == 1, concat!("The alignment of field `",
+        "section_index", "` with type `", stringify!(u8),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < u8 > () == 1, concat!("The alignment of field `",
+        "array_index", "` with type `", stringify!(u8),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < u8 > () == 1, concat!("The alignment of field `",
+        "offset", "` with type `", stringify!(u8),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < u8 > () == 1, concat!("The alignment of field `",
+        "value", "` with type `", stringify!(u8),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+};
+impl FlipBit {
+    pub fn to_bytes(&self) -> &[u8] {
+        ::pina::bytemuck::bytes_of(self)
+    }
+    pub fn try_from_bytes(data: &[u8]) -> Result<&Self, ::pina::ProgramError> {
+        ::pina::bytemuck::try_from_bytes::<Self>(data)
+            .or(Err(::pina::ProgramError::InvalidInstructionData))
+    }
+    pub fn builder() -> FlipBitBuilderType {
+        let mut bytes = [0u8; MyInstruction::BYTES];
+        <Self as ::pina::HasDiscriminator>::VALUE.write_discriminator(&mut bytes);
+        Self::__builder().discriminator(bytes)
+    }
+}
+impl ::pina::HasDiscriminator for FlipBit {
+    type Type = MyInstruction;
+    const VALUE: Self::Type = MyInstruction::FlipBit;
+}

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__instruction_minimal.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__instruction_minimal.snap
@@ -1,0 +1,48 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+#[repr(C)]
+#[derive(
+    ::pina::TypedBuilder,
+    ::pina::Pod,
+    ::pina::Zeroable,
+    ::core::clone::Clone,
+    ::core::marker::Copy,
+    ::core::cmp::PartialEq,
+    ::core::cmp::Eq,
+    ::core::fmt::Debug
+)]
+#[builder(builder_method(vis = "", name = __builder))]
+#[bytemuck(crate = "::pina::bytemuck")]
+pub struct Initialize {
+    discriminator: [u8; MyInstruction::BYTES],
+}
+#[allow(dead_code)]
+type InitializeBuilderType = InitializeBuilder<(([u8; MyInstruction::BYTES],),)>;
+const __INITIALIZE_ALIGNMENT_ASSERTIONS__: () = {
+    ::core::assert!(
+        ::core::mem::align_of:: < [u8; MyInstruction::BYTES] > () == 1,
+        concat!("The alignment of field `", "discriminator", "` with type `",
+        stringify!([u8; MyInstruction::BYTES]),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+};
+impl Initialize {
+    pub fn to_bytes(&self) -> &[u8] {
+        ::pina::bytemuck::bytes_of(self)
+    }
+    pub fn try_from_bytes(data: &[u8]) -> Result<&Self, ::pina::ProgramError> {
+        ::pina::bytemuck::try_from_bytes::<Self>(data)
+            .or(Err(::pina::ProgramError::InvalidInstructionData))
+    }
+    pub fn builder() -> InitializeBuilderType {
+        let mut bytes = [0u8; MyInstruction::BYTES];
+        <Self as ::pina::HasDiscriminator>::VALUE.write_discriminator(&mut bytes);
+        Self::__builder().discriminator(bytes)
+    }
+}
+impl ::pina::HasDiscriminator for Initialize {
+    type Type = MyInstruction;
+    const VALUE: Self::Type = MyInstruction::Initialize;
+}

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__instruction_with_array_and_pod.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__instruction_with_array_and_pod.snap
@@ -1,0 +1,74 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+#[repr(C)]
+#[derive(
+    ::pina::TypedBuilder,
+    ::pina::Pod,
+    ::pina::Zeroable,
+    ::core::clone::Clone,
+    ::core::marker::Copy,
+    ::core::cmp::PartialEq,
+    ::core::cmp::Eq,
+    ::core::fmt::Debug
+)]
+#[builder(builder_method(vis = "", name = __builder))]
+#[bytemuck(crate = "::pina::bytemuck")]
+pub struct ComplexInstruction {
+    discriminator: [u8; MyInstruction::BYTES],
+    pub seed: [u8; 32],
+    pub amount: PodU64,
+    pub bump: u8,
+    pub flags: [u8; 4],
+}
+#[allow(dead_code)]
+type ComplexInstructionBuilderType = ComplexInstructionBuilder<
+    (([u8; MyInstruction::BYTES],), (), (), (), ()),
+>;
+const __COMPLEXINSTRUCTION_ALIGNMENT_ASSERTIONS__: () = {
+    ::core::assert!(
+        ::core::mem::align_of:: < [u8; MyInstruction::BYTES] > () == 1,
+        concat!("The alignment of field `", "discriminator", "` with type `",
+        stringify!([u8; MyInstruction::BYTES]),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < [u8; 32] > () == 1, concat!("The alignment of field `",
+        "seed", "` with type `", stringify!([u8; 32]),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < PodU64 > () == 1, concat!("The alignment of field `",
+        "amount", "` with type `", stringify!(PodU64),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < u8 > () == 1, concat!("The alignment of field `",
+        "bump", "` with type `", stringify!(u8),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < [u8; 4] > () == 1, concat!("The alignment of field `",
+        "flags", "` with type `", stringify!([u8; 4]),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+};
+impl ComplexInstruction {
+    pub fn to_bytes(&self) -> &[u8] {
+        ::pina::bytemuck::bytes_of(self)
+    }
+    pub fn try_from_bytes(data: &[u8]) -> Result<&Self, ::pina::ProgramError> {
+        ::pina::bytemuck::try_from_bytes::<Self>(data)
+            .or(Err(::pina::ProgramError::InvalidInstructionData))
+    }
+    pub fn builder() -> ComplexInstructionBuilderType {
+        let mut bytes = [0u8; MyInstruction::BYTES];
+        <Self as ::pina::HasDiscriminator>::VALUE.write_discriminator(&mut bytes);
+        Self::__builder().discriminator(bytes)
+    }
+}
+impl ::pina::HasDiscriminator for ComplexInstruction {
+    type Type = MyInstruction;
+    const VALUE: Self::Type = MyInstruction::ComplexInstruction;
+}

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__instruction_with_custom_variant.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__instruction_with_custom_variant.snap
@@ -1,0 +1,60 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+#[repr(C)]
+#[derive(
+    ::pina::TypedBuilder,
+    ::pina::Pod,
+    ::pina::Zeroable,
+    ::core::clone::Clone,
+    ::core::marker::Copy,
+    ::core::cmp::PartialEq,
+    ::core::cmp::Eq,
+    ::core::fmt::Debug
+)]
+#[builder(builder_method(vis = "", name = __builder))]
+#[bytemuck(crate = "::pina::bytemuck")]
+pub struct TransferData {
+    discriminator: [u8; OpCode::BYTES],
+    pub amount: PodU64,
+    pub destination: [u8; 32],
+}
+#[allow(dead_code)]
+type TransferDataBuilderType = TransferDataBuilder<(([u8; OpCode::BYTES],), (), ())>;
+const __TRANSFERDATA_ALIGNMENT_ASSERTIONS__: () = {
+    ::core::assert!(
+        ::core::mem::align_of:: < [u8; OpCode::BYTES] > () == 1,
+        concat!("The alignment of field `", "discriminator", "` with type `",
+        stringify!([u8; OpCode::BYTES]),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < PodU64 > () == 1, concat!("The alignment of field `",
+        "amount", "` with type `", stringify!(PodU64),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < [u8; 32] > () == 1, concat!("The alignment of field `",
+        "destination", "` with type `", stringify!([u8; 32]),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+};
+impl TransferData {
+    pub fn to_bytes(&self) -> &[u8] {
+        ::pina::bytemuck::bytes_of(self)
+    }
+    pub fn try_from_bytes(data: &[u8]) -> Result<&Self, ::pina::ProgramError> {
+        ::pina::bytemuck::try_from_bytes::<Self>(data)
+            .or(Err(::pina::ProgramError::InvalidInstructionData))
+    }
+    pub fn builder() -> TransferDataBuilderType {
+        let mut bytes = [0u8; OpCode::BYTES];
+        <Self as ::pina::HasDiscriminator>::VALUE.write_discriminator(&mut bytes);
+        Self::__builder().discriminator(bytes)
+    }
+}
+impl ::pina::HasDiscriminator for TransferData {
+    type Type = OpCode;
+    const VALUE: Self::Type = OpCode::DoTransfer;
+}

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__instruction_with_existing_derive.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__instruction_with_existing_derive.snap
@@ -1,0 +1,54 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+#[derive(
+    Debug,
+    ::pina::TypedBuilder,
+    ::pina::Pod,
+    ::pina::Zeroable,
+    ::core::clone::Clone,
+    ::core::marker::Copy,
+    ::core::cmp::PartialEq,
+    ::core::cmp::Eq
+)]
+#[repr(C)]
+#[builder(builder_method(vis = "", name = __builder))]
+#[bytemuck(crate = "::pina::bytemuck")]
+pub struct Transfer {
+    discriminator: [u8; InstrDisc::BYTES],
+    pub amount: PodU64,
+}
+#[allow(dead_code)]
+type TransferBuilderType = TransferBuilder<(([u8; InstrDisc::BYTES],), ())>;
+const __TRANSFER_ALIGNMENT_ASSERTIONS__: () = {
+    ::core::assert!(
+        ::core::mem::align_of:: < [u8; InstrDisc::BYTES] > () == 1,
+        concat!("The alignment of field `", "discriminator", "` with type `",
+        stringify!([u8; InstrDisc::BYTES]),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+    ::core::assert!(
+        ::core::mem::align_of:: < PodU64 > () == 1, concat!("The alignment of field `",
+        "amount", "` with type `", stringify!(PodU64),
+        "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+    );
+};
+impl Transfer {
+    pub fn to_bytes(&self) -> &[u8] {
+        ::pina::bytemuck::bytes_of(self)
+    }
+    pub fn try_from_bytes(data: &[u8]) -> Result<&Self, ::pina::ProgramError> {
+        ::pina::bytemuck::try_from_bytes::<Self>(data)
+            .or(Err(::pina::ProgramError::InvalidInstructionData))
+    }
+    pub fn builder() -> TransferBuilderType {
+        let mut bytes = [0u8; InstrDisc::BYTES];
+        <Self as ::pina::HasDiscriminator>::VALUE.write_discriminator(&mut bytes);
+        Self::__builder().discriminator(bytes)
+    }
+}
+impl ::pina::HasDiscriminator for Transfer {
+    type Type = InstrDisc;
+    const VALUE: Self::Type = InstrDisc::Transfer;
+}

--- a/crates/pina_macros/src/tests.rs
+++ b/crates/pina_macros/src/tests.rs
@@ -1,0 +1,478 @@
+use quote::quote;
+
+use crate::account_impl;
+use crate::accounts_derive_impl;
+use crate::discriminator_impl;
+use crate::error_impl;
+use crate::event_impl;
+use crate::instruction_impl;
+
+/// Format a `proc_macro2::TokenStream` into a readable Rust string using
+/// `prettyplease`.
+fn pretty(tokens: proc_macro2::TokenStream) -> String {
+	let file =
+		syn::parse2(tokens).unwrap_or_else(|e| panic!("generated tokens are not valid Rust: {e}"));
+	prettyplease::unparse(&file)
+}
+
+// ---------------------------------------------------------------------------
+// #[discriminator] snapshots
+// ---------------------------------------------------------------------------
+
+#[test]
+fn discriminator_u8_default() {
+	let args = quote! {};
+	let input = quote! {
+		#[derive(Debug)]
+		pub enum MyDiscriminator {
+			First = 0,
+			Second = 1,
+			Third = 2,
+		}
+	};
+	let output = pretty(discriminator_impl(args, input));
+	insta::assert_snapshot!("discriminator_u8_default", output);
+}
+
+#[test]
+fn discriminator_u16_primitive() {
+	let args = quote! { primitive = u16, crate = ::pina };
+	let input = quote! {
+		pub enum WideDiscriminator {
+			Alpha = 100,
+			Beta = 200,
+		}
+	};
+	let output = pretty(discriminator_impl(args, input));
+	insta::assert_snapshot!("discriminator_u16_primitive", output);
+}
+
+#[test]
+fn discriminator_u32_primitive() {
+	let args = quote! { primitive = u32, crate = ::pina };
+	let input = quote! {
+		pub enum U32Discriminator {
+			A = 0,
+			B = 1000,
+			C = 2000,
+		}
+	};
+	let output = pretty(discriminator_impl(args, input));
+	insta::assert_snapshot!("discriminator_u32_primitive", output);
+}
+
+#[test]
+fn discriminator_u64_primitive() {
+	let args = quote! { primitive = u64, crate = ::pina };
+	let input = quote! {
+		pub enum HugeDiscriminator {
+			Mint = 0,
+			Transfer = 1,
+		}
+	};
+	let output = pretty(discriminator_impl(args, input));
+	insta::assert_snapshot!("discriminator_u64_primitive", output);
+}
+
+#[test]
+fn discriminator_final_attribute() {
+	let args = quote! { primitive = u8, crate = ::pina, final };
+	let input = quote! {
+		#[derive(Debug)]
+		pub enum FinalDiscriminator {
+			Only = 0,
+		}
+	};
+	let output = pretty(discriminator_impl(args, input));
+	insta::assert_snapshot!("discriminator_final_attribute", output);
+}
+
+#[test]
+fn discriminator_single_variant() {
+	let args = quote! { crate = ::pina };
+	let input = quote! {
+		pub enum SingleVariant {
+			Singleton = 42,
+		}
+	};
+	let output = pretty(discriminator_impl(args, input));
+	insta::assert_snapshot!("discriminator_single_variant", output);
+}
+
+#[test]
+fn discriminator_many_variants() {
+	let args = quote! { primitive = u16, crate = ::pina };
+	let input = quote! {
+		#[derive(Debug)]
+		pub enum ManyVariants {
+			Create = 0,
+			Read = 1,
+			Update = 2,
+			Delete = 3,
+			List = 4,
+			Search = 5,
+			Export = 6,
+			Import = 7,
+		}
+	};
+	let output = pretty(discriminator_impl(args, input));
+	insta::assert_snapshot!("discriminator_many_variants", output);
+}
+
+// ---------------------------------------------------------------------------
+// #[error] snapshots
+// ---------------------------------------------------------------------------
+
+#[test]
+fn error_basic() {
+	let args = quote! { crate = ::pina };
+	let input = quote! {
+		#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+		pub enum MyError {
+			Invalid = 0,
+			Duplicate = 1,
+		}
+	};
+	let output = pretty(error_impl(args, input));
+	insta::assert_snapshot!("error_basic", output);
+}
+
+#[test]
+fn error_final() {
+	let args = quote! { crate = ::pina, final };
+	let input = quote! {
+		#[derive(Debug)]
+		pub enum FinalError {
+			Unauthorized = 0,
+		}
+	};
+	let output = pretty(error_impl(args, input));
+	insta::assert_snapshot!("error_final", output);
+}
+
+#[test]
+fn error_many_variants() {
+	let args = quote! { crate = ::pina };
+	let input = quote! {
+		#[derive(Debug)]
+		pub enum DetailedError {
+			/// Not enough funds to complete the transaction.
+			InsufficientFunds = 0,
+			/// The account has already been initialized.
+			AlreadyInitialized = 1,
+			/// The provided authority does not match.
+			InvalidAuthority = 2,
+			/// The mint does not match.
+			InvalidMint = 3,
+			/// Arithmetic overflow occurred.
+			Overflow = 4,
+		}
+	};
+	let output = pretty(error_impl(args, input));
+	insta::assert_snapshot!("error_many_variants", output);
+}
+
+#[test]
+fn error_default_crate_path() {
+	let args = quote! {};
+	let input = quote! {
+		pub enum DefaultCrateError {
+			Something = 0,
+		}
+	};
+	let output = pretty(error_impl(args, input));
+	insta::assert_snapshot!("error_default_crate_path", output);
+}
+
+// ---------------------------------------------------------------------------
+// #[account] snapshots
+// ---------------------------------------------------------------------------
+
+#[test]
+fn account_basic() {
+	let args = quote! { crate = ::pina, discriminator = MyAccount };
+	let input = quote! {
+		pub struct ConfigState {
+			pub version: u8,
+			pub bump: u8,
+		}
+	};
+	let output = pretty(account_impl(args, input));
+	insta::assert_snapshot!("account_basic", output);
+}
+
+#[test]
+fn account_with_existing_derives() {
+	let args = quote! { crate = ::pina, discriminator = MyAccount };
+	let input = quote! {
+		#[derive(Debug)]
+		pub struct GameState {
+			pub score: u8,
+			pub level: u8,
+		}
+	};
+	let output = pretty(account_impl(args, input));
+	insta::assert_snapshot!("account_with_existing_derives", output);
+}
+
+#[test]
+fn account_with_array_fields() {
+	let args = quote! { crate = ::pina, discriminator = AccountDiscriminator };
+	let input = quote! {
+		pub struct DataAccount {
+			pub authority: [u8; 32],
+			pub data: [u8; 64],
+			pub flags: [u8; 4],
+		}
+	};
+	let output = pretty(account_impl(args, input));
+	insta::assert_snapshot!("account_with_array_fields", output);
+}
+
+#[test]
+fn account_with_pod_types() {
+	let args = quote! { crate = ::pina, discriminator = MyDiscriminator };
+	let input = quote! {
+		pub struct BalanceAccount {
+			pub owner: [u8; 32],
+			pub amount: PodU64,
+			pub decimals: u8,
+			pub is_frozen: PodBool,
+		}
+	};
+	let output = pretty(account_impl(args, input));
+	insta::assert_snapshot!("account_with_pod_types", output);
+}
+
+#[test]
+fn account_with_custom_variant() {
+	let args = quote! { crate = ::pina, discriminator = AcctDisc, variant = Custom };
+	let input = quote! {
+		pub struct MyStruct {
+			pub value: u8,
+		}
+	};
+	let output = pretty(account_impl(args, input));
+	insta::assert_snapshot!("account_with_custom_variant", output);
+}
+
+#[test]
+fn account_many_fields() {
+	let args = quote! { crate = ::pina, discriminator = MyAccount };
+	let input = quote! {
+		pub struct LargeState {
+			pub authority: [u8; 32],
+			pub bump: u8,
+			pub treasury_bump: u8,
+			pub mint_bump: u8,
+			pub version: u8,
+			pub padding: [u8; 3],
+			pub total_supply: PodU64,
+			pub name: [u8; 32],
+		}
+	};
+	let output = pretty(account_impl(args, input));
+	insta::assert_snapshot!("account_many_fields", output);
+}
+
+// ---------------------------------------------------------------------------
+// #[instruction] snapshots
+// ---------------------------------------------------------------------------
+
+#[test]
+fn instruction_minimal() {
+	let args = quote! { crate = ::pina, discriminator = MyInstruction };
+	let input = quote! {
+		pub struct Initialize {}
+	};
+	let output = pretty(instruction_impl(args, input));
+	insta::assert_snapshot!("instruction_minimal", output);
+}
+
+#[test]
+fn instruction_many_fields() {
+	let args = quote! { crate = ::pina, discriminator = MyInstruction };
+	let input = quote! {
+		pub struct FlipBit {
+			pub section_index: u8,
+			pub array_index: u8,
+			pub offset: u8,
+			pub value: u8,
+		}
+	};
+	let output = pretty(instruction_impl(args, input));
+	insta::assert_snapshot!("instruction_many_fields", output);
+}
+
+#[test]
+fn instruction_with_existing_derive() {
+	let args = quote! { crate = ::pina, discriminator = InstrDisc };
+	let input = quote! {
+		#[derive(Debug)]
+		pub struct Transfer {
+			pub amount: PodU64,
+		}
+	};
+	let output = pretty(instruction_impl(args, input));
+	insta::assert_snapshot!("instruction_with_existing_derive", output);
+}
+
+#[test]
+fn instruction_with_custom_variant() {
+	let args = quote! { crate = ::pina, discriminator = OpCode, variant = DoTransfer };
+	let input = quote! {
+		pub struct TransferData {
+			pub amount: PodU64,
+			pub destination: [u8; 32],
+		}
+	};
+	let output = pretty(instruction_impl(args, input));
+	insta::assert_snapshot!("instruction_with_custom_variant", output);
+}
+
+#[test]
+fn instruction_with_array_and_pod() {
+	let args = quote! { crate = ::pina, discriminator = MyInstruction };
+	let input = quote! {
+		pub struct ComplexInstruction {
+			pub seed: [u8; 32],
+			pub amount: PodU64,
+			pub bump: u8,
+			pub flags: [u8; 4],
+		}
+	};
+	let output = pretty(instruction_impl(args, input));
+	insta::assert_snapshot!("instruction_with_array_and_pod", output);
+}
+
+// ---------------------------------------------------------------------------
+// #[event] snapshots
+// ---------------------------------------------------------------------------
+
+#[test]
+fn event_basic() {
+	let args = quote! { crate = ::pina, discriminator = EventDisc };
+	let input = quote! {
+		pub struct TransferEvent {
+			pub from: [u8; 32],
+			pub to: [u8; 32],
+			pub amount: PodU64,
+		}
+	};
+	let output = pretty(event_impl(args, input));
+	insta::assert_snapshot!("event_basic", output);
+}
+
+#[test]
+fn event_with_variant() {
+	let args = quote! { crate = ::pina, discriminator = EventKind, variant = Init };
+	let input = quote! {
+		pub struct InitializeEvent {
+			pub choice: u8,
+		}
+	};
+	let output = pretty(event_impl(args, input));
+	insta::assert_snapshot!("event_with_variant", output);
+}
+
+#[test]
+fn event_minimal() {
+	let args = quote! { crate = ::pina, discriminator = EventDisc };
+	let input = quote! {
+		pub struct EmptyEvent {}
+	};
+	let output = pretty(event_impl(args, input));
+	insta::assert_snapshot!("event_minimal", output);
+}
+
+#[test]
+fn event_with_existing_derive() {
+	let args = quote! { crate = ::pina, discriminator = EvtDisc };
+	let input = quote! {
+		#[derive(Debug)]
+		pub struct AuditEvent {
+			pub action: u8,
+			pub timestamp: PodU64,
+		}
+	};
+	let output = pretty(event_impl(args, input));
+	insta::assert_snapshot!("event_with_existing_derive", output);
+}
+
+// ---------------------------------------------------------------------------
+// #[derive(Accounts)] snapshots
+// ---------------------------------------------------------------------------
+
+#[test]
+fn accounts_derive_basic() {
+	let input = quote! {
+		#[pina(crate = ::pina)]
+		pub struct InitAccounts<'a> {
+			pub payer: &'a AccountView,
+			pub config: &'a AccountView,
+			pub system_program: &'a AccountView,
+		}
+	};
+	let output = pretty(accounts_derive_impl(input));
+	insta::assert_snapshot!("accounts_derive_basic", output);
+}
+
+#[test]
+fn accounts_derive_with_remaining() {
+	let input = quote! {
+		#[pina(crate = ::pina)]
+		pub struct TransferAccounts<'a> {
+			pub authority: &'a AccountView,
+			pub source: &'a AccountView,
+			pub destination: &'a AccountView,
+			#[pina(remaining)]
+			pub extra: &'a [AccountView],
+		}
+	};
+	let output = pretty(accounts_derive_impl(input));
+	insta::assert_snapshot!("accounts_derive_with_remaining", output);
+}
+
+#[test]
+fn accounts_derive_single_field() {
+	let input = quote! {
+		#[pina(crate = ::pina)]
+		pub struct SingleAccount<'a> {
+			pub account: &'a AccountView,
+		}
+	};
+	let output = pretty(accounts_derive_impl(input));
+	insta::assert_snapshot!("accounts_derive_single_field", output);
+}
+
+#[test]
+fn accounts_derive_many_fields() {
+	let input = quote! {
+		#[pina(crate = ::pina)]
+		pub struct EscrowAccounts<'a> {
+			pub maker: &'a AccountView,
+			pub escrow: &'a AccountView,
+			pub mint_a: &'a AccountView,
+			pub mint_b: &'a AccountView,
+			pub maker_ata_a: &'a AccountView,
+			pub vault: &'a AccountView,
+			pub token_program: &'a AccountView,
+			pub associated_token_program: &'a AccountView,
+			pub system_program: &'a AccountView,
+		}
+	};
+	let output = pretty(accounts_derive_impl(input));
+	insta::assert_snapshot!("accounts_derive_many_fields", output);
+}
+
+#[test]
+fn accounts_derive_default_crate() {
+	let input = quote! {
+		pub struct DefaultCrateAccounts<'a> {
+			pub authority: &'a AccountView,
+			pub data: &'a AccountView,
+		}
+	};
+	let output = pretty(accounts_derive_impl(input));
+	insta::assert_snapshot!("accounts_derive_default_crate", output);
+}


### PR DESCRIPTION
## Summary

- Add 31 snapshot tests using `cargo-insta` covering edge cases for all 6 proc macros in `pina_macros`: `#[discriminator]`, `#[error]`, `#[account]`, `#[instruction]`, `#[event]`, and `#[derive(Accounts)]`
- Refactor each macro to extract internal `_impl` functions that accept/return `proc_macro2::TokenStream`, enabling direct unit testing without `proc_macro` context
- Add `insta` and `prettyplease` as dev-dependencies for snapshot testing with readable formatted output

### Test coverage by macro

| Macro | Tests | Edge cases covered |
|---|---|---|
| `#[discriminator]` | 7 | u8 default, u16, u32, u64 primitives, `final` attribute, single variant, many variants (8) |
| `#[error]` | 4 | basic, `final`, many variants with doc comments, default crate path |
| `#[account]` | 6 | basic, existing derives, array fields, Pod types, custom variant, many fields |
| `#[instruction]` | 5 | minimal (empty fields), many fields, existing derive, custom variant, mixed array/Pod |
| `#[event]` | 4 | basic, custom variant, minimal (empty), existing derive |
| `#[derive(Accounts)]` | 5 | basic, `#[pina(remaining)]`, single field, many fields (9), default crate path |

## Test plan

- [x] `cargo test -p pina_macros` -- all 31 snapshot tests pass
- [x] `cargo clippy -p pina_macros --all-features --tests` -- no new warnings
- [x] `dprint check` -- formatting verified
- [x] Doc-tests continue to pass (10 doc-tests)
- [ ] CI validates all tests pass on the branch