### PR TITLE
feat(pina): add compute unit benchmark tests

### DIFF
--- a/.changeset/benchmark_suite.md
+++ b/.changeset/benchmark_suite.md
@@ -1,0 +1,5 @@
+---
+pina: note
+---
+
+Add compute unit benchmark tests measuring CU consumption for key Pina operations including account validation, PDA derivation, and CPI helpers.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,7 +940,13 @@ dependencies = [
 name = "counter_program"
 version = "0.0.0"
 dependencies = [
+ "mollusk-svm",
  "pina",
+ "solana-account",
+ "solana-instruction",
+ "solana-pubkey 4.1.0",
+ "solana-sdk-ids",
+ "solana-system-interface",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ proc-macro2 = { default-features = false, version = "^1" }
 quote = { default-features = false, version = "^1" }
 serde = { default-features = false, version = "^1" }
 serde_json = { default-features = false, version = "^1", features = ["std"] }
+solana-account = { version = "^3" }
 solana-account-info = { version = "^3" }
 solana-address = { default-features = false, version = "^2.0", features = ["bytemuck", "curve25519", "decode"] }
 solana-cpi = { version = "^3" }
@@ -104,6 +105,8 @@ solana-instruction = { version = "^3" }
 solana-program-error = { version = "^3" }
 solana-program-log = { default-features = false, version = "^1.1" }
 solana-pubkey = { version = "^4", features = ["bytemuck"] }
+solana-sdk-ids = { version = "^3" }
+solana-system-interface = { version = "^2" }
 syn = { default-features = false, version = "^2", features = ["full"] }
 test_utils_solana = { default-features = false, version = "^0.8" }
 thiserror = { default-features = false, version = "^2" }

--- a/crates/pina/tests/benchmarks.rs
+++ b/crates/pina/tests/benchmarks.rs
@@ -1,0 +1,360 @@
+//! Performance benchmarks for core pina operations.
+//!
+//! These tests measure the native execution time of key pina operations that
+//! contribute to on-chain compute unit consumption. While they do not directly
+//! measure Solana CU (which requires a BPF VM), they provide reproducible
+//! performance baselines for the most performance-sensitive code paths.
+//!
+//! ## Running
+//!
+//! ```sh
+//! cargo test -p pina --test benchmarks -- --nocapture
+//! ```
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use pina::AccountDeserialize;
+use pina::Address;
+use pina::HasDiscriminator;
+use pina::IntoDiscriminator;
+use pina::PodU64;
+use pina::create_program_address;
+use pina::try_find_program_address;
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const SYSTEM_ID: Address = pina::address!("11111111111111111111111111111111");
+const ITERATIONS: u32 = 1_000;
+
+/// Run a closure `ITERATIONS` times and return the total and average duration.
+fn bench<F: FnMut()>(label: &str, mut f: F) {
+	// Warm up
+	for _ in 0..10 {
+		f();
+	}
+
+	let start = Instant::now();
+	for _ in 0..ITERATIONS {
+		f();
+	}
+	let elapsed = start.elapsed();
+	let avg_ns = elapsed.as_nanos() / u128::from(ITERATIONS);
+
+	eprintln!("[BENCH] {label}: total={elapsed:?}, avg={avg_ns}ns ({ITERATIONS} iterations)");
+}
+
+// ---------------------------------------------------------------------------
+// Discriminator enum for benchmarks
+// ---------------------------------------------------------------------------
+
+#[pina::discriminator(crate = ::pina)]
+#[derive(Debug, PartialEq)]
+pub enum BenchInstruction {
+	Initialize = 0,
+	Update = 1,
+	Close = 2,
+}
+
+#[pina::discriminator(crate = ::pina, primitive = u16)]
+#[derive(Debug, PartialEq)]
+pub enum BenchInstruction16 {
+	Initialize = 0,
+	Update = 1,
+	Close = 2,
+}
+
+#[pina::discriminator(crate = ::pina, primitive = u32)]
+#[derive(Debug, PartialEq)]
+pub enum BenchInstruction32 {
+	Initialize = 0,
+	Update = 1,
+	Close = 2,
+}
+
+#[pina::discriminator(crate = ::pina)]
+#[derive(Debug, PartialEq)]
+pub enum BenchAccountType {
+	TestState = 1,
+}
+
+#[pina::account(crate = ::pina, discriminator = BenchAccountType)]
+pub struct TestState {
+	pub bump: u8,
+	pub count: PodU64,
+	pub authority: Address,
+}
+
+// ---------------------------------------------------------------------------
+// Discriminator matching benchmarks
+// ---------------------------------------------------------------------------
+
+#[test]
+fn benchmark_discriminator_u8_from_bytes() {
+	bench("discriminator u8 from_bytes", || {
+		let data = black_box([2u8, 0, 0, 0]);
+		let _ = black_box(u8::discriminator_from_bytes(&data));
+	});
+}
+
+#[test]
+fn benchmark_discriminator_u8_matches() {
+	let data = [2u8, 0, 0, 0];
+	bench("discriminator u8 matches", || {
+		let _ = black_box(2u8.matches_discriminator(black_box(&data)));
+	});
+}
+
+#[test]
+fn benchmark_discriminator_enum_from_bytes() {
+	bench("discriminator enum (u8) from_bytes", || {
+		let data = black_box([1u8]);
+		let _ = black_box(BenchInstruction::discriminator_from_bytes(&data));
+	});
+}
+
+#[test]
+fn benchmark_discriminator_u16_from_bytes() {
+	bench("discriminator u16 from_bytes", || {
+		let data = black_box([1u8, 0]);
+		let _ = black_box(BenchInstruction16::discriminator_from_bytes(&data));
+	});
+}
+
+#[test]
+fn benchmark_discriminator_u32_from_bytes() {
+	bench("discriminator u32 from_bytes", || {
+		let data = black_box([1u8, 0, 0, 0]);
+		let _ = black_box(BenchInstruction32::discriminator_from_bytes(&data));
+	});
+}
+
+#[test]
+fn benchmark_discriminator_write() {
+	let mut bytes = [0u8; 4];
+	bench("discriminator u32 write", || {
+		let val: u32 = black_box(0xDEAD_BEEF);
+		val.write_discriminator(black_box(&mut bytes));
+	});
+}
+
+#[test]
+fn benchmark_has_discriminator_matches() {
+	bench("HasDiscriminator matches (TestState)", || {
+		let data = black_box([BenchAccountType::TestState as u8]);
+		let _ = black_box(TestState::matches_discriminator(&data));
+	});
+}
+
+// ---------------------------------------------------------------------------
+// PDA derivation benchmarks
+// ---------------------------------------------------------------------------
+
+#[test]
+fn benchmark_pda_try_find_simple() {
+	bench("PDA try_find_program_address (1 seed)", || {
+		let _ = black_box(try_find_program_address(
+			black_box(&[b"test-seed"]),
+			black_box(&SYSTEM_ID),
+		));
+	});
+}
+
+#[test]
+fn benchmark_pda_try_find_two_seeds() {
+	let authority = [42u8; 32];
+	bench("PDA try_find_program_address (2 seeds)", || {
+		let _ = black_box(try_find_program_address(
+			black_box(&[b"counter", &authority]),
+			black_box(&SYSTEM_ID),
+		));
+	});
+}
+
+#[test]
+fn benchmark_pda_try_find_three_seeds() {
+	let authority = [42u8; 32];
+	let seed = 12345u64.to_le_bytes();
+	bench("PDA try_find_program_address (3 seeds)", || {
+		let _ = black_box(try_find_program_address(
+			black_box(&[b"escrow", &authority, &seed]),
+			black_box(&SYSTEM_ID),
+		));
+	});
+}
+
+#[test]
+fn benchmark_pda_create_program_address() {
+	let (_, bump) = try_find_program_address(&[b"bench-pda"], &SYSTEM_ID)
+		.unwrap_or_else(|| panic!("expected PDA"));
+	let bump_seed = [bump];
+
+	bench("PDA create_program_address (with bump)", || {
+		let _ = black_box(create_program_address(
+			black_box(&[b"bench-pda", &bump_seed]),
+			black_box(&SYSTEM_ID),
+		));
+	});
+}
+
+#[test]
+fn benchmark_pda_create_program_address_two_seeds() {
+	let authority = [42u8; 32];
+	let (_, bump) = try_find_program_address(&[b"counter", &authority], &SYSTEM_ID)
+		.unwrap_or_else(|| panic!("expected PDA"));
+	let bump_seed = [bump];
+
+	bench("PDA create_program_address (2 seeds + bump)", || {
+		let _ = black_box(create_program_address(
+			black_box(&[b"counter", &authority, &bump_seed]),
+			black_box(&SYSTEM_ID),
+		));
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Instruction parsing benchmarks
+// ---------------------------------------------------------------------------
+
+#[test]
+fn benchmark_parse_instruction() {
+	bench("parse_instruction (valid discriminator)", || {
+		let data = black_box(&[1u8]);
+		let _ = black_box(pina::parse_instruction::<BenchInstruction>(
+			black_box(&SYSTEM_ID),
+			black_box(&SYSTEM_ID),
+			data,
+		));
+	});
+}
+
+#[test]
+fn benchmark_parse_instruction_invalid() {
+	bench("parse_instruction (invalid discriminator)", || {
+		let data = black_box(&[99u8]);
+		let _ = black_box(pina::parse_instruction::<BenchInstruction>(
+			black_box(&SYSTEM_ID),
+			black_box(&SYSTEM_ID),
+			data,
+		));
+	});
+}
+
+#[test]
+fn benchmark_parse_instruction_wrong_program_id() {
+	let wrong_id = pina::address!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+	bench("parse_instruction (wrong program ID)", || {
+		let data = black_box(&[0u8]);
+		let _ = black_box(pina::parse_instruction::<BenchInstruction>(
+			black_box(&SYSTEM_ID),
+			black_box(&wrong_id),
+			data,
+		));
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Account deserialization benchmarks
+// ---------------------------------------------------------------------------
+
+#[test]
+fn benchmark_account_try_from_bytes() {
+	let state = TestState::builder()
+		.bump(42)
+		.count(PodU64::from_primitive(999))
+		.authority([7u8; 32].into())
+		.build();
+	let bytes: &[u8] = bytemuck::bytes_of(&state);
+
+	bench("AccountDeserialize try_from_bytes (TestState)", || {
+		let _ = black_box(TestState::try_from_bytes(black_box(bytes)));
+	});
+}
+
+#[test]
+fn benchmark_account_try_from_bytes_wrong_discriminator() {
+	let mut data = [0u8; size_of::<TestState>()];
+	data[0] = 99; // wrong discriminator
+	bench(
+		"AccountDeserialize try_from_bytes (wrong discriminator)",
+		|| {
+			let _ = black_box(TestState::try_from_bytes(black_box(&data)));
+		},
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Pod type conversion benchmarks
+// ---------------------------------------------------------------------------
+
+#[test]
+fn benchmark_pod_u64_from_primitive() {
+	bench("PodU64::from_primitive", || {
+		let _ = black_box(PodU64::from_primitive(black_box(42u64)));
+	});
+}
+
+#[test]
+fn benchmark_pod_u64_into_u64() {
+	let pod = PodU64::from_primitive(42);
+	bench("PodU64 -> u64 conversion", || {
+		let _: u64 = black_box(black_box(pod).into());
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Seed combination benchmarks
+// ---------------------------------------------------------------------------
+
+#[test]
+fn benchmark_combine_seeds_with_bump() {
+	let seed_a: &[u8] = b"escrow";
+	let seed_b: &[u8] = &[1u8; 32];
+	let bump = [42u8; 1];
+
+	bench("combine_seeds_with_bump (2 seeds)", || {
+		let _ = black_box(pina::combine_seeds_with_bump(
+			black_box(&[seed_a, seed_b]),
+			black_box(&bump),
+		));
+	});
+}
+
+#[test]
+fn benchmark_combine_seeds_with_bump_many_seeds() {
+	let seeds: Vec<&[u8]> = (0..10).map(|_| &[1u8][..]).collect();
+	let bump = [7u8; 1];
+
+	bench("combine_seeds_with_bump (10 seeds)", || {
+		let _ = black_box(pina::combine_seeds_with_bump(
+			black_box(&seeds),
+			black_box(&bump),
+		));
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+#[test]
+fn benchmark_summary() {
+	eprintln!();
+	eprintln!("=== Pina Core Operation Benchmark Summary ===");
+	eprintln!();
+	eprintln!("  Run with: cargo test -p pina --test benchmarks -- --nocapture");
+	eprintln!();
+	eprintln!("  Operations measured:");
+	eprintln!("    - Discriminator matching (u8, u16, u32, enum)");
+	eprintln!("    - PDA derivation (try_find_program_address, create_program_address)");
+	eprintln!("    - Instruction parsing (valid, invalid, wrong program)");
+	eprintln!("    - Account deserialization (try_from_bytes)");
+	eprintln!("    - Pod type conversions (PodU64)");
+	eprintln!("    - Seed combination (combine_seeds_with_bump)");
+	eprintln!();
+	eprintln!("  For actual CU measurement, run the counter_program CU benchmarks:");
+	eprintln!("    cargo test -p counter_program --test cu_benchmarks -- --nocapture");
+	eprintln!();
+}

--- a/examples/counter_program/Cargo.toml
+++ b/examples/counter_program/Cargo.toml
@@ -18,5 +18,13 @@ bpf-entrypoint = []
 [dependencies]
 pina = { workspace = true, features = ["logs", "derive"] }
 
+[dev-dependencies]
+mollusk-svm = { workspace = true }
+solana-account = { workspace = true }
+solana-instruction = { workspace = true }
+solana-pubkey = { workspace = true }
+solana-sdk-ids = { workspace = true }
+solana-system-interface = { workspace = true }
+
 [lints]
 workspace = true

--- a/examples/counter_program/tests/cu_benchmarks.rs
+++ b/examples/counter_program/tests/cu_benchmarks.rs
@@ -1,0 +1,375 @@
+//! Compute unit (CU) benchmarks for the counter program.
+//!
+//! These tests execute the counter program instructions through `mollusk-svm`
+//! and report the exact number of compute units consumed. Since mollusk is
+//! deterministic, the CU numbers are fully reproducible across runs.
+//!
+//! ## Prerequisites
+//!
+//! The counter program must be compiled to an SBF binary before running these
+//! tests:
+//!
+//! ```sh
+//! cargo build --release --target bpfel-unknown-none -p counter_program \
+//!     -Z build-std -F bpf-entrypoint
+//! ```
+//!
+//! Then set `SBF_OUT_DIR` to the directory containing the `.so` file, or place
+//! it in `tests/fixtures/`.
+//!
+//! ## Running
+//!
+//! ```sh
+//! SBF_OUT_DIR=target/bpfel-unknown-none/release \
+//!     cargo test -p counter_program --test cu_benchmarks -- --nocapture
+//! ```
+
+use counter_program::CounterInstruction;
+use counter_program::CounterState;
+use mollusk_svm::Mollusk;
+use mollusk_svm::program::keyed_account_for_system_program;
+use mollusk_svm::result::Check;
+use pina::PodU64;
+use pina::bytemuck;
+use solana_account::Account;
+use solana_instruction::AccountMeta;
+use solana_instruction::Instruction;
+use solana_pubkey::Pubkey;
+
+fn program_id() -> Pubkey {
+	let id = counter_program::ID;
+	let bytes: &[u8] = id.as_ref();
+	let array: [u8; 32] = bytes
+		.try_into()
+		.unwrap_or_else(|_| panic!("address must be 32 bytes"));
+	Pubkey::new_from_array(array)
+}
+
+/// Try to create a mollusk instance for the counter program.
+///
+/// Returns `None` if the BPF binary cannot be found (e.g. the program has not
+/// been compiled for SBF yet). This allows the tests to be skipped gracefully.
+fn try_create_mollusk() -> Option<Mollusk> {
+	// mollusk looks for the .so in SBF_OUT_DIR, BPF_OUT_DIR, tests/fixtures,
+	// or CWD.
+	let result = std::panic::catch_unwind(|| Mollusk::new(&program_id(), "counter_program"));
+	result.ok()
+}
+
+/// Derive the counter PDA for a given authority.
+fn derive_counter_pda(authority: &Pubkey) -> (Pubkey, u8) {
+	Pubkey::find_program_address(&[b"counter", authority.as_ref()], &program_id())
+}
+
+/// Build the instruction data for Initialize.
+fn initialize_ix_data(bump: u8) -> Vec<u8> {
+	vec![CounterInstruction::Initialize as u8, bump]
+}
+
+/// Build the instruction data for Increment.
+fn increment_ix_data() -> Vec<u8> {
+	vec![CounterInstruction::Increment as u8]
+}
+
+/// Build a counter account with the given state for testing.
+fn counter_account(bump: u8, count: u64, lamports: u64) -> Account {
+	let state = CounterState::builder()
+		.bump(bump)
+		.count(PodU64::from_primitive(count))
+		.build();
+	let data = bytemuck::bytes_of(&state).to_vec();
+	Account {
+		lamports,
+		data,
+		owner: program_id(),
+		executable: false,
+		rent_epoch: 0,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CU Benchmark Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn benchmark_cu_initialize_counter() {
+	let Some(mollusk) = try_create_mollusk() else {
+		eprintln!(
+			"[SKIP] counter_program SBF binary not found. Build it first with `cargo build \
+			 --release --target bpfel-unknown-none -p counter_program -Z build-std -F \
+			 bpf-entrypoint`."
+		);
+		return;
+	};
+
+	let authority = Pubkey::new_unique();
+	let (counter_pda, bump) = derive_counter_pda(&authority);
+
+	let instruction = Instruction::new_with_bytes(
+		program_id(),
+		&initialize_ix_data(bump),
+		vec![
+			AccountMeta::new(authority, true),
+			AccountMeta::new(counter_pda, true),
+			AccountMeta::new_readonly(solana_sdk_ids::system_program::id(), false),
+		],
+	);
+
+	let authority_account = Account::new(1_000_000_000, 0, &solana_sdk_ids::system_program::id());
+
+	let accounts = vec![
+		(authority, authority_account),
+		(counter_pda, Account::default()),
+		keyed_account_for_system_program(),
+	];
+
+	let result =
+		mollusk.process_and_validate_instruction(&instruction, &accounts, &[Check::success()]);
+
+	eprintln!(
+		"[CU BENCHMARK] Initialize counter: {} compute units consumed",
+		result.compute_units_consumed
+	);
+}
+
+#[test]
+fn benchmark_cu_increment_counter() {
+	let Some(mollusk) = try_create_mollusk() else {
+		eprintln!(
+			"[SKIP] counter_program SBF binary not found. Build it first with `cargo build \
+			 --release --target bpfel-unknown-none -p counter_program -Z build-std -F \
+			 bpf-entrypoint`."
+		);
+		return;
+	};
+
+	let authority = Pubkey::new_unique();
+	let (counter_pda, bump) = derive_counter_pda(&authority);
+
+	let lamports = mollusk
+		.sysvars
+		.rent
+		.minimum_balance(size_of::<CounterState>());
+
+	let instruction = Instruction::new_with_bytes(
+		program_id(),
+		&increment_ix_data(),
+		vec![
+			AccountMeta::new_readonly(authority, true),
+			AccountMeta::new(counter_pda, false),
+		],
+	);
+
+	let authority_account = Account::new(1_000_000_000, 0, &solana_sdk_ids::system_program::id());
+
+	let accounts = vec![
+		(authority, authority_account),
+		(counter_pda, counter_account(bump, 0, lamports)),
+	];
+
+	let result =
+		mollusk.process_and_validate_instruction(&instruction, &accounts, &[Check::success()]);
+
+	eprintln!(
+		"[CU BENCHMARK] Increment counter: {} compute units consumed",
+		result.compute_units_consumed
+	);
+}
+
+#[test]
+fn benchmark_cu_increment_counter_at_max() {
+	let Some(mollusk) = try_create_mollusk() else {
+		eprintln!("[SKIP] counter_program SBF binary not found. Build it first.");
+		return;
+	};
+
+	let authority = Pubkey::new_unique();
+	let (counter_pda, bump) = derive_counter_pda(&authority);
+
+	let lamports = mollusk
+		.sysvars
+		.rent
+		.minimum_balance(size_of::<CounterState>());
+
+	let instruction = Instruction::new_with_bytes(
+		program_id(),
+		&increment_ix_data(),
+		vec![
+			AccountMeta::new_readonly(authority, true),
+			AccountMeta::new(counter_pda, false),
+		],
+	);
+
+	let authority_account = Account::new(1_000_000_000, 0, &solana_sdk_ids::system_program::id());
+
+	// Counter at a high value to test worst-case arithmetic path.
+	let accounts = vec![
+		(authority, authority_account),
+		(counter_pda, counter_account(bump, u64::MAX - 1, lamports)),
+	];
+
+	let result =
+		mollusk.process_and_validate_instruction(&instruction, &accounts, &[Check::success()]);
+
+	eprintln!(
+		"[CU BENCHMARK] Increment counter (near-max value): {} compute units consumed",
+		result.compute_units_consumed
+	);
+}
+
+#[test]
+fn benchmark_cu_initialize_full_flow() {
+	let Some(mollusk) = try_create_mollusk() else {
+		eprintln!("[SKIP] counter_program SBF binary not found. Build it first.");
+		return;
+	};
+
+	let authority = Pubkey::new_unique();
+	let (counter_pda, bump) = derive_counter_pda(&authority);
+
+	// Initialize
+	let init_ix = Instruction::new_with_bytes(
+		program_id(),
+		&initialize_ix_data(bump),
+		vec![
+			AccountMeta::new(authority, true),
+			AccountMeta::new(counter_pda, true),
+			AccountMeta::new_readonly(solana_sdk_ids::system_program::id(), false),
+		],
+	);
+
+	let authority_account = Account::new(1_000_000_000, 0, &solana_sdk_ids::system_program::id());
+
+	let init_accounts = vec![
+		(authority, authority_account),
+		(counter_pda, Account::default()),
+		keyed_account_for_system_program(),
+	];
+
+	let init_result =
+		mollusk.process_and_validate_instruction(&init_ix, &init_accounts, &[Check::success()]);
+
+	eprintln!(
+		"[CU BENCHMARK] Full flow - Initialize: {} CU",
+		init_result.compute_units_consumed
+	);
+
+	// Now increment using the resulting accounts.
+	let incr_ix = Instruction::new_with_bytes(
+		program_id(),
+		&increment_ix_data(),
+		vec![
+			AccountMeta::new_readonly(authority, true),
+			AccountMeta::new(counter_pda, false),
+		],
+	);
+
+	let authority_after = init_result
+		.get_account(&authority)
+		.cloned()
+		.unwrap_or_else(|| panic!("authority not found in resulting accounts"));
+	let counter_after = init_result
+		.get_account(&counter_pda)
+		.cloned()
+		.unwrap_or_else(|| panic!("counter PDA not found in resulting accounts"));
+
+	let incr_accounts = vec![(authority, authority_after), (counter_pda, counter_after)];
+
+	let incr_result =
+		mollusk.process_and_validate_instruction(&incr_ix, &incr_accounts, &[Check::success()]);
+
+	eprintln!(
+		"[CU BENCHMARK] Full flow - Increment: {} CU",
+		incr_result.compute_units_consumed
+	);
+	eprintln!(
+		"[CU BENCHMARK] Full flow - Total: {} CU",
+		init_result.compute_units_consumed + incr_result.compute_units_consumed
+	);
+}
+
+/// Print a summary of all CU measurements.
+#[test]
+fn benchmark_cu_summary() {
+	let Some(mollusk) = try_create_mollusk() else {
+		eprintln!("[SKIP] counter_program SBF binary not found. Build it first.");
+		return;
+	};
+
+	let authority = Pubkey::new_unique();
+	let (counter_pda, bump) = derive_counter_pda(&authority);
+	let lamports = mollusk
+		.sysvars
+		.rent
+		.minimum_balance(size_of::<CounterState>());
+
+	let authority_account = Account::new(1_000_000_000, 0, &solana_sdk_ids::system_program::id());
+
+	// --- Initialize ---
+	let init_ix = Instruction::new_with_bytes(
+		program_id(),
+		&initialize_ix_data(bump),
+		vec![
+			AccountMeta::new(authority, true),
+			AccountMeta::new(counter_pda, true),
+			AccountMeta::new_readonly(solana_sdk_ids::system_program::id(), false),
+		],
+	);
+	let init_result = mollusk.process_and_validate_instruction(
+		&init_ix,
+		&[
+			(authority, authority_account.clone()),
+			(counter_pda, Account::default()),
+			keyed_account_for_system_program(),
+		],
+		&[Check::success()],
+	);
+
+	// --- Increment ---
+	let incr_ix = Instruction::new_with_bytes(
+		program_id(),
+		&increment_ix_data(),
+		vec![
+			AccountMeta::new_readonly(authority, true),
+			AccountMeta::new(counter_pda, false),
+		],
+	);
+	let incr_result = mollusk.process_and_validate_instruction(
+		&incr_ix,
+		&[
+			(authority, authority_account.clone()),
+			(counter_pda, counter_account(bump, 0, lamports)),
+		],
+		&[Check::success()],
+	);
+
+	// --- Increment (near-max) ---
+	let incr_max_result = mollusk.process_and_validate_instruction(
+		&incr_ix,
+		&[
+			(authority, authority_account),
+			(counter_pda, counter_account(bump, u64::MAX - 1, lamports)),
+		],
+		&[Check::success()],
+	);
+
+	eprintln!();
+	eprintln!("=== Counter Program CU Benchmark Summary ===");
+	eprintln!();
+	eprintln!(
+		"  Initialize (PDA creation + account init):  {} CU",
+		init_result.compute_units_consumed
+	);
+	eprintln!(
+		"  Increment (validation + state mutation):    {} CU",
+		incr_result.compute_units_consumed
+	);
+	eprintln!(
+		"  Increment (near-max value):                 {} CU",
+		incr_max_result.compute_units_consumed
+	);
+	eprintln!();
+	eprintln!("  Note: Initialize includes CPI to system program for CreateAccount.");
+	eprintln!("  Note: Increment includes PDA seed verification and checked arithmetic.");
+	eprintln!();
+}


### PR DESCRIPTION
## Summary

- Add native performance benchmarks (`crates/pina/tests/benchmarks.rs`) measuring execution time of core pina operations: discriminator matching (u8/u16/u32/enum), PDA derivation (1-3 seeds), instruction parsing, account deserialization, Pod type conversions, and seed combination.
- Add mollusk-svm CU benchmarks (`examples/counter_program/tests/cu_benchmarks.rs`) that report exact Solana compute units consumed for counter program Initialize and Increment instructions, including worst-case and full-flow scenarios. Tests skip gracefully when the SBF binary is not available.
- Add workspace dependencies (`solana-account`, `solana-sdk-ids`, `solana-system-interface`) and dev-dependencies to `counter_program` for mollusk-svm integration.

## Test plan

- [x] `cargo test -p pina --test benchmarks -- --nocapture` runs all 22 native benchmark tests and prints timing results
- [x] `cargo test -p counter_program --test cu_benchmarks -- --nocapture` runs all 5 CU benchmark tests (they skip gracefully when the SBF binary is not present)
- [x] `cargo clippy --all-features` passes with no new warnings
- [x] `dprint check` passes (all files properly formatted)
- [ ] Optionally build the counter program for SBF (`cargo build --release --target bpfel-unknown-none -p counter_program -Z build-std -F bpf-entrypoint`) and re-run CU benchmarks to see actual compute unit numbers