### PR TITLE
fix(pina): keep typed account borrows guarded

### DIFF
--- a/.changeset/guarded-account-borrows.md
+++ b/.changeset/guarded-account-borrows.md
@@ -1,5 +1,5 @@
 ---
-pina: minor
+pina: major
 ---
 
 Keep typed account and token loaders borrow-guarded so runtime borrow checks remain active

--- a/.changeset/guarded-account-borrows.md
+++ b/.changeset/guarded-account-borrows.md
@@ -1,0 +1,8 @@
+---
+pina: minor
+---
+
+Keep typed account and token loaders borrow-guarded so runtime borrow checks remain active
+for the lifetime of returned views. Add regression tests for overlapping typed borrows,
+validate `taker_ata_b` in the escrow example, and enforce custom security dylints in the
+standard lint/CI workflow.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,10 @@ jobs:
         run: lint:clippy
         shell: devenv shell -c -- bash -e {0}
 
+      - name: lint dylint
+        run: lint:dylint
+        shell: devenv shell -c -- bash -e {0}
+
       - name: lint formatting
         run: lint:format
         shell: devenv shell -c -- bash -e {0}

--- a/crates/pina/src/loaders.rs
+++ b/crates/pina/src/loaders.rs
@@ -3,11 +3,15 @@
 use core::slice::from_raw_parts;
 use core::slice::from_raw_parts_mut;
 
+use pinocchio::account::Ref;
+use pinocchio::account::RefMut;
 use pinocchio::ProgramResult;
 use pinocchio_system::instructions::Transfer;
 
 use crate::AccountDeserialize;
 use crate::AccountInfoValidation;
+use crate::AccountRef;
+use crate::AccountRefMut;
 #[cfg(feature = "token")]
 use crate::AccountValidation;
 use crate::AccountView;
@@ -339,40 +343,37 @@ impl AccountInfoValidation for AccountView {
 
 impl AsAccount for AccountView {
 	#[track_caller]
-	fn as_account<T>(&self, program_id: &Address) -> Result<&T, ProgramError>
+	fn as_account<T>(&self, program_id: &Address) -> Result<AccountRef<'_, T>, ProgramError>
 	where
 		T: AccountDeserialize + HasDiscriminator + Pod,
 	{
 		self.assert_owner(program_id)?;
 		self.assert_data_len(size_of::<T>())?;
 
-		// SAFETY: `try_borrow` returns a reference whose lifetime is tied to
-		// `self`. We create a raw-parts slice of exactly `size_of::<T>()` bytes
-		// from the same pointer. The `assert_data_len` check above guarantees
-		// the account data is exactly `size_of::<T>()` bytes.
-		// `T::try_from_bytes` then validates the discriminator and performs a
-		// bytemuck cast.
-		unsafe { T::try_from_bytes(from_raw_parts(self.try_borrow()?.as_ptr(), size_of::<T>())) }
+		Ref::try_map(self.try_borrow()?, |data| {
+			// SAFETY: `assert_data_len` above guarantees the account data is
+			// exactly `size_of::<T>()` bytes. We re-slice to that exact length
+			// and delegate discriminator/layout validation to `T`.
+			unsafe { T::try_from_bytes(from_raw_parts(data.as_ptr(), size_of::<T>())) }
+		})
+		.map_err(|(_borrow, err)| err)
 	}
 
 	#[track_caller]
-	fn as_account_mut<T>(&self, program_id: &Address) -> Result<&mut T, ProgramError>
+	fn as_account_mut<T>(&self, program_id: &Address) -> Result<AccountRefMut<'_, T>, ProgramError>
 	where
 		T: AccountDeserialize + HasDiscriminator + Pod,
 	{
 		self.assert_owner(program_id)?;
 		self.assert_data_len(size_of::<T>())?;
 
-		// SAFETY: Same reasoning as `as_account` above, but with a mutable
-		// borrow. The `assert_data_len` check above guarantees the account data
-		// is exactly `size_of::<T>()` bytes. The Solana runtime guarantees
-		// exclusive access when `try_borrow_mut` succeeds.
-		unsafe {
-			T::try_from_bytes_mut(from_raw_parts_mut(
-				self.try_borrow_mut()?.as_mut_ptr(),
-				size_of::<T>(),
-			))
-		}
+		RefMut::try_map(self.try_borrow_mut()?, |data| {
+			// SAFETY: Same reasoning as `as_account` above, but with a mutable
+			// borrow. The returned guard keeps the runtime borrow state active
+			// for as long as the typed view is alive.
+			unsafe { T::try_from_bytes_mut(from_raw_parts_mut(data.as_mut_ptr(), size_of::<T>())) }
+		})
+		.map_err(|(_borrow, err)| err)
 	}
 }
 
@@ -459,17 +460,23 @@ impl_account_validation!(
 #[cfg(feature = "token")]
 impl AsTokenAccount for AccountView {
 	#[track_caller]
-	fn as_token_mint(&self) -> Result<&crate::token::state::Mint, ProgramError> {
-		self.check_borrow()?;
+	fn as_token_mint(&self) -> Result<AccountRef<'_, crate::token::state::Mint>, ProgramError> {
+		Ref::try_map(self.try_borrow()?, |data| {
+			if data.len() != crate::token::state::Mint::LEN {
+				return Err(ProgramError::InvalidAccountData);
+			}
 
-		// SECURITY: relies on pinocchio's internal layout validation inside
-		// `from_account_view_unchecked`. Callers should verify ownership before
-		// trusting the result.
-		unsafe { crate::token::state::Mint::from_account_view_unchecked(self) }
+			// SECURITY: caller-side ownership validation still applies; the
+			// borrow guard now remains live for the returned typed view.
+			Ok(unsafe { crate::token::state::Mint::from_bytes_unchecked(data) })
+		})
+		.map_err(|(_borrow, err)| err)
 	}
 
 	#[track_caller]
-	fn as_token_mint_checked(&self) -> Result<&crate::token::state::Mint, ProgramError> {
+	fn as_token_mint_checked(
+		&self,
+	) -> Result<AccountRef<'_, crate::token::state::Mint>, ProgramError> {
 		self.as_token_mint_checked_with_owners(&[crate::token::ID])
 	}
 
@@ -477,20 +484,29 @@ impl AsTokenAccount for AccountView {
 	fn as_token_mint_checked_with_owners(
 		&self,
 		owners: &[Address],
-	) -> Result<&crate::token::state::Mint, ProgramError> {
+	) -> Result<AccountRef<'_, crate::token::state::Mint>, ProgramError> {
 		self.assert_owners(owners)?;
 		self.as_token_mint()
 	}
 
-	fn as_token_account(&self) -> Result<&crate::token::state::TokenAccount, ProgramError> {
-		self.check_borrow()?;
+	fn as_token_account(
+		&self,
+	) -> Result<AccountRef<'_, crate::token::state::TokenAccount>, ProgramError> {
+		Ref::try_map(self.try_borrow()?, |data| {
+			if data.len() != crate::token::state::TokenAccount::LEN {
+				return Err(ProgramError::InvalidAccountData);
+			}
 
-		// SECURITY: see `as_token_mint` above.
-		unsafe { crate::token::state::TokenAccount::from_account_view_unchecked(self) }
+			// SECURITY: see `as_token_mint` above.
+			Ok(unsafe { crate::token::state::TokenAccount::from_bytes_unchecked(data) })
+		})
+		.map_err(|(_borrow, err)| err)
 	}
 
 	#[track_caller]
-	fn as_token_account_checked(&self) -> Result<&crate::token::state::TokenAccount, ProgramError> {
+	fn as_token_account_checked(
+		&self,
+	) -> Result<AccountRef<'_, crate::token::state::TokenAccount>, ProgramError> {
 		self.as_token_account_checked_with_owners(&[crate::token::ID])
 	}
 
@@ -498,20 +514,29 @@ impl AsTokenAccount for AccountView {
 	fn as_token_account_checked_with_owners(
 		&self,
 		owners: &[Address],
-	) -> Result<&crate::token::state::TokenAccount, ProgramError> {
+	) -> Result<AccountRef<'_, crate::token::state::TokenAccount>, ProgramError> {
 		self.assert_owners(owners)?;
 		self.as_token_account()
 	}
 
-	fn as_token_2022_mint(&self) -> Result<&crate::token_2022::state::Mint, ProgramError> {
-		self.check_borrow()?;
+	fn as_token_2022_mint(
+		&self,
+	) -> Result<AccountRef<'_, crate::token_2022::state::Mint>, ProgramError> {
+		Ref::try_map(self.try_borrow()?, |data| {
+			if data.len() < crate::token_2022::state::Mint::BASE_LEN {
+				return Err(ProgramError::InvalidAccountData);
+			}
 
-		// SECURITY: see `as_token_mint` above.
-		unsafe { crate::token_2022::state::Mint::from_account_view_unchecked(self) }
+			// SECURITY: see `as_token_mint` above.
+			Ok(unsafe { crate::token_2022::state::Mint::from_bytes_unchecked(data) })
+		})
+		.map_err(|(_borrow, err)| err)
 	}
 
 	#[track_caller]
-	fn as_token_2022_mint_checked(&self) -> Result<&crate::token_2022::state::Mint, ProgramError> {
+	fn as_token_2022_mint_checked(
+		&self,
+	) -> Result<AccountRef<'_, crate::token_2022::state::Mint>, ProgramError> {
 		self.as_token_2022_mint_checked_with_owners(&[crate::token_2022::ID])
 	}
 
@@ -519,24 +544,29 @@ impl AsTokenAccount for AccountView {
 	fn as_token_2022_mint_checked_with_owners(
 		&self,
 		owners: &[Address],
-	) -> Result<&crate::token_2022::state::Mint, ProgramError> {
+	) -> Result<AccountRef<'_, crate::token_2022::state::Mint>, ProgramError> {
 		self.assert_owners(owners)?;
 		self.as_token_2022_mint()
 	}
 
 	fn as_token_2022_account(
 		&self,
-	) -> Result<&crate::token_2022::state::TokenAccount, ProgramError> {
-		self.check_borrow()?;
+	) -> Result<AccountRef<'_, crate::token_2022::state::TokenAccount>, ProgramError> {
+		Ref::try_map(self.try_borrow()?, |data| {
+			if data.len() < crate::token_2022::state::TokenAccount::BASE_LEN {
+				return Err(ProgramError::InvalidAccountData);
+			}
 
-		// SECURITY: see `as_token_mint` above.
-		unsafe { crate::token_2022::state::TokenAccount::from_account_view_unchecked(self) }
+			// SECURITY: see `as_token_mint` above.
+			Ok(unsafe { crate::token_2022::state::TokenAccount::from_bytes_unchecked(data) })
+		})
+		.map_err(|(_borrow, err)| err)
 	}
 
 	#[track_caller]
 	fn as_token_2022_account_checked(
 		&self,
-	) -> Result<&crate::token_2022::state::TokenAccount, ProgramError> {
+	) -> Result<AccountRef<'_, crate::token_2022::state::TokenAccount>, ProgramError> {
 		self.as_token_2022_account_checked_with_owners(&[crate::token_2022::ID])
 	}
 
@@ -544,7 +574,7 @@ impl AsTokenAccount for AccountView {
 	fn as_token_2022_account_checked_with_owners(
 		&self,
 		owners: &[Address],
-	) -> Result<&crate::token_2022::state::TokenAccount, ProgramError> {
+	) -> Result<AccountRef<'_, crate::token_2022::state::TokenAccount>, ProgramError> {
 		self.assert_owners(owners)?;
 		self.as_token_2022_account()
 	}
@@ -554,16 +584,9 @@ impl AsTokenAccount for AccountView {
 		owner: &Address,
 		mint: &Address,
 		token_program: &Address,
-	) -> Result<&crate::token::state::TokenAccount, ProgramError> {
-		self.check_borrow()?;
-
-		// SECURITY: see `as_token_mint` above. Additionally, the address is
-		// verified against the derived ATA address before the unchecked cast.
-		unsafe {
-			crate::token::state::TokenAccount::from_account_view_unchecked(
-				self.assert_associated_token_address(owner, mint, token_program)?,
-			)
-		}
+	) -> Result<AccountRef<'_, crate::token::state::TokenAccount>, ProgramError> {
+		self.assert_associated_token_address(owner, mint, token_program)?;
+		self.as_token_account()
 	}
 
 	#[track_caller]
@@ -572,7 +595,7 @@ impl AsTokenAccount for AccountView {
 		owner: &Address,
 		mint: &Address,
 		token_program: &Address,
-	) -> Result<&crate::token::state::TokenAccount, ProgramError> {
+	) -> Result<AccountRef<'_, crate::token::state::TokenAccount>, ProgramError> {
 		self.assert_owner(token_program)?;
 		self.as_associated_token_account(owner, mint, token_program)
 	}

--- a/crates/pina/src/traits.rs
+++ b/crates/pina/src/traits.rs
@@ -5,6 +5,12 @@ use crate::AccountView;
 use crate::Address;
 use crate::ProgramError;
 
+/// Borrow-guarded immutable typed view into account data.
+pub type AccountRef<'a, T> = pinocchio::account::Ref<'a, T>;
+
+/// Borrow-guarded mutable typed view into account data.
+pub type AccountRefMut<'a, T> = pinocchio::account::RefMut<'a, T>;
+
 /// Zero-copy deserialization for on-chain account data.
 ///
 /// Validates the discriminator and reinterprets the byte slice as `&Self`
@@ -419,7 +425,8 @@ pub trait HasDiscriminator: Sized {
 /// Performs:
 /// 1. Program owner check
 /// 2. Discriminator byte check
-/// 3. Checked bytemuck conversion of account data to `&T` or `&mut T`.
+/// 3. Checked bytemuck conversion of account data to a borrow-guarded typed
+///    view.
 ///
 /// <!-- {=pinaPublicResultContract|trim|linePrefix:"/// ":true} -->/// All APIs in this section are designed for on-chain determinism.
 ///
@@ -432,25 +439,24 @@ pub trait HasDiscriminator: Sized {
 /// ```ignore
 /// // Inside an instruction handler:
 /// let escrow_account = &accounts[0];
-/// let escrow: &EscrowState = escrow_account.as_account(&program_id)?;
+/// let escrow = escrow_account.as_account::<EscrowState>(&program_id)?;
 ///
 /// // For mutable access:
-/// let escrow_mut: &mut EscrowState = escrow_account.as_account_mut(&program_id)?;
+/// let mut escrow_mut = escrow_account.as_account_mut::<EscrowState>(&program_id)?;
 /// escrow_mut.amount = PodU64::from(100u64);
 /// ```
 pub trait AsAccount {
 	/// Validate ownership and deserialize the account data into an immutable
-	/// reference of type `T`. Returns `InvalidAccountData` if the
+	/// borrow-guarded view of type `T`. Returns `InvalidAccountData` if the
 	/// discriminator doesn't match or the data is the wrong size.
-	fn as_account<T>(&self, program_id: &Address) -> Result<&T, ProgramError>
+	fn as_account<T>(&self, program_id: &Address) -> Result<AccountRef<'_, T>, ProgramError>
 	where
 		T: AccountDeserialize + HasDiscriminator + Pod;
 
 	/// Validate ownership and deserialize the account data into a mutable
-	/// reference of type `T`. The Solana runtime guarantees exclusive access
-	/// when the mutable borrow succeeds.
-	#[allow(clippy::mut_from_ref)]
-	fn as_account_mut<T>(&self, program_id: &Address) -> Result<&mut T, ProgramError>
+	/// borrow-guarded view of type `T`. The Solana runtime guarantees
+	/// exclusive access when the mutable borrow succeeds.
+	fn as_account_mut<T>(&self, program_id: &Address) -> Result<AccountRefMut<'_, T>, ProgramError>
 	where
 		T: AccountDeserialize + HasDiscriminator + Pod;
 }
@@ -465,50 +471,60 @@ pub trait AsAccount {
 #[cfg(feature = "token")]
 pub trait AsTokenAccount {
 	/// Interpret the account data as an SPL Token mint.
-	fn as_token_mint(&self) -> Result<&crate::token::state::Mint, ProgramError>;
+	fn as_token_mint(&self) -> Result<AccountRef<'_, crate::token::state::Mint>, ProgramError>;
 	/// Interpret the account data as an SPL Token mint, validating owner.
-	fn as_token_mint_checked(&self) -> Result<&crate::token::state::Mint, ProgramError>;
+	fn as_token_mint_checked(
+		&self,
+	) -> Result<AccountRef<'_, crate::token::state::Mint>, ProgramError>;
 	/// Interpret the account data as an SPL Token mint, validating owner is one
 	/// of the provided program ids.
 	fn as_token_mint_checked_with_owners(
 		&self,
 		owners: &[Address],
-	) -> Result<&crate::token::state::Mint, ProgramError>;
+	) -> Result<AccountRef<'_, crate::token::state::Mint>, ProgramError>;
 	/// Interpret the account data as an SPL Token account.
-	fn as_token_account(&self) -> Result<&crate::token::state::TokenAccount, ProgramError>;
+	fn as_token_account(
+		&self,
+	) -> Result<AccountRef<'_, crate::token::state::TokenAccount>, ProgramError>;
 	/// Interpret the account data as an SPL Token account, validating owner.
-	fn as_token_account_checked(&self) -> Result<&crate::token::state::TokenAccount, ProgramError>;
+	fn as_token_account_checked(
+		&self,
+	) -> Result<AccountRef<'_, crate::token::state::TokenAccount>, ProgramError>;
 	/// Interpret the account data as an SPL Token account, validating owner is
 	/// one of the provided program ids.
 	fn as_token_account_checked_with_owners(
 		&self,
 		owners: &[Address],
-	) -> Result<&crate::token::state::TokenAccount, ProgramError>;
+	) -> Result<AccountRef<'_, crate::token::state::TokenAccount>, ProgramError>;
 	/// Interpret the account data as a Token-2022 mint.
-	fn as_token_2022_mint(&self) -> Result<&crate::token_2022::state::Mint, ProgramError>;
+	fn as_token_2022_mint(
+		&self,
+	) -> Result<AccountRef<'_, crate::token_2022::state::Mint>, ProgramError>;
 	/// Interpret the account data as a Token-2022 mint, validating owner.
-	fn as_token_2022_mint_checked(&self) -> Result<&crate::token_2022::state::Mint, ProgramError>;
+	fn as_token_2022_mint_checked(
+		&self,
+	) -> Result<AccountRef<'_, crate::token_2022::state::Mint>, ProgramError>;
 	/// Interpret the account data as a Token-2022 mint, validating owner is one
 	/// of the provided program ids.
 	fn as_token_2022_mint_checked_with_owners(
 		&self,
 		owners: &[Address],
-	) -> Result<&crate::token_2022::state::Mint, ProgramError>;
+	) -> Result<AccountRef<'_, crate::token_2022::state::Mint>, ProgramError>;
 	/// Interpret the account data as a Token-2022 token account.
 	fn as_token_2022_account(
 		&self,
-	) -> Result<&crate::token_2022::state::TokenAccount, ProgramError>;
+	) -> Result<AccountRef<'_, crate::token_2022::state::TokenAccount>, ProgramError>;
 	/// Interpret the account data as a Token-2022 token account, validating
 	/// owner.
 	fn as_token_2022_account_checked(
 		&self,
-	) -> Result<&crate::token_2022::state::TokenAccount, ProgramError>;
+	) -> Result<AccountRef<'_, crate::token_2022::state::TokenAccount>, ProgramError>;
 	/// Interpret the account data as a Token-2022 token account, validating
 	/// owner is one of the provided program ids.
 	fn as_token_2022_account_checked_with_owners(
 		&self,
 		owners: &[Address],
-	) -> Result<&crate::token_2022::state::TokenAccount, ProgramError>;
+	) -> Result<AccountRef<'_, crate::token_2022::state::TokenAccount>, ProgramError>;
 	/// Interpret the account data as an associated token account, verifying
 	/// the address matches the derived ATA for the given wallet, mint, and
 	/// token program.
@@ -517,7 +533,7 @@ pub trait AsTokenAccount {
 		owner: &Address,
 		mint: &Address,
 		token_program: &Address,
-	) -> Result<&crate::token::state::TokenAccount, ProgramError>;
+	) -> Result<AccountRef<'_, crate::token::state::TokenAccount>, ProgramError>;
 	/// Interpret the account data as an associated token account, validating
 	/// both owner and ATA derivation.
 	fn as_associated_token_account_checked(
@@ -525,7 +541,7 @@ pub trait AsTokenAccount {
 		owner: &Address,
 		mint: &Address,
 		token_program: &Address,
-	) -> Result<&crate::token::state::TokenAccount, ProgramError>;
+	) -> Result<AccountRef<'_, crate::token::state::TokenAccount>, ProgramError>;
 }
 
 /// Direct lamport transfer between accounts.
@@ -921,8 +937,8 @@ mod tests {
 
 	#[test]
 	fn max_discriminator_space_is_u64_size() {
-		assert_eq!(crate::MAX_DISCRIMINATOR_SPACE, 8);
-		assert_eq!(crate::MAX_DISCRIMINATOR_SPACE, size_of::<u64>());
+		assert_eq!(MAX_DISCRIMINATOR_SPACE, 8);
+		assert_eq!(MAX_DISCRIMINATOR_SPACE, size_of::<u64>());
 	}
 
 	/// Verify that field values round-trip through AccountDeserialize.

--- a/crates/pina/tests/integration.rs
+++ b/crates/pina/tests/integration.rs
@@ -14,6 +14,7 @@
 #![allow(unsafe_code, dead_code)]
 
 use core::alloc::Layout;
+use core::mem::size_of;
 use core::mem::MaybeUninit;
 use core::ptr::copy_nonoverlapping;
 use std::alloc::alloc;
@@ -153,7 +154,7 @@ impl<'a> ProcessAccountInfos<'a> for UpdateAccounts<'a> {
 			.assert_type::<TestState>(&TEST_PROGRAM_ID)?;
 
 		// Update state.
-		let state = self
+		let mut state = self
 			.state_account
 			.as_account_mut::<TestState>(&TEST_PROGRAM_ID)?;
 		state.value = args.new_value;
@@ -174,7 +175,7 @@ impl<'a> ProcessAccountInfos<'a> for CloseAccounts<'a> {
 			.assert_type::<TestState>(&TEST_PROGRAM_ID)?;
 
 		// Zero account data before closing.
-		let state = self
+		let mut state = self
 			.state_account
 			.as_account_mut::<TestState>(&TEST_PROGRAM_ID)?;
 		state.zeroed();
@@ -1433,7 +1434,7 @@ fn account_data_mutation_persists() {
 
 	// Mutate value.
 	{
-		let state = account_views[0]
+		let mut state = account_views[0]
 			.as_account_mut::<TestState>(&TEST_PROGRAM_ID)
 			.unwrap_or_else(|e| panic!("write failed: {e:?}"));
 		state.value = PodU64::from_primitive(12345);
@@ -1445,6 +1446,66 @@ fn account_data_mutation_persists() {
 		.unwrap_or_else(|e| panic!("read failed: {e:?}"));
 	assert_eq!(u64::from(state.value), 12345);
 	assert_eq!(state.bump, 10, "bump should be unchanged");
+}
+
+#[test]
+fn mutable_typed_borrow_blocks_second_mutable_borrow() {
+	let key: Address = address!("BHvLHF6mJpWxywWY5S2tsHdDtHirHyeRxoS6uF6T5FoY");
+	let state_bytes = build_test_state_bytes(10, 500);
+
+	let accounts = [AccountBuilder::new()
+		.address(key)
+		.owner(TEST_PROGRAM_ID)
+		.lamports(1_000_000)
+		.data(&state_bytes)
+		.is_writable(true)];
+
+	let dummy_data: &[u8] = &[0u8];
+	let mut input = unsafe { create_test_input(&accounts, dummy_data) };
+	let mut accts = [UNINIT; 10];
+	let (_, account_views, ..) = unsafe { deserialize_test_input::<10>(&mut input, &mut accts) };
+
+	let first = account_views[0]
+		.as_account_mut::<TestState>(&TEST_PROGRAM_ID)
+		.unwrap_or_else(|e| panic!("first mutable borrow failed: {e:?}"));
+	let second = account_views[0].as_account_mut::<TestState>(&TEST_PROGRAM_ID);
+
+	assert!(matches!(second, Err(ProgramError::AccountBorrowFailed)));
+	drop(first);
+	assert!(account_views[0].as_account_mut::<TestState>(&TEST_PROGRAM_ID).is_ok());
+}
+
+#[test]
+fn immutable_typed_borrow_blocks_mutation_and_resize() {
+	let key: Address = address!("BHvLHF6mJpWxywWY5S2tsHdDtHirHyeRxoS6uF6T5FoY");
+	let state_bytes = build_test_state_bytes(10, 500);
+
+	let accounts = [AccountBuilder::new()
+		.address(key)
+		.owner(TEST_PROGRAM_ID)
+		.lamports(1_000_000)
+		.data(&state_bytes)
+		.is_writable(true)];
+
+	let dummy_data: &[u8] = &[0u8];
+	let mut input = unsafe { create_test_input(&accounts, dummy_data) };
+	let mut accts = [UNINIT; 10];
+	let (_, account_views, ..) = unsafe { deserialize_test_input::<10>(&mut input, &mut accts) };
+
+	let state = account_views[0]
+		.as_account::<TestState>(&TEST_PROGRAM_ID)
+		.unwrap_or_else(|e| panic!("immutable borrow failed: {e:?}"));
+
+	assert!(matches!(
+		account_views[0].as_account_mut::<TestState>(&TEST_PROGRAM_ID),
+		Err(ProgramError::AccountBorrowFailed)
+	));
+	assert_eq!(
+		account_views[0].resize(size_of::<TestState>() + 1),
+		Err(ProgramError::AccountBorrowFailed)
+	);
+	drop(state);
+	assert!(account_views[0].as_account_mut::<TestState>(&TEST_PROGRAM_ID).is_ok());
 }
 
 // ---------------------------------------------------------------------------

--- a/devenv.nix
+++ b/devenv.nix
@@ -397,6 +397,7 @@ in
       exec = ''
         set -e
         lint:clippy
+        lint:dylint
         lint:format
         verify:docs
       '';
@@ -461,6 +462,14 @@ in
         cargo clippy --workspace --all-features --locked ''${exclude_args[@]}
       '';
       description = "Check that all rust lints are passing.";
+      binary = "bash";
+    };
+    "lint:dylint" = {
+      exec = ''
+        set -e
+        cargo dylint --all -- --all-targets
+      '';
+      description = "Run custom security dylints.";
       binary = "bash";
     };
     "setup:vscode" = {

--- a/examples/anchor_floats/src/lib.rs
+++ b/examples/anchor_floats/src/lib.rs
@@ -103,8 +103,8 @@ impl<'a> ProcessAccountInfos<'a> for CreateAccounts<'a> {
 			&ID,
 		)?;
 
-		let account = self.account.as_account_mut::<FloatDataAccount>(&ID)?;
-		apply_create(account, self.authority.address(), data_f32, data_f64);
+		let mut account = self.account.as_account_mut::<FloatDataAccount>(&ID)?;
+		apply_create(&mut account, self.authority.address(), data_f32, data_f64);
 
 		Ok(())
 	}
@@ -121,8 +121,8 @@ impl<'a> ProcessAccountInfos<'a> for UpdateAccounts<'a> {
 			.assert_writable()?
 			.assert_type::<FloatDataAccount>(&ID)?;
 
-		let account = self.account.as_account_mut::<FloatDataAccount>(&ID)?;
-		apply_update(account, self.authority.address(), data_f32, data_f64)
+		let mut account = self.account.as_account_mut::<FloatDataAccount>(&ID)?;
+		apply_update(&mut account, self.authority.address(), data_f32, data_f64)
 	}
 }
 

--- a/examples/counter_program/src/lib.rs
+++ b/examples/counter_program/src/lib.rs
@@ -211,7 +211,7 @@ impl<'a> ProcessAccountInfos<'a> for InitializeAccounts<'a> {
 
 		// `as_account_mut` deserializes the raw account bytes into a mutable
 		// reference to `CounterState`, verifying the owner and discriminator.
-		let counter = self.counter.as_account_mut::<CounterState>(&ID)?;
+		let mut counter = self.counter.as_account_mut::<CounterState>(&ID)?;
 		*counter = CounterState::builder()
 			.bump(args.bump)
 			.count(PodU64::from_primitive(0))
@@ -248,7 +248,7 @@ impl<'a> ProcessAccountInfos<'a> for IncrementAccounts<'a> {
 
 		// --- Mutate state ---
 
-		let counter = self.counter.as_account_mut::<CounterState>(&ID)?;
+		let mut counter = self.counter.as_account_mut::<CounterState>(&ID)?;
 		let current: u64 = counter.count.into();
 		counter.count = PodU64::from_primitive(
 			current

--- a/examples/escrow_program/src/lib.rs
+++ b/examples/escrow_program/src/lib.rs
@@ -135,16 +135,17 @@ impl<'a> ProcessAccountInfos<'a> for MakeAccounts<'a> {
 		let token_program = self.token_program.address();
 
 		// assertions
-		self.token_program.assert_addresses(&SPL_PROGRAM_IDS)?;
-		self.maker.assert_signer()?;
-		self.mint_a.assert_owner(token_program)?;
-		self.mint_b.assert_owner(token_program)?;
-		self.maker_ata_a
-			.assert_owner(token_program)?
-			.assert_associated_token_address(
-			self.maker.address(),
-			self.mint_a.address(),
-			token_program,
+			self.token_program.assert_addresses(&SPL_PROGRAM_IDS)?;
+			self.maker.assert_signer()?;
+			self.mint_a.assert_owner(token_program)?;
+			self.mint_b.assert_owner(token_program)?;
+			self.maker_ata_a
+				.assert_writable()?
+				.assert_owner(token_program)?
+				.assert_associated_token_address(
+				self.maker.address(),
+				self.mint_a.address(),
+				token_program,
 		)?;
 		self.escrow
 			.assert_empty()?
@@ -188,14 +189,18 @@ impl<'a> ProcessAccountInfos<'a> for MakeAccounts<'a> {
 			mint: self.mint_a,
 			system_program: self.system_program,
 			token_program: self.token_program,
-		}
-		.invoke()?;
+			}
+			.invoke()?;
 
-		let decimals = self.mint_a.as_token_mint()?.decimals();
-		token_2022::instructions::TransferChecked {
-			from: self.maker_ata_a,
-			to: self.vault,
-			authority: self.maker,
+			let decimals = if token_program == &token_2022::ID {
+				self.mint_a.as_token_2022_mint()?.decimals()
+			} else {
+				self.mint_a.as_token_mint()?.decimals()
+			};
+			token_2022::instructions::TransferChecked {
+				from: self.maker_ata_a,
+				to: self.vault,
+				authority: self.maker,
 			amount: args.amount_a.into(),
 			mint: self.mint_a,
 			decimals,
@@ -229,27 +234,35 @@ impl<'a> ProcessAccountInfos<'a> for TakeAccounts<'a> {
 		let token_program = self.token_program.address();
 
 		// -- assertions --
-		self.token_program.assert_addresses(&SPL_PROGRAM_IDS)?;
-		self.taker.assert_signer()?.assert_writable()?;
-		self.taker_ata_b
-			.assert_owner(token_program)?
-			.assert_associated_token_address(
-				self.taker.address(),
-				self.mint_b.address(),
-				token_program,
-			)?;
-		self.taker_ata_a
-			.assert_owner(token_program)?
-			.assert_data_len(token::state::TokenAccount::LEN)?
-			.assert_associated_token_address(
-				self.taker.address(),
-				self.mint_a.address(),
-				token_program,
-			)?;
-		self.escrow
-			.assert_not_empty()?
-			.assert_writable()?
-			.assert_type::<EscrowState>(&ID)?;
+			self.token_program.assert_addresses(&SPL_PROGRAM_IDS)?;
+			self.taker.assert_signer()?.assert_writable()?;
+			self.taker_ata_b
+				.assert_writable()?
+				.assert_owner(token_program)?
+				.assert_associated_token_address(
+					self.taker.address(),
+					self.mint_b.address(),
+					token_program,
+				)?;
+			let taker_ata_a = self.taker_ata_a
+				.assert_writable()?
+				.assert_owner(token_program)?
+				.assert_associated_token_address(
+					self.taker.address(),
+					self.mint_a.address(),
+					token_program,
+				)?;
+			if token_program == &token_2022::ID {
+				taker_ata_a.as_token_2022_account()?;
+			} else {
+				taker_ata_a
+					.assert_data_len(token::state::TokenAccount::LEN)?
+					.as_token_account()?;
+			}
+			self.escrow
+				.assert_not_empty()?
+				.assert_writable()?
+				.assert_type::<EscrowState>(&ID)?;
 
 		let (maker, mint_a, mint_b, amount_b, seed, bump) = {
 			let escrow = self.escrow.as_account::<EscrowState>(&ID)?;
@@ -292,16 +305,20 @@ impl<'a> ProcessAccountInfos<'a> for TakeAccounts<'a> {
 		}
 		.invoke()?;
 
-		token_2022::instructions::TransferChecked {
-			from: self.taker_ata_b,
-			mint: self.mint_b,
-			to: self.maker_ata_b,
-			authority: self.taker,
-			amount: amount_b.into(),
-			decimals: self.mint_b.as_token_2022_mint()?.decimals(),
-			token_program: self.token_program.address(),
-		}
-		.invoke()?;
+			token_2022::instructions::TransferChecked {
+				from: self.taker_ata_b,
+				mint: self.mint_b,
+				to: self.maker_ata_b,
+				authority: self.taker,
+				amount: amount_b.into(),
+				decimals: if token_program == &token_2022::ID {
+					self.mint_b.as_token_2022_mint()?.decimals()
+				} else {
+					self.mint_b.as_token_mint()?.decimals()
+				},
+				token_program: self.token_program.address(),
+			}
+			.invoke()?;
 
 		let bump_as_seeds = [bump];
 		let escrow_seeds =
@@ -309,15 +326,23 @@ impl<'a> ProcessAccountInfos<'a> for TakeAccounts<'a> {
 		let escrow_signer = Signer::from(&escrow_seeds);
 		let signers = [escrow_signer];
 
-		token_2022::instructions::TransferChecked {
-			from: self.vault,
-			mint: self.mint_a,
-			to: self.taker_ata_a,
-			authority: self.escrow,
-			amount: self.vault.as_token_2022_account()?.amount(),
-			decimals: self.mint_a.as_token_2022_mint()?.decimals(),
-			token_program: self.token_program.address(),
-		}
+			token_2022::instructions::TransferChecked {
+				from: self.vault,
+				mint: self.mint_a,
+				to: self.taker_ata_a,
+				authority: self.escrow,
+				amount: if token_program == &token_2022::ID {
+					self.vault.as_token_2022_account()?.amount()
+				} else {
+					self.vault.as_token_account()?.amount()
+				},
+				decimals: if token_program == &token_2022::ID {
+					self.mint_a.as_token_2022_mint()?.decimals()
+				} else {
+					self.mint_a.as_token_mint()?.decimals()
+				},
+				token_program: self.token_program.address(),
+			}
 		.invoke_signed(&signers)?;
 		token_2022::instructions::CloseAccount {
 			account: self.vault,

--- a/examples/escrow_program/src/lib.rs
+++ b/examples/escrow_program/src/lib.rs
@@ -165,7 +165,7 @@ impl<'a> ProcessAccountInfos<'a> for MakeAccounts<'a> {
 			args.bump,
 		)?;
 
-		let escrow = self.escrow.as_account_mut::<EscrowState>(&ID)?;
+		let mut escrow = self.escrow.as_account_mut::<EscrowState>(&ID)?;
 		*escrow = EscrowState::builder()
 			.maker(*self.maker.address())
 			.mint_a(*self.mint_a.address())
@@ -225,9 +225,13 @@ impl<'a> ProcessAccountInfos<'a> for TakeAccounts<'a> {
 		// -- assertions --
 		self.token_program.assert_addresses(&SPL_PROGRAM_IDS)?;
 		self.taker.assert_signer()?.assert_writable()?;
-		// TODO: add validation for `self.taker_ata_b` — currently it is only
-		// validated implicitly by the token program during the transfer CPI. An
-		// explicit ATA address check here would catch mismatches earlier.
+		self.taker_ata_b
+			.assert_owners(&SPL_PROGRAM_IDS)?
+			.assert_associated_token_address(
+				self.taker.address(),
+				self.mint_b.address(),
+				self.token_program.address(),
+			)?;
 		self.taker_ata_a
 			.assert_owners(&SPL_PROGRAM_IDS)?
 			.assert_data_len(token::state::TokenAccount::LEN)?
@@ -241,26 +245,25 @@ impl<'a> ProcessAccountInfos<'a> for TakeAccounts<'a> {
 			.assert_writable()?
 			.assert_type::<EscrowState>(&ID)?;
 
-		let EscrowState {
-			maker,
-			mint_a,
-			mint_b,
-			amount_b,
-			seed,
-			bump,
-			..
-		} = self.escrow.as_account::<EscrowState>(&ID)?;
-		let escrow_seeds_with_bump = seeds_escrow!(self.maker.address().as_ref(), &seed.0, *bump);
+		let escrow = self.escrow.as_account::<EscrowState>(&ID)?;
+		let maker = escrow.maker;
+		let mint_a = escrow.mint_a;
+		let mint_b = escrow.mint_b;
+		let amount_b = escrow.amount_b;
+		let seed = escrow.seed;
+		let bump = escrow.bump;
+		let escrow_seeds_with_bump =
+			seeds_escrow!(self.maker.address().as_ref(), &seed.0, bump);
 
 		self.escrow
 			.assert_seeds_with_bump(escrow_seeds_with_bump, &ID)?;
-		self.maker.assert_address(maker)?;
+		self.maker.assert_address(&maker)?;
 		self.mint_a
 			.assert_owners(&SPL_PROGRAM_IDS)?
-			.assert_address(mint_a)?;
+			.assert_address(&mint_a)?;
 		self.mint_b
 			.assert_owners(&SPL_PROGRAM_IDS)?
-			.assert_address(mint_b)?;
+			.assert_address(&mint_b)?;
 
 		self.vault
 			.assert_not_empty()?
@@ -287,13 +290,13 @@ impl<'a> ProcessAccountInfos<'a> for TakeAccounts<'a> {
 			mint: self.mint_b,
 			to: self.maker_ata_b,
 			authority: self.taker,
-			amount: (*amount_b).into(),
+			amount: amount_b.into(),
 			decimals: self.mint_b.as_token_2022_mint()?.decimals(),
 			token_program: self.token_program.address(),
 		}
 		.invoke()?;
 
-		let bump_as_seeds = [*bump];
+		let bump_as_seeds = [bump];
 		let escrow_seeds =
 			seeds_escrow!(true, self.maker.address().as_ref(), &seed.0, &bump_as_seeds);
 		let escrow_signer = Signer::from(&escrow_seeds);
@@ -317,9 +320,7 @@ impl<'a> ProcessAccountInfos<'a> for TakeAccounts<'a> {
 		}
 		.invoke_signed(&signers)?;
 
-		{
-			self.escrow.as_account_mut::<EscrowState>(&ID)?.zeroed();
-		}
+		self.escrow.as_account_mut::<EscrowState>(&ID)?.zeroed();
 
 		self.escrow.close_with_recipient(self.maker)
 	}

--- a/examples/escrow_program/src/lib.rs
+++ b/examples/escrow_program/src/lib.rs
@@ -132,16 +132,19 @@ impl<'a> ProcessAccountInfos<'a> for MakeAccounts<'a> {
 		let escrow_seeds = seeds_escrow!(self.maker.address().as_ref(), &args.seed.0);
 		let escrow_seeds_with_bump =
 			seeds_escrow!(self.maker.address().as_ref(), &args.seed.0, args.bump);
+		let token_program = self.token_program.address();
 
 		// assertions
 		self.token_program.assert_addresses(&SPL_PROGRAM_IDS)?;
 		self.maker.assert_signer()?;
-		self.mint_a.assert_owners(&SPL_PROGRAM_IDS)?;
-		self.mint_b.assert_owners(&SPL_PROGRAM_IDS)?;
-		self.maker_ata_a.assert_associated_token_address(
+		self.mint_a.assert_owner(token_program)?;
+		self.mint_b.assert_owner(token_program)?;
+		self.maker_ata_a
+			.assert_owner(token_program)?
+			.assert_associated_token_address(
 			self.maker.address(),
 			self.mint_a.address(),
-			self.token_program.address(),
+			token_program,
 		)?;
 		self.escrow
 			.assert_empty()?
@@ -150,10 +153,11 @@ impl<'a> ProcessAccountInfos<'a> for MakeAccounts<'a> {
 		self.vault
 			.assert_empty()?
 			.assert_writable()?
+			.assert_owner(token_program)?
 			.assert_associated_token_address(
 				self.escrow.address(),
 				self.mint_a.address(),
-				self.token_program.address(),
+				token_program,
 			)?;
 
 		// create the program account
@@ -221,24 +225,25 @@ impl<'a> ProcessAccountInfos<'a> for TakeAccounts<'a> {
 	fn process(&self, data: &[u8]) -> ProgramResult {
 		// Validate the discriminator; TakeInstruction has no payload fields.
 		let _ = TakeInstruction::try_from_bytes(data)?;
+		let token_program = self.token_program.address();
 
 		// -- assertions --
 		self.token_program.assert_addresses(&SPL_PROGRAM_IDS)?;
 		self.taker.assert_signer()?.assert_writable()?;
 		self.taker_ata_b
-			.assert_owners(&SPL_PROGRAM_IDS)?
+			.assert_owner(token_program)?
 			.assert_associated_token_address(
 				self.taker.address(),
 				self.mint_b.address(),
-				self.token_program.address(),
+				token_program,
 			)?;
 		self.taker_ata_a
-			.assert_owners(&SPL_PROGRAM_IDS)?
+			.assert_owner(token_program)?
 			.assert_data_len(token::state::TokenAccount::LEN)?
 			.assert_associated_token_address(
 				self.taker.address(),
 				self.mint_a.address(),
-				self.token_program.address(),
+				token_program,
 			)?;
 		self.escrow
 			.assert_not_empty()?
@@ -262,20 +267,17 @@ impl<'a> ProcessAccountInfos<'a> for TakeAccounts<'a> {
 		self.escrow
 			.assert_seeds_with_bump(escrow_seeds_with_bump, &ID)?;
 		self.maker.assert_address(&maker)?;
-		self.mint_a
-			.assert_owners(&SPL_PROGRAM_IDS)?
-			.assert_address(&mint_a)?;
-		self.mint_b
-			.assert_owners(&SPL_PROGRAM_IDS)?
-			.assert_address(&mint_b)?;
+		self.mint_a.assert_owner(token_program)?.assert_address(&mint_a)?;
+		self.mint_b.assert_owner(token_program)?.assert_address(&mint_b)?;
 
 		self.vault
 			.assert_not_empty()?
 			.assert_writable()?
+			.assert_owner(token_program)?
 			.assert_associated_token_address(
 				self.escrow.address(),
 				self.mint_a.address(),
-				self.token_program.address(),
+				token_program,
 			)?;
 
 		// create token account if none exists

--- a/examples/escrow_program/src/lib.rs
+++ b/examples/escrow_program/src/lib.rs
@@ -153,7 +153,6 @@ impl<'a> ProcessAccountInfos<'a> for MakeAccounts<'a> {
 		self.vault
 			.assert_empty()?
 			.assert_writable()?
-			.assert_owner(token_program)?
 			.assert_associated_token_address(
 				self.escrow.address(),
 				self.mint_a.address(),
@@ -169,16 +168,18 @@ impl<'a> ProcessAccountInfos<'a> for MakeAccounts<'a> {
 			args.bump,
 		)?;
 
-		let mut escrow = self.escrow.as_account_mut::<EscrowState>(&ID)?;
-		*escrow = EscrowState::builder()
-			.maker(*self.maker.address())
-			.mint_a(*self.mint_a.address())
-			.mint_b(*self.mint_b.address())
-			.amount_a(args.amount_a)
-			.amount_b(args.amount_b)
-			.seed(args.seed)
-			.bump(args.bump)
-			.build();
+		{
+			let mut escrow = self.escrow.as_account_mut::<EscrowState>(&ID)?;
+			*escrow = EscrowState::builder()
+				.maker(*self.maker.address())
+				.mint_a(*self.mint_a.address())
+				.mint_b(*self.mint_b.address())
+				.amount_a(args.amount_a)
+				.amount_b(args.amount_b)
+				.seed(args.seed)
+				.bump(args.bump)
+				.build();
+		}
 
 		associated_token_account::instructions::Create {
 			account: self.vault,

--- a/examples/escrow_program/src/lib.rs
+++ b/examples/escrow_program/src/lib.rs
@@ -245,13 +245,17 @@ impl<'a> ProcessAccountInfos<'a> for TakeAccounts<'a> {
 			.assert_writable()?
 			.assert_type::<EscrowState>(&ID)?;
 
-		let escrow = self.escrow.as_account::<EscrowState>(&ID)?;
-		let maker = escrow.maker;
-		let mint_a = escrow.mint_a;
-		let mint_b = escrow.mint_b;
-		let amount_b = escrow.amount_b;
-		let seed = escrow.seed;
-		let bump = escrow.bump;
+		let (maker, mint_a, mint_b, amount_b, seed, bump) = {
+			let escrow = self.escrow.as_account::<EscrowState>(&ID)?;
+			(
+				escrow.maker,
+				escrow.mint_a,
+				escrow.mint_b,
+				escrow.amount_b,
+				escrow.seed,
+				escrow.bump,
+			)
+		};
 		let escrow_seeds_with_bump =
 			seeds_escrow!(self.maker.address().as_ref(), &seed.0, bump);
 

--- a/examples/todo_program/src/lib.rs
+++ b/examples/todo_program/src/lib.rs
@@ -97,7 +97,7 @@ impl<'a> ProcessAccountInfos<'a> for InitializeAccounts<'a> {
 			self.todo, self.owner, &ID, seeds, args.bump,
 		)?;
 
-		let todo = self.todo.as_account_mut::<TodoState>(&ID)?;
+		let mut todo = self.todo.as_account_mut::<TodoState>(&ID)?;
 		*todo = TodoState::builder()
 			.owner(*owner)
 			.bump(args.bump)
@@ -127,13 +127,13 @@ impl<'a> ProcessAccountInfos<'a> for UpdateAccounts<'a> {
 		match parse_instruction::<TodoInstruction>(&ID, &ID, data)? {
 			TodoInstruction::ToggleCompleted => {
 				let _ = ToggleCompletedInstruction::try_from_bytes(data)?;
-				let todo = self.todo.as_account_mut::<TodoState>(&ID)?;
+				let mut todo = self.todo.as_account_mut::<TodoState>(&ID)?;
 				let completed = bool::from(todo.completed);
 				todo.completed = PodBool::from_bool(!completed);
 			}
 			TodoInstruction::UpdateDigest => {
 				let args = UpdateDigestInstruction::try_from_bytes(data)?;
-				let todo = self.todo.as_account_mut::<TodoState>(&ID)?;
+				let mut todo = self.todo.as_account_mut::<TodoState>(&ID)?;
 				todo.digest = args.digest;
 			}
 			TodoInstruction::Initialize => return Err(ProgramError::InvalidInstructionData),

--- a/security/00-signer-authorization/insecure/src/lib.rs
+++ b/security/00-signer-authorization/insecure/src/lib.rs
@@ -54,7 +54,7 @@ impl<'a> ProcessAccountInfos<'a> for WithdrawAccounts<'a> {
 			.assert_writable()?
 			.assert_type::<VaultState>(&ID)?;
 
-		let vault = self.vault.as_account_mut::<VaultState>(&ID)?;
+		let mut vault = self.vault.as_account_mut::<VaultState>(&ID)?;
 		let current: u64 = vault.balance.into();
 		let amount: u64 = args.amount.into();
 		vault.balance = PodU64::from_primitive(current.saturating_sub(amount));

--- a/security/00-signer-authorization/secure/src/lib.rs
+++ b/security/00-signer-authorization/secure/src/lib.rs
@@ -60,7 +60,7 @@ impl<'a> ProcessAccountInfos<'a> for WithdrawAccounts<'a> {
 		// Also verify the authority matches the vault's stored authority.
 		self.authority.assert_address(&vault.authority)?;
 
-		let vault = self.vault.as_account_mut::<VaultState>(&ID)?;
+		let mut vault = self.vault.as_account_mut::<VaultState>(&ID)?;
 		let current: u64 = vault.balance.into();
 		let amount: u64 = args.amount.into();
 		vault.balance = PodU64::from_primitive(checked_withdraw_balance(current, amount)?);

--- a/security/03-type-cosplay/secure/src/lib.rs
+++ b/security/03-type-cosplay/secure/src/lib.rs
@@ -60,7 +60,7 @@ impl<'a> ProcessAccountInfos<'a> for AdminActionAccounts<'a> {
 		let config = self.config.as_account::<AdminConfig>(&ID)?;
 		self.authority.assert_address(&config.authority)?;
 
-		let config_mut = self.config.as_account_mut::<AdminConfig>(&ID)?;
+		let mut config_mut = self.config.as_account_mut::<AdminConfig>(&ID)?;
 		config_mut.fee = args.new_fee;
 
 		Ok(())

--- a/security/04-initialization/insecure/src/lib.rs
+++ b/security/04-initialization/insecure/src/lib.rs
@@ -69,7 +69,7 @@ impl<'a> ProcessAccountInfos<'a> for InitializeAccounts<'a> {
 			args.bump,
 		)?;
 
-		let config = self.config.as_account_mut::<Config>(&ID)?;
+		let mut config = self.config.as_account_mut::<Config>(&ID)?;
 		*config = Config::builder()
 			.authority(*self.authority.address())
 			.value(args.value)

--- a/security/04-initialization/secure/src/lib.rs
+++ b/security/04-initialization/secure/src/lib.rs
@@ -64,7 +64,7 @@ impl<'a> ProcessAccountInfos<'a> for InitializeAccounts<'a> {
 			args.bump,
 		)?;
 
-		let config = self.config.as_account_mut::<Config>(&ID)?;
+		let mut config = self.config.as_account_mut::<Config>(&ID)?;
 		*config = Config::builder()
 			.authority(*self.authority.address())
 			.value(args.value)

--- a/security/06-duplicate-mutable-accounts/insecure/src/lib.rs
+++ b/security/06-duplicate-mutable-accounts/insecure/src/lib.rs
@@ -57,11 +57,11 @@ impl<'a> ProcessAccountInfos<'a> for TransferAccounts<'a> {
 		// operate on the same account.
 		let amount: u64 = args.amount.into();
 
-		let source = self.source.as_account_mut::<Balance>(&ID)?;
+		let mut source = self.source.as_account_mut::<Balance>(&ID)?;
 		let source_amount: u64 = source.amount.into();
 		source.amount = PodU64::from_primitive(source_amount.saturating_sub(amount));
 
-		let dest = self.dest.as_account_mut::<Balance>(&ID)?;
+		let mut dest = self.dest.as_account_mut::<Balance>(&ID)?;
 		let dest_amount: u64 = dest.amount.into();
 		dest.amount = PodU64::from_primitive(dest_amount.saturating_add(amount));
 

--- a/security/06-duplicate-mutable-accounts/secure/src/lib.rs
+++ b/security/06-duplicate-mutable-accounts/secure/src/lib.rs
@@ -76,10 +76,10 @@ impl<'a> ProcessAccountInfos<'a> for TransferAccounts<'a> {
 
 		let amount: u64 = args.amount.into();
 
-		let source = self.source.as_account_mut::<Balance>(&ID)?;
+		let mut source = self.source.as_account_mut::<Balance>(&ID)?;
 		let source_amount: u64 = source.amount.into();
 
-		let dest = self.dest.as_account_mut::<Balance>(&ID)?;
+		let mut dest = self.dest.as_account_mut::<Balance>(&ID)?;
 		let dest_amount: u64 = dest.amount.into();
 		let (new_source, new_dest) = checked_transfer_balances(source_amount, dest_amount, amount)?;
 		source.amount = PodU64::from_primitive(new_source);

--- a/security/07-bump-seed-canonicalization/insecure/src/lib.rs
+++ b/security/07-bump-seed-canonicalization/insecure/src/lib.rs
@@ -69,7 +69,7 @@ impl<'a> ProcessAccountInfos<'a> for CreateAccounts<'a> {
 		let seeds = &[SEED, self.authority.address().as_ref()];
 		create_program_account_with_bump::<Data>(self.data, self.authority, &ID, seeds, args.bump)?;
 
-		let data_account = self.data.as_account_mut::<Data>(&ID)?;
+		let mut data_account = self.data.as_account_mut::<Data>(&ID)?;
 		*data_account = Data::builder()
 			.authority(*self.authority.address())
 			.value(args.value)

--- a/security/07-bump-seed-canonicalization/secure/src/lib.rs
+++ b/security/07-bump-seed-canonicalization/secure/src/lib.rs
@@ -60,7 +60,7 @@ impl<'a> ProcessAccountInfos<'a> for CreateAccounts<'a> {
 		let (_address, bump) =
 			create_program_account::<Data>(self.data, self.authority, &ID, seeds)?;
 
-		let data_account = self.data.as_account_mut::<Data>(&ID)?;
+		let mut data_account = self.data.as_account_mut::<Data>(&ID)?;
 		*data_account = Data::builder()
 			.authority(*self.authority.address())
 			.value(args.value)

--- a/security/08-pda-sharing/insecure/src/lib.rs
+++ b/security/08-pda-sharing/insecure/src/lib.rs
@@ -73,7 +73,7 @@ impl<'a> ProcessAccountInfos<'a> for CreateConfigAccounts<'a> {
 		let (_address, bump) =
 			create_program_account::<UserConfig>(self.config, self.authority, &ID, seeds)?;
 
-		let config = self.config.as_account_mut::<UserConfig>(&ID)?;
+		let mut config = self.config.as_account_mut::<UserConfig>(&ID)?;
 		*config = UserConfig::builder()
 			.authority(*self.authority.address())
 			.setting(args.setting)

--- a/security/08-pda-sharing/secure/src/lib.rs
+++ b/security/08-pda-sharing/secure/src/lib.rs
@@ -73,7 +73,7 @@ impl<'a> ProcessAccountInfos<'a> for CreateConfigAccounts<'a> {
 		let (_address, bump) =
 			create_program_account::<UserConfig>(self.config, self.authority, &ID, seeds)?;
 
-		let config = self.config.as_account_mut::<UserConfig>(&ID)?;
+		let mut config = self.config.as_account_mut::<UserConfig>(&ID)?;
 		*config = UserConfig::builder()
 			.authority(*self.authority.address())
 			.setting(args.setting)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added custom security linter (dylint) to CI and standard lint tasks.
  * Marked a major release via a changeset.

* **Improvements**
  * Account access now returns borrow-guarded typed views with stronger runtime borrow checks and safer token-account validations.
  * Examples and demos updated to enable in-place state mutation and clearer token-program handling.

* **Tests**
  * Added regression tests for overlapping borrow behavior and escrow/associated-token validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->