### PR TITLE
feat: quasar-inspired features — pod arithmetic, IDL hardening, static CU profiler

### DIFF
--- a/.changeset/quasar_inspired_features.md
+++ b/.changeset/quasar_inspired_features.md
@@ -1,0 +1,49 @@
+---
+default: major
+---
+
+### Pod Arithmetic (pina_pod_primitives)
+
+Add full Quasar-style arithmetic, bitwise, ordering, and display traits to all Pod integer types (`PodU16`, `PodU32`, `PodU64`, `PodU128`, `PodI16`, `PodI32`, `PodI64`, `PodI128`).
+
+**Arithmetic operators** (`Add`, `Sub`, `Mul`, `Div`, `Rem`) work between Pod types and between Pod + native types. Assign variants (`AddAssign`, `SubAssign`, etc.) allow ergonomic in-place mutation like `my_account.count += 1u64;`.
+
+**Arithmetic semantics**: debug builds panic on overflow (checked), release builds use wrapping for CU efficiency on Solana.
+
+**Bitwise operators**: `BitAnd`, `BitOr`, `BitXor`, `Shl`, `Shr`, `Not` with assign variants.
+
+**Signed types** get `Neg` for unary negation.
+
+**Checked arithmetic**: `checked_add`, `checked_sub`, `checked_mul`, `checked_div` return `Option` for explicit overflow detection.
+
+**Saturating arithmetic**: `saturating_add`, `saturating_sub`, `saturating_mul` clamp at bounds.
+
+**Constants**: `ZERO`, `MIN`, `MAX` for all types.
+
+**Helpers**: `get()` method, `is_zero()`, improved `Debug` (e.g. `PodU64(42)`), `Display`, `Ord`, `PartialOrd`, `PartialEq<native>`, `PartialOrd<native>`.
+
+**PodBool**: `Not` operator and `Display` added.
+
+**Backward compatible**: all existing APIs preserved, no breaking changes.
+
+### IDL Parser Hardening (pina_cli)
+
+Add static validation to the IDL parser that runs after IR assembly:
+
+- **Discriminator collision detection**: checks within accounts and within instructions for duplicate discriminator values. Three-way collisions produce all pairwise diagnostics.
+- **Duplicate input field detection**: checks within each instruction for name collisions between account names and argument names.
+- **Human-readable error formatting** for both collision types.
+
+Validation is automatically run during `assemble_program_ir()`.
+
+### Static CU Profiler (pina profile)
+
+Add a new `pina profile` CLI command for static compute unit profiling of compiled SBF programs.
+
+- `pina profile <path-to-so>` — text summary with per-function CU estimates
+- `pina profile <path-to-so> --json` — JSON output for CI integration
+- `pina profile <path-to-so> --output report.json` — write to file
+
+The profiler parses ELF binaries to extract `.text` sections and symbol tables, counts SBF instructions per function, and estimates CU costs without requiring a running validator. Works best with unstripped binaries.
+
+v1 scope: text/JSON output, per-function breakdown, best-effort symbol resolution. Flamegraph/browser UI planned for v2.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "agave-feature-set"
 version = "3.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -966,6 +972,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1343,6 +1358,16 @@ name = "five8_core"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "059c31d7d36c43fe39d89e55711858b4da8be7eb6dabac23c7289b1a19489406"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1747,6 +1772,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1938,7 +1973,12 @@ version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
+ "crc32fast",
+ "flate2",
+ "hashbrown 0.15.5",
+ "indexmap",
  "memchr",
+ "ruzstd",
 ]
 
 [[package]]
@@ -2060,12 +2100,14 @@ dependencies = [
  "heck",
  "insta",
  "insta-cmd",
+ "object",
  "pina_codama_renderer",
  "pina_profile",
  "proc-macro2",
  "serde",
  "serde_json",
  "syn 2.0.117",
+ "tempfile",
  "thiserror 2.0.18",
  "walkdir",
 ]
@@ -2476,6 +2518,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruzstd"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fad02996bfc73da3e301efe90b1837be9ed8f4a462b6ed410aa35d00381de89f"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2724,6 +2775,12 @@ dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "similar"
@@ -3720,6 +3777,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3964,6 +4027,16 @@ name = "transfer_sol"
 version = "0.0.0"
 dependencies = [
  "pina",
+]
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1933,6 +1933,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2052,6 +2061,7 @@ dependencies = [
  "insta",
  "insta-cmd",
  "pina_codama_renderer",
+ "pina_profile",
  "proc-macro2",
  "serde",
  "serde_json",
@@ -2092,6 +2102,17 @@ version = "0.6.0"
 dependencies = [
  "bytemuck",
  "proptest",
+]
+
+[[package]]
+name = "pina_profile"
+version = "0.6.0"
+dependencies = [
+ "object",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
 	"crates/pina_codama_renderer",
 	"crates/pina_macros",
 	"crates/pina_pod_primitives",
+	"crates/pina_profile",
 	"crates/pina_sdk_ids",
 	"examples/anchor_declare_id",
 	"examples/anchor_declare_program",
@@ -122,6 +123,7 @@ pina_cli = { default-features = false, path = "crates/pina_cli", version = "0.6.
 pina_codama_renderer = { default-features = false, path = "crates/pina_codama_renderer", version = "0.6.0" }
 pina_macros = { default-features = false, path = "crates/pina_macros", version = "0.6.0" }
 pina_pod_primitives = { default-features = false, path = "crates/pina_pod_primitives", version = "0.6.0" }
+pina_profile = { default-features = false, path = "crates/pina_profile", version = "0.6.0" }
 pina_sdk_ids = { default-features = false, path = "crates/pina_sdk_ids", version = "0.6.0" }
 
 [workspace.metadata.dylint]

--- a/crates/pina_cli/Cargo.toml
+++ b/crates/pina_cli/Cargo.toml
@@ -19,6 +19,7 @@ clap = { workspace = true }
 codama-nodes = { workspace = true }
 heck = { workspace = true, default-features = true }
 pina_codama_renderer = { workspace = true }
+pina_profile = { workspace = true }
 proc-macro2 = { workspace = true, default-features = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/crates/pina_cli/Cargo.toml
+++ b/crates/pina_cli/Cargo.toml
@@ -30,6 +30,9 @@ walkdir = { workspace = true }
 [dev-dependencies]
 insta = { workspace = true, features = ["json"] }
 insta-cmd = "0.6.0"
+object = { version = "0.36", features = ["write", "elf", "std"] }
+serde_json = { workspace = true }
+tempfile = "3"
 
 [lints]
 workspace = true

--- a/crates/pina_cli/src/main.rs
+++ b/crates/pina_cli/src/main.rs
@@ -46,6 +46,19 @@ enum Commands {
 		#[arg(long, default_value_t = false)]
 		force: bool,
 	},
+	/// Static CU profiler for compiled SBF programs.
+	Profile {
+		/// Path to the compiled SBF `.so` file.
+		path: PathBuf,
+
+		/// Output as JSON instead of text.
+		#[arg(long, default_value_t = false)]
+		json: bool,
+
+		/// Write output to a file instead of stdout.
+		#[arg(short, long)]
+		output: Option<PathBuf>,
+	},
 	/// Codama generation workflows.
 	Codama {
 		#[command(subcommand)]
@@ -94,6 +107,7 @@ fn main() {
 			pretty,
 		} => run_idl(path.as_path(), output.as_deref(), name.as_deref(), pretty),
 		Commands::Init { name, path, force } => run_init(name.as_str(), path.as_deref(), force),
+		Commands::Profile { path, json, output } => run_profile(&path, json, output.as_deref()),
 		Commands::Codama { command } => {
 			match command {
 				CodamaCommands::Generate {
@@ -157,6 +171,42 @@ fn run_init(name: &str, path: Option<&std::path::Path>, force: bool) {
 
 	println!("Initialized new Pina project at {}", project_path.display());
 	pina_cli::print_next_steps(&project_path, name);
+}
+
+fn run_profile(path: &std::path::Path, json: bool, output: Option<&std::path::Path>) {
+	let profile = match pina_profile::profile_program(path) {
+		Ok(p) => p,
+		Err(e) => {
+			eprintln!("Error: {e}");
+			std::process::exit(1);
+		}
+	};
+
+	let format = if json {
+		pina_profile::OutputFormat::Json
+	} else {
+		pina_profile::OutputFormat::Text
+	};
+
+	if let Some(output_path) = output {
+		let mut file = match std::fs::File::create(output_path) {
+			Ok(f) => f,
+			Err(e) => {
+				eprintln!("Failed to create {}: {e}", output_path.display());
+				std::process::exit(1);
+			}
+		};
+		if let Err(e) = pina_profile::output::write_profile(&profile, format, &mut file) {
+			eprintln!("Failed to write profile: {e}");
+			std::process::exit(1);
+		}
+	} else {
+		let mut stdout = std::io::stdout().lock();
+		if let Err(e) = pina_profile::output::write_profile(&profile, format, &mut stdout) {
+			eprintln!("Failed to write profile: {e}");
+			std::process::exit(1);
+		}
+	}
 }
 
 fn run_codama_generate(

--- a/crates/pina_cli/src/main.rs
+++ b/crates/pina_cli/src/main.rs
@@ -174,6 +174,13 @@ fn run_init(name: &str, path: Option<&std::path::Path>, force: bool) {
 }
 
 fn run_profile(path: &std::path::Path, json: bool, output: Option<&std::path::Path>) {
+	if let Some(output_path) = output {
+		if output_path == path {
+			eprintln!("Refusing to overwrite input binary {}", path.display());
+			std::process::exit(1);
+		}
+	}
+
 	let profile = match pina_profile::profile_program(path) {
 		Ok(p) => p,
 		Err(e) => {

--- a/crates/pina_cli/src/parse/collision.rs
+++ b/crates/pina_cli/src/parse/collision.rs
@@ -99,10 +99,7 @@ pub fn find_duplicate_input_fields(ir: &ProgramIr) -> Vec<DuplicateInputField> {
 		}
 
 		for arg in &instruction.arguments {
-			field_sources
-				.entry(&arg.name)
-				.or_default()
-				.push("argument");
+			field_sources.entry(&arg.name).or_default().push("argument");
 		}
 
 		for (name, sources) in &field_sources {
@@ -155,13 +152,12 @@ pub fn format_duplicate_field_errors(duplicates: &[DuplicateInputField]) -> Vec<
 
 #[cfg(test)]
 mod tests {
+	use super::*;
 	use crate::ir::AccountIr;
 	use crate::ir::DiscriminatorIr;
 	use crate::ir::FieldIr;
 	use crate::ir::InstructionAccountIr;
 	use crate::ir::InstructionIr;
-
-	use super::*;
 
 	fn make_account(name: &str, disc_value: u64) -> AccountIr {
 		AccountIr {
@@ -185,23 +181,27 @@ mod tests {
 			name: name.to_owned(),
 			accounts: account_names
 				.iter()
-				.map(|n| InstructionAccountIr {
-					name: (*n).to_owned(),
-					is_writable: false,
-					is_signer: false,
-					is_optional: false,
-					default_value: None,
-					is_pda: false,
-					pda_name: None,
-					docs: vec![],
+				.map(|n| {
+					InstructionAccountIr {
+						name: (*n).to_owned(),
+						is_writable: false,
+						is_signer: false,
+						is_optional: false,
+						default_value: None,
+						is_pda: false,
+						pda_name: None,
+						docs: vec![],
+					}
 				})
 				.collect(),
 			arguments: arg_names
 				.iter()
-				.map(|n| FieldIr {
-					name: (*n).to_owned(),
-					rust_type: "u64".to_owned(),
-					docs: vec![],
+				.map(|n| {
+					FieldIr {
+						name: (*n).to_owned(),
+						rust_type: "u64".to_owned(),
+						docs: vec![],
+					}
 				})
 				.collect(),
 			discriminator: DiscriminatorIr {
@@ -227,19 +227,13 @@ mod tests {
 
 	#[test]
 	fn no_collisions_when_discriminators_differ() {
-		let ir = make_program(
-			vec![make_account("A", 0), make_account("B", 1)],
-			vec![],
-		);
+		let ir = make_program(vec![make_account("A", 0), make_account("B", 1)], vec![]);
 		assert!(find_discriminator_collisions(&ir).is_empty());
 	}
 
 	#[test]
 	fn detects_account_discriminator_collision() {
-		let ir = make_program(
-			vec![make_account("A", 0), make_account("B", 0)],
-			vec![],
-		);
+		let ir = make_program(vec![make_account("A", 0), make_account("B", 0)], vec![]);
 		let collisions = find_discriminator_collisions(&ir);
 		assert_eq!(collisions.len(), 1);
 		assert_eq!(collisions[0].kind, "account");

--- a/crates/pina_cli/src/parse/collision.rs
+++ b/crates/pina_cli/src/parse/collision.rs
@@ -1,0 +1,395 @@
+//! Static validation for discriminator collisions and duplicate input names.
+//!
+//! These checks run after the IR has been fully assembled and surface errors
+//! early — before serialization — so users get actionable diagnostics.
+
+use std::collections::HashMap;
+
+use crate::ir::ProgramIr;
+
+/// A collision between two named entities sharing the same discriminator.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscriminatorCollision {
+	/// The kind of entity (e.g. "account", "instruction").
+	pub kind: &'static str,
+	/// First entity name.
+	pub name_a: String,
+	/// Second entity name.
+	pub name_b: String,
+	/// The colliding discriminator value.
+	pub discriminator_value: u64,
+	/// The discriminator repr size in bytes.
+	pub repr_size: usize,
+}
+
+/// A duplicate input field name within a single instruction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DuplicateInputField {
+	/// Instruction name.
+	pub instruction: String,
+	/// The duplicate field name.
+	pub field_name: String,
+	/// Sources of the field (e.g. `["account", "argument"]`).
+	pub sources: Vec<&'static str>,
+}
+
+/// Check for discriminator collisions across all accounts and instructions.
+///
+/// Returns a list of collision descriptions. An empty list means no
+/// collisions.
+pub fn find_discriminator_collisions(ir: &ProgramIr) -> Vec<DiscriminatorCollision> {
+	let mut collisions = Vec::new();
+
+	// Check within accounts.
+	check_collisions_within(
+		"account",
+		&ir.accounts,
+		|a| (&a.name, a.discriminator.value, a.discriminator.repr_size),
+		&mut collisions,
+	);
+
+	// Check within instructions.
+	check_collisions_within(
+		"instruction",
+		&ir.instructions,
+		|i| (&i.name, i.discriminator.value, i.discriminator.repr_size),
+		&mut collisions,
+	);
+
+	collisions
+}
+
+/// Generic O(n²) collision check within a single kind.
+fn check_collisions_within<T>(
+	kind: &'static str,
+	items: &[T],
+	extract: impl Fn(&T) -> (&str, u64, usize),
+	collisions: &mut Vec<DiscriminatorCollision>,
+) {
+	for (i, item_a) in items.iter().enumerate() {
+		let (name_a, val_a, repr_a) = extract(item_a);
+		for item_b in &items[(i + 1)..] {
+			let (name_b, val_b, _repr_b) = extract(item_b);
+			if val_a == val_b {
+				collisions.push(DiscriminatorCollision {
+					kind,
+					name_a: name_a.to_owned(),
+					name_b: name_b.to_owned(),
+					discriminator_value: val_a,
+					repr_size: repr_a,
+				});
+			}
+		}
+	}
+}
+
+/// Check for duplicate input field names within instructions.
+///
+/// An instruction's "input" consists of both its account names and its
+/// argument names. Having duplicates would cause ambiguity in client
+/// generation.
+pub fn find_duplicate_input_fields(ir: &ProgramIr) -> Vec<DuplicateInputField> {
+	let mut duplicates = Vec::new();
+
+	for instruction in &ir.instructions {
+		let mut field_sources: HashMap<&str, Vec<&'static str>> = HashMap::new();
+
+		for acct in &instruction.accounts {
+			field_sources.entry(&acct.name).or_default().push("account");
+		}
+
+		for arg in &instruction.arguments {
+			field_sources
+				.entry(&arg.name)
+				.or_default()
+				.push("argument");
+		}
+
+		for (name, sources) in &field_sources {
+			if sources.len() > 1 {
+				duplicates.push(DuplicateInputField {
+					instruction: instruction.name.clone(),
+					field_name: (*name).to_owned(),
+					sources: sources.clone(),
+				});
+			}
+		}
+	}
+
+	duplicates
+}
+
+/// Format collision errors into human-readable messages.
+pub fn format_collision_errors(collisions: &[DiscriminatorCollision]) -> Vec<String> {
+	collisions
+		.iter()
+		.map(|c| {
+			format!(
+				"{} '{}' and {} '{}' share discriminator value {} (repr: {} byte{})",
+				c.kind,
+				c.name_a,
+				c.kind,
+				c.name_b,
+				c.discriminator_value,
+				c.repr_size,
+				if c.repr_size == 1 { "" } else { "s" },
+			)
+		})
+		.collect()
+}
+
+/// Format duplicate input field errors into human-readable messages.
+pub fn format_duplicate_field_errors(duplicates: &[DuplicateInputField]) -> Vec<String> {
+	duplicates
+		.iter()
+		.map(|d| {
+			format!(
+				"instruction '{}' has duplicate input field '{}' from {}",
+				d.instruction,
+				d.field_name,
+				d.sources.join(" + "),
+			)
+		})
+		.collect()
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::ir::AccountIr;
+	use crate::ir::DiscriminatorIr;
+	use crate::ir::FieldIr;
+	use crate::ir::InstructionAccountIr;
+	use crate::ir::InstructionIr;
+
+	use super::*;
+
+	fn make_account(name: &str, disc_value: u64) -> AccountIr {
+		AccountIr {
+			name: name.to_owned(),
+			fields: vec![],
+			discriminator: DiscriminatorIr {
+				value: disc_value,
+				repr_size: 1,
+			},
+			docs: vec![],
+		}
+	}
+
+	fn make_instruction(
+		name: &str,
+		disc_value: u64,
+		account_names: &[&str],
+		arg_names: &[&str],
+	) -> InstructionIr {
+		InstructionIr {
+			name: name.to_owned(),
+			accounts: account_names
+				.iter()
+				.map(|n| InstructionAccountIr {
+					name: (*n).to_owned(),
+					is_writable: false,
+					is_signer: false,
+					is_optional: false,
+					default_value: None,
+					is_pda: false,
+					pda_name: None,
+					docs: vec![],
+				})
+				.collect(),
+			arguments: arg_names
+				.iter()
+				.map(|n| FieldIr {
+					name: (*n).to_owned(),
+					rust_type: "u64".to_owned(),
+					docs: vec![],
+				})
+				.collect(),
+			discriminator: DiscriminatorIr {
+				value: disc_value,
+				repr_size: 1,
+			},
+			docs: vec![],
+		}
+	}
+
+	fn make_program(accounts: Vec<AccountIr>, instructions: Vec<InstructionIr>) -> ProgramIr {
+		ProgramIr {
+			name: "test".to_owned(),
+			public_key: "1111111111111111111111111111111111".to_owned(),
+			accounts,
+			instructions,
+			errors: vec![],
+			pdas: vec![],
+		}
+	}
+
+	// ---- discriminator collision tests ----
+
+	#[test]
+	fn no_collisions_when_discriminators_differ() {
+		let ir = make_program(
+			vec![make_account("A", 0), make_account("B", 1)],
+			vec![],
+		);
+		assert!(find_discriminator_collisions(&ir).is_empty());
+	}
+
+	#[test]
+	fn detects_account_discriminator_collision() {
+		let ir = make_program(
+			vec![make_account("A", 0), make_account("B", 0)],
+			vec![],
+		);
+		let collisions = find_discriminator_collisions(&ir);
+		assert_eq!(collisions.len(), 1);
+		assert_eq!(collisions[0].kind, "account");
+		assert_eq!(collisions[0].name_a, "A");
+		assert_eq!(collisions[0].name_b, "B");
+		assert_eq!(collisions[0].discriminator_value, 0);
+	}
+
+	#[test]
+	fn detects_instruction_discriminator_collision() {
+		let ir = make_program(
+			vec![],
+			vec![
+				make_instruction("init", 0, &["authority"], &[]),
+				make_instruction("update", 0, &["authority"], &[]),
+			],
+		);
+		let collisions = find_discriminator_collisions(&ir);
+		assert_eq!(collisions.len(), 1);
+		assert_eq!(collisions[0].kind, "instruction");
+	}
+
+	#[test]
+	fn no_cross_kind_collisions() {
+		// Account disc=0 and instruction disc=0 should NOT collide.
+		let ir = make_program(
+			vec![make_account("AccountA", 0)],
+			vec![make_instruction("init", 0, &["authority"], &[])],
+		);
+		assert!(find_discriminator_collisions(&ir).is_empty());
+	}
+
+	#[test]
+	fn multiple_collisions() {
+		let ir = make_program(
+			vec![
+				make_account("A", 0),
+				make_account("B", 0),
+				make_account("C", 1),
+				make_account("D", 1),
+			],
+			vec![],
+		);
+		let collisions = find_discriminator_collisions(&ir);
+		assert_eq!(collisions.len(), 2);
+	}
+
+	#[test]
+	fn three_way_collision_produces_three_pairs() {
+		let ir = make_program(
+			vec![
+				make_account("A", 0),
+				make_account("B", 0),
+				make_account("C", 0),
+			],
+			vec![],
+		);
+		let collisions = find_discriminator_collisions(&ir);
+		// (A,B), (A,C), (B,C)
+		assert_eq!(collisions.len(), 3);
+	}
+
+	// ---- duplicate input field tests ----
+
+	#[test]
+	fn no_duplicates_when_names_differ() {
+		let ir = make_program(
+			vec![],
+			vec![make_instruction("init", 0, &["authority"], &["amount"])],
+		);
+		assert!(find_duplicate_input_fields(&ir).is_empty());
+	}
+
+	#[test]
+	fn detects_duplicate_account_arg_name() {
+		let ir = make_program(
+			vec![],
+			vec![make_instruction("init", 0, &["amount"], &["amount"])],
+		);
+		let dupes = find_duplicate_input_fields(&ir);
+		assert_eq!(dupes.len(), 1);
+		assert_eq!(dupes[0].instruction, "init");
+		assert_eq!(dupes[0].field_name, "amount");
+	}
+
+	#[test]
+	fn no_false_positives_across_instructions() {
+		let ir = make_program(
+			vec![],
+			vec![
+				make_instruction("init", 0, &["authority"], &[]),
+				make_instruction("update", 1, &["authority"], &[]),
+			],
+		);
+		assert!(find_duplicate_input_fields(&ir).is_empty());
+	}
+
+	// ---- formatting tests ----
+
+	#[test]
+	fn format_collision_message() {
+		let collision = DiscriminatorCollision {
+			kind: "account",
+			name_a: "Counter".to_owned(),
+			name_b: "Vault".to_owned(),
+			discriminator_value: 0,
+			repr_size: 1,
+		};
+		let msgs = format_collision_errors(&[collision]);
+		assert_eq!(msgs.len(), 1);
+		assert!(msgs[0].contains("Counter"));
+		assert!(msgs[0].contains("Vault"));
+		assert!(msgs[0].contains("discriminator value 0"));
+	}
+
+	#[test]
+	fn format_duplicate_field_message() {
+		let dup = DuplicateInputField {
+			instruction: "init".to_owned(),
+			field_name: "amount".to_owned(),
+			sources: vec!["account", "argument"],
+		};
+		let msgs = format_duplicate_field_errors(&[dup]);
+		assert_eq!(msgs.len(), 1);
+		assert!(msgs[0].contains("init"));
+		assert!(msgs[0].contains("amount"));
+		assert!(msgs[0].contains("account + argument"));
+	}
+
+	// ---- error variants ----
+
+	#[test]
+	fn collision_errors_for_empty_programs() {
+		let ir = make_program(vec![], vec![]);
+		assert!(find_discriminator_collisions(&ir).is_empty());
+		assert!(find_duplicate_input_fields(&ir).is_empty());
+	}
+
+	#[test]
+	fn single_account_no_collision() {
+		let ir = make_program(vec![make_account("Only", 42)], vec![]);
+		assert!(find_discriminator_collisions(&ir).is_empty());
+	}
+
+	#[test]
+	fn single_instruction_no_collision() {
+		let ir = make_program(
+			vec![],
+			vec![make_instruction("only", 42, &["auth"], &["val"])],
+		);
+		assert!(find_discriminator_collisions(&ir).is_empty());
+	}
+}

--- a/crates/pina_cli/src/parse/collision.rs
+++ b/crates/pina_cli/src/parse/collision.rs
@@ -69,8 +69,8 @@ fn check_collisions_within<T>(
 	for (i, item_a) in items.iter().enumerate() {
 		let (name_a, val_a, repr_a) = extract(item_a);
 		for item_b in &items[(i + 1)..] {
-			let (name_b, val_b, _repr_b) = extract(item_b);
-			if val_a == val_b {
+			let (name_b, val_b, repr_b) = extract(item_b);
+			if val_a == val_b && repr_a == repr_b {
 				collisions.push(DiscriminatorCollision {
 					kind,
 					name_a: name_a.to_owned(),
@@ -160,12 +160,16 @@ mod tests {
 	use crate::ir::InstructionIr;
 
 	fn make_account(name: &str, disc_value: u64) -> AccountIr {
+		make_account_with_repr(name, disc_value, 1)
+	}
+
+	fn make_account_with_repr(name: &str, disc_value: u64, repr_size: usize) -> AccountIr {
 		AccountIr {
 			name: name.to_owned(),
 			fields: vec![],
 			discriminator: DiscriminatorIr {
 				value: disc_value,
-				repr_size: 1,
+				repr_size,
 			},
 			docs: vec![],
 		}
@@ -262,6 +266,19 @@ mod tests {
 		let ir = make_program(
 			vec![make_account("AccountA", 0)],
 			vec![make_instruction("init", 0, &["authority"], &[])],
+		);
+		assert!(find_discriminator_collisions(&ir).is_empty());
+	}
+
+	#[test]
+	fn different_repr_size_no_collision() {
+		// Same numeric value but different repr sizes should NOT collide.
+		let ir = make_program(
+			vec![
+				make_account_with_repr("A", 1, 1), // u8 discriminator
+				make_account_with_repr("B", 1, 2), // u16 discriminator
+			],
+			vec![],
 		);
 		assert!(find_discriminator_collisions(&ir).is_empty());
 	}

--- a/crates/pina_cli/src/parse/mod.rs
+++ b/crates/pina_cli/src/parse/mod.rs
@@ -1,5 +1,6 @@
 pub mod account_state;
 pub mod accounts_struct;
+pub mod collision;
 pub mod discriminator;
 pub mod doc_comments;
 pub mod entrypoint;
@@ -139,14 +140,50 @@ pub fn assemble_program_ir(file: &syn::File, program_name: &str) -> Result<Progr
 		})
 		.collect();
 
-	Ok(ProgramIr {
+	let ir = ProgramIr {
 		name: program_name.to_owned(),
 		public_key,
 		accounts,
 		instructions,
 		errors,
 		pdas: pdas_ir,
-	})
+	};
+
+	// Step 4: Validate the assembled IR for collisions and duplicates.
+	validate_program_ir(&ir)?;
+
+	Ok(ir)
+}
+
+/// Run static validation checks on a fully assembled [`ProgramIr`].
+///
+/// Currently checks:
+/// - Discriminator collisions within accounts and within instructions.
+/// - Duplicate input field names within instructions (account names vs
+///   argument names).
+///
+/// Returns `Ok(())` when the IR is valid, or an [`IdlError`] describing the
+/// first set of violations found.
+pub fn validate_program_ir(ir: &ProgramIr) -> Result<(), IdlError> {
+	let collisions = collision::find_discriminator_collisions(ir);
+	if !collisions.is_empty() {
+		let messages = collision::format_collision_errors(&collisions);
+		return Err(IdlError::Other(format!(
+			"Discriminator collisions detected:\n  {}",
+			messages.join("\n  "),
+		)));
+	}
+
+	let duplicates = collision::find_duplicate_input_fields(ir);
+	if !duplicates.is_empty() {
+		let messages = collision::format_duplicate_field_errors(&duplicates);
+		return Err(IdlError::Other(format!(
+			"Duplicate instruction input field names detected:\n  {}",
+			messages.join("\n  "),
+		)));
+	}
+
+	Ok(())
 }
 
 /// Find the discriminator value for an account struct by matching the struct

--- a/crates/pina_cli/tests/profile_command.rs
+++ b/crates/pina_cli/tests/profile_command.rs
@@ -1,0 +1,187 @@
+//! Integration tests for the `pina profile` CLI command.
+//!
+//! Builds minimal synthetic SBF ELF binaries and exercises the CLI end-to-end.
+
+use std::io::Write;
+use std::process::Command;
+
+use object::Architecture;
+use object::BinaryFormat;
+use object::Endianness;
+use object::SectionKind;
+use object::SymbolFlags;
+use object::SymbolKind;
+use object::SymbolScope;
+use object::write::Object;
+use object::write::Symbol;
+use object::write::SymbolSection;
+
+/// Build a minimal SBF ELF binary with a `.text` section and optional symbols.
+fn build_sbf_elf(text_size: usize, symbols: &[(&str, u64, u64)]) -> Vec<u8> {
+	let mut obj = Object::new(BinaryFormat::Elf, Architecture::Sbf, Endianness::Little);
+
+	let section = obj.add_section(Vec::new(), b".text".to_vec(), SectionKind::Text);
+
+	let text_data = vec![0u8; text_size];
+	obj.set_section_data(section, text_data, 8);
+
+	for &(name, offset, size) in symbols {
+		obj.add_symbol(Symbol {
+			name: name.as_bytes().to_vec(),
+			value: offset,
+			size,
+			kind: SymbolKind::Text,
+			scope: SymbolScope::Dynamic,
+			weak: false,
+			section: SymbolSection::Section(section),
+			flags: SymbolFlags::None,
+		});
+	}
+
+	obj.write()
+		.unwrap_or_else(|e| panic!("failed to write ELF: {e}"))
+}
+
+/// Write bytes to a temp file and return it.
+fn write_temp_elf(data: &[u8]) -> tempfile::NamedTempFile {
+	let mut file = tempfile::Builder::new()
+		.suffix(".so")
+		.tempfile()
+		.unwrap_or_else(|e| panic!("failed to create temp file: {e}"));
+	file.write_all(data)
+		.unwrap_or_else(|e| panic!("failed to write temp ELF: {e}"));
+	file.flush()
+		.unwrap_or_else(|e| panic!("failed to flush temp ELF: {e}"));
+	file
+}
+
+#[test]
+fn cli_profile_text_output() {
+	let elf_data = build_sbf_elf(160, &[("process_instruction", 0, 160)]);
+	let file = write_temp_elf(&elf_data);
+
+	let output = Command::new(env!("CARGO_BIN_EXE_pina"))
+		.args(["profile", file.path().to_str().unwrap()])
+		.output()
+		.unwrap_or_else(|e| panic!("failed to run pina profile: {e}"));
+
+	assert!(
+		output.status.success(),
+		"pina profile failed: {}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+	let stdout = String::from_utf8_lossy(&output.stdout);
+	assert!(
+		stdout.contains("process_instruction"),
+		"expected function name in output: {stdout}"
+	);
+	assert!(
+		stdout.contains("Total estimated CU"),
+		"expected CU summary in output: {stdout}"
+	);
+}
+
+#[test]
+fn cli_profile_json_output() {
+	let elf_data = build_sbf_elf(160, &[("process_instruction", 0, 160)]);
+	let file = write_temp_elf(&elf_data);
+
+	let output = Command::new(env!("CARGO_BIN_EXE_pina"))
+		.args(["profile", file.path().to_str().unwrap(), "--json"])
+		.output()
+		.unwrap_or_else(|e| panic!("failed to run pina profile --json: {e}"));
+
+	assert!(
+		output.status.success(),
+		"pina profile --json failed: {}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+	let stdout = String::from_utf8_lossy(&output.stdout);
+	let parsed: serde_json::Value =
+		serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("invalid JSON: {e}"));
+	assert_eq!(parsed["total_instructions"], 20);
+	assert!(parsed["functions"].is_array());
+}
+
+#[test]
+fn cli_profile_output_to_file() {
+	let elf_data = build_sbf_elf(80, &[("my_func", 0, 80)]);
+	let elf_file = write_temp_elf(&elf_data);
+	let output_file = tempfile::Builder::new()
+		.suffix(".json")
+		.tempfile()
+		.unwrap_or_else(|e| panic!("temp: {e}"));
+
+	let result = Command::new(env!("CARGO_BIN_EXE_pina"))
+		.args([
+			"profile",
+			elf_file.path().to_str().unwrap(),
+			"--json",
+			"--output",
+			output_file.path().to_str().unwrap(),
+		])
+		.output()
+		.unwrap_or_else(|e| panic!("failed to run pina profile --output: {e}"));
+
+	assert!(
+		result.status.success(),
+		"pina profile --output failed: {}",
+		String::from_utf8_lossy(&result.stderr)
+	);
+
+	let content = std::fs::read_to_string(output_file.path())
+		.unwrap_or_else(|e| panic!("read output file: {e}"));
+	let parsed: serde_json::Value = serde_json::from_str(&content)
+		.unwrap_or_else(|e| panic!("invalid JSON in output file: {e}"));
+	assert!(parsed["functions"].is_array());
+}
+
+#[test]
+fn cli_profile_nonexistent_file_fails() {
+	let output = Command::new(env!("CARGO_BIN_EXE_pina"))
+		.args(["profile", "/nonexistent/path.so"])
+		.output()
+		.unwrap_or_else(|e| panic!("failed to run: {e}"));
+
+	assert!(!output.status.success());
+	let stderr = String::from_utf8_lossy(&output.stderr);
+	assert!(stderr.contains("Error"), "expected error message: {stderr}");
+}
+
+#[test]
+fn cli_profile_non_elf_fails() {
+	let mut file = tempfile::Builder::new()
+		.suffix(".so")
+		.tempfile()
+		.unwrap_or_else(|e| panic!("temp: {e}"));
+	file.write_all(b"not an elf").unwrap();
+	file.flush().unwrap();
+
+	let output = Command::new(env!("CARGO_BIN_EXE_pina"))
+		.args(["profile", file.path().to_str().unwrap()])
+		.output()
+		.unwrap_or_else(|e| panic!("failed to run: {e}"));
+
+	assert!(!output.status.success());
+	let stderr = String::from_utf8_lossy(&output.stderr);
+	assert!(stderr.contains("Error"), "expected error message: {stderr}");
+}
+
+#[test]
+fn cli_profile_refuses_overwrite_input() {
+	let elf_data = build_sbf_elf(80, &[]);
+	let file = write_temp_elf(&elf_data);
+	let path_str = file.path().to_str().unwrap();
+
+	let output = Command::new(env!("CARGO_BIN_EXE_pina"))
+		.args(["profile", path_str, "--output", path_str])
+		.output()
+		.unwrap_or_else(|e| panic!("failed to run: {e}"));
+
+	assert!(!output.status.success());
+	let stderr = String::from_utf8_lossy(&output.stderr);
+	assert!(
+		stderr.contains("Refusing to overwrite"),
+		"expected overwrite guard: {stderr}"
+	);
+}

--- a/crates/pina_pod_primitives/src/lib.rs
+++ b/crates/pina_pod_primitives/src/lib.rs
@@ -1,9 +1,28 @@
 #![no_std]
 
 //! Alignment-safe primitive wrappers that can be used in `Pod` structs.
+//!
+//! Pod types (`PodU64`, `PodU32`, etc.) wrap native integers in `[u8; N]`
+//! arrays, guaranteeing alignment 1. This allows direct pointer casts from
+//! account data without alignment concerns — critical for `#[repr(C)]`
+//! zero-copy structs on Solana.
+//!
+//! # Arithmetic
+//!
+//! Arithmetic operators (`+`, `-`, `*`) use **wrapping** semantics in release
+//! builds for CU efficiency and **panic on overflow** in debug builds. Use
+//! `checked_add`, `checked_sub`, `checked_mul`, `checked_div` where overflow
+//! must be detected in all build profiles.
+//!
+//! # Constants
+//!
+//! Each Pod integer type provides `ZERO`, `MIN`, and `MAX` constants.
 
 use bytemuck::Pod;
 use bytemuck::Zeroable;
+use core::fmt;
+use core::mem::align_of;
+use core::mem::size_of;
 
 /// The standard `bool` is not a `Pod`, define a replacement that is.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
@@ -51,6 +70,21 @@ impl From<PodBool> for bool {
 	}
 }
 
+impl core::ops::Not for PodBool {
+	type Output = Self;
+
+	#[inline]
+	fn not(self) -> Self {
+		Self::from_bool(!bool::from(self))
+	}
+}
+
+impl fmt::Display for PodBool {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		bool::from(*self).fmt(f)
+	}
+}
+
 /// Implements bidirectional conversion between a `Pod*` wrapper type and its
 /// corresponding standard integer.
 ///
@@ -65,67 +99,650 @@ macro_rules! impl_int_conversion {
 			pub const fn from_primitive(n: $I) -> Self {
 				Self(n.to_le_bytes())
 			}
+
+			/// Returns the contained native value, converting from
+			/// little-endian bytes.
+			#[inline]
+			pub const fn get(&self) -> $I {
+				<$I>::from_le_bytes(self.0)
+			}
 		}
+
 		impl From<$I> for $P {
 			fn from(n: $I) -> Self {
 				Self::from_primitive(n)
 			}
 		}
+
 		impl From<$P> for $I {
 			fn from(pod: $P) -> Self {
-				Self::from_le_bytes(pod.0)
+				pod.get()
 			}
 		}
 	};
 }
 
-/// `u16` type that can be used in `Pod`s.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
-#[repr(transparent)]
-pub struct PodU16(pub [u8; 2]);
-impl_int_conversion!(PodU16, u16);
+/// Implements constants, ordering, display, checked/saturating arithmetic, and
+/// helper methods for a Pod integer type.
+macro_rules! impl_pod_common {
+	($name:ident, $native:ty, $size:expr) => {
+		impl $name {
+			/// The zero value.
+			pub const ZERO: Self = Self([0u8; $size]);
 
-/// `i16` type that can be used in `Pod`s.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
-#[repr(transparent)]
-pub struct PodI16(pub [u8; 2]);
-impl_int_conversion!(PodI16, i16);
+			#[doc = concat!(
+				"The largest value representable by [`",
+				stringify!($native),
+				"`]."
+			)]
+			pub const MAX: Self = Self(<$native>::MAX.to_le_bytes());
 
-/// `u32` type that can be used in `Pod`s.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
-#[repr(transparent)]
-pub struct PodU32(pub [u8; 4]);
-impl_int_conversion!(PodU32, u32);
+			#[doc = concat!(
+				"The smallest value representable by [`",
+				stringify!($native),
+				"`]."
+			)]
+			pub const MIN: Self = Self(<$native>::MIN.to_le_bytes());
 
-/// `i32` type that can be used in `Pod`s.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
-#[repr(transparent)]
-pub struct PodI32(pub [u8; 4]);
-impl_int_conversion!(PodI32, i32);
+			/// Returns `true` if the value is zero.
+			#[inline]
+			#[must_use]
+			pub fn is_zero(&self) -> bool {
+				self.0 == [0u8; $size]
+			}
 
-/// `u64` type that can be used in `Pod`s.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
-#[repr(transparent)]
-pub struct PodU64(pub [u8; 8]);
-impl_int_conversion!(PodU64, u64);
+			/// Checked addition. Returns `None` on overflow.
+			#[inline]
+			#[must_use]
+			pub fn checked_add(self, rhs: impl Into<$name>) -> Option<Self> {
+				self.get().checked_add(rhs.into().get()).map(Self::from)
+			}
 
-/// `i64` type that can be used in `Pod`s.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
-#[repr(transparent)]
-pub struct PodI64(pub [u8; 8]);
-impl_int_conversion!(PodI64, i64);
+			/// Checked subtraction. Returns `None` on underflow.
+			#[inline]
+			#[must_use]
+			pub fn checked_sub(self, rhs: impl Into<$name>) -> Option<Self> {
+				self.get().checked_sub(rhs.into().get()).map(Self::from)
+			}
 
-/// `u128` type that can be used in `Pod`s.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
-#[repr(transparent)]
-pub struct PodU128(pub [u8; 16]);
-impl_int_conversion!(PodU128, u128);
+			/// Checked multiplication. Returns `None` on overflow.
+			#[inline]
+			#[must_use]
+			pub fn checked_mul(self, rhs: impl Into<$name>) -> Option<Self> {
+				self.get().checked_mul(rhs.into().get()).map(Self::from)
+			}
 
-/// `i128` type that can be used in `Pod`s.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
-#[repr(transparent)]
-pub struct PodI128(pub [u8; 16]);
-impl_int_conversion!(PodI128, i128);
+			/// Checked division. Returns `None` if `rhs` is zero.
+			#[inline]
+			#[must_use]
+			pub fn checked_div(self, rhs: impl Into<$name>) -> Option<Self> {
+				self.get().checked_div(rhs.into().get()).map(Self::from)
+			}
+
+			/// Saturating addition. Clamps at the numeric bounds instead of
+			/// overflowing.
+			#[inline]
+			#[must_use]
+			pub fn saturating_add(self, rhs: impl Into<$name>) -> Self {
+				Self::from(self.get().saturating_add(rhs.into().get()))
+			}
+
+			/// Saturating subtraction. Clamps at the numeric bound instead of
+			/// underflowing.
+			#[inline]
+			#[must_use]
+			pub fn saturating_sub(self, rhs: impl Into<$name>) -> Self {
+				Self::from(self.get().saturating_sub(rhs.into().get()))
+			}
+
+			/// Saturating multiplication. Clamps at the numeric bounds instead
+			/// of overflowing.
+			#[inline]
+			#[must_use]
+			pub fn saturating_mul(self, rhs: impl Into<$name>) -> Self {
+				Self::from(self.get().saturating_mul(rhs.into().get()))
+			}
+		}
+
+		impl PartialOrd for $name {
+			#[inline]
+			fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+				Some(self.cmp(other))
+			}
+		}
+
+		impl Ord for $name {
+			#[inline]
+			fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+				self.get().cmp(&other.get())
+			}
+		}
+
+		impl PartialEq<$native> for $name {
+			#[inline]
+			fn eq(&self, other: &$native) -> bool {
+				self.get() == *other
+			}
+		}
+
+		impl PartialOrd<$native> for $name {
+			#[inline]
+			fn partial_cmp(&self, other: &$native) -> Option<core::cmp::Ordering> {
+				self.get().partial_cmp(other)
+			}
+		}
+
+		impl fmt::Display for $name {
+			fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+				self.get().fmt(f)
+			}
+		}
+	};
+}
+
+/// Implements arithmetic operators for a Pod type.
+///
+/// In debug builds, operators panic on overflow via `checked_*`. In release
+/// builds, they use `wrapping_*` for CU efficiency on Solana.
+macro_rules! impl_pod_arithmetic {
+	($name:ident, $native:ty) => {
+		// --- Pod + native ---
+
+		impl core::ops::Add<$native> for $name {
+			type Output = Self;
+
+			#[inline]
+			fn add(self, rhs: $native) -> Self {
+				#[cfg(debug_assertions)]
+				{
+					Self::from(
+						self.get()
+							.checked_add(rhs)
+							.unwrap_or_else(|| panic!("attempt to add with overflow")),
+					)
+				}
+				#[cfg(not(debug_assertions))]
+				{
+					Self::from(self.get().wrapping_add(rhs))
+				}
+			}
+		}
+
+		impl core::ops::Sub<$native> for $name {
+			type Output = Self;
+
+			#[inline]
+			fn sub(self, rhs: $native) -> Self {
+				#[cfg(debug_assertions)]
+				{
+					Self::from(
+						self.get()
+							.checked_sub(rhs)
+							.unwrap_or_else(|| panic!("attempt to subtract with overflow")),
+					)
+				}
+				#[cfg(not(debug_assertions))]
+				{
+					Self::from(self.get().wrapping_sub(rhs))
+				}
+			}
+		}
+
+		impl core::ops::Mul<$native> for $name {
+			type Output = Self;
+
+			#[inline]
+			fn mul(self, rhs: $native) -> Self {
+				#[cfg(debug_assertions)]
+				{
+					Self::from(
+						self.get()
+							.checked_mul(rhs)
+							.unwrap_or_else(|| panic!("attempt to multiply with overflow")),
+					)
+				}
+				#[cfg(not(debug_assertions))]
+				{
+					Self::from(self.get().wrapping_mul(rhs))
+				}
+			}
+		}
+
+		impl core::ops::Div<$native> for $name {
+			type Output = Self;
+
+			#[inline]
+			fn div(self, rhs: $native) -> Self {
+				Self::from(self.get() / rhs)
+			}
+		}
+
+		impl core::ops::Rem<$native> for $name {
+			type Output = Self;
+
+			#[inline]
+			fn rem(self, rhs: $native) -> Self {
+				Self::from(self.get() % rhs)
+			}
+		}
+
+		// --- Pod + Pod ---
+
+		impl core::ops::Add for $name {
+			type Output = Self;
+
+			#[inline]
+			fn add(self, rhs: Self) -> Self {
+				self + rhs.get()
+			}
+		}
+
+		impl core::ops::Sub for $name {
+			type Output = Self;
+
+			#[inline]
+			fn sub(self, rhs: Self) -> Self {
+				self - rhs.get()
+			}
+		}
+
+		impl core::ops::Mul for $name {
+			type Output = Self;
+
+			#[inline]
+			fn mul(self, rhs: Self) -> Self {
+				self * rhs.get()
+			}
+		}
+
+		impl core::ops::Div for $name {
+			type Output = Self;
+
+			#[inline]
+			fn div(self, rhs: Self) -> Self {
+				self / rhs.get()
+			}
+		}
+
+		impl core::ops::Rem for $name {
+			type Output = Self;
+
+			#[inline]
+			fn rem(self, rhs: Self) -> Self {
+				self % rhs.get()
+			}
+		}
+
+		// --- Assign with native ---
+
+		impl core::ops::AddAssign<$native> for $name {
+			#[inline]
+			fn add_assign(&mut self, rhs: $native) {
+				*self = *self + rhs;
+			}
+		}
+
+		impl core::ops::SubAssign<$native> for $name {
+			#[inline]
+			fn sub_assign(&mut self, rhs: $native) {
+				*self = *self - rhs;
+			}
+		}
+
+		impl core::ops::MulAssign<$native> for $name {
+			#[inline]
+			fn mul_assign(&mut self, rhs: $native) {
+				*self = *self * rhs;
+			}
+		}
+
+		impl core::ops::DivAssign<$native> for $name {
+			#[inline]
+			fn div_assign(&mut self, rhs: $native) {
+				*self = *self / rhs;
+			}
+		}
+
+		impl core::ops::RemAssign<$native> for $name {
+			#[inline]
+			fn rem_assign(&mut self, rhs: $native) {
+				*self = *self % rhs;
+			}
+		}
+
+		// --- Assign with Pod ---
+
+		impl core::ops::AddAssign for $name {
+			#[inline]
+			fn add_assign(&mut self, rhs: Self) {
+				*self = *self + rhs;
+			}
+		}
+
+		impl core::ops::SubAssign for $name {
+			#[inline]
+			fn sub_assign(&mut self, rhs: Self) {
+				*self = *self - rhs;
+			}
+		}
+
+		impl core::ops::MulAssign for $name {
+			#[inline]
+			fn mul_assign(&mut self, rhs: Self) {
+				*self = *self * rhs;
+			}
+		}
+
+		impl core::ops::DivAssign for $name {
+			#[inline]
+			fn div_assign(&mut self, rhs: Self) {
+				*self = *self / rhs;
+			}
+		}
+
+		impl core::ops::RemAssign for $name {
+			#[inline]
+			fn rem_assign(&mut self, rhs: Self) {
+				*self = *self % rhs;
+			}
+		}
+
+		// --- Bitwise ---
+
+		impl core::ops::BitAnd<$native> for $name {
+			type Output = Self;
+
+			#[inline]
+			fn bitand(self, rhs: $native) -> Self {
+				Self::from(self.get() & rhs)
+			}
+		}
+
+		impl core::ops::BitOr<$native> for $name {
+			type Output = Self;
+
+			#[inline]
+			fn bitor(self, rhs: $native) -> Self {
+				Self::from(self.get() | rhs)
+			}
+		}
+
+		impl core::ops::BitXor<$native> for $name {
+			type Output = Self;
+
+			#[inline]
+			fn bitxor(self, rhs: $native) -> Self {
+				Self::from(self.get() ^ rhs)
+			}
+		}
+
+		impl core::ops::BitAnd for $name {
+			type Output = Self;
+
+			#[inline]
+			fn bitand(self, rhs: Self) -> Self {
+				self & rhs.get()
+			}
+		}
+
+		impl core::ops::BitOr for $name {
+			type Output = Self;
+
+			#[inline]
+			fn bitor(self, rhs: Self) -> Self {
+				self | rhs.get()
+			}
+		}
+
+		impl core::ops::BitXor for $name {
+			type Output = Self;
+
+			#[inline]
+			fn bitxor(self, rhs: Self) -> Self {
+				self ^ rhs.get()
+			}
+		}
+
+		impl core::ops::Shl<u32> for $name {
+			type Output = Self;
+
+			#[inline]
+			fn shl(self, rhs: u32) -> Self {
+				Self::from(self.get() << rhs)
+			}
+		}
+
+		impl core::ops::Shr<u32> for $name {
+			type Output = Self;
+
+			#[inline]
+			fn shr(self, rhs: u32) -> Self {
+				Self::from(self.get() >> rhs)
+			}
+		}
+
+		impl core::ops::Not for $name {
+			type Output = Self;
+
+			#[inline]
+			fn not(self) -> Self {
+				Self::from(!self.get())
+			}
+		}
+
+		// --- Bitwise assign with native ---
+
+		impl core::ops::BitAndAssign<$native> for $name {
+			#[inline]
+			fn bitand_assign(&mut self, rhs: $native) {
+				*self = *self & rhs;
+			}
+		}
+
+		impl core::ops::BitOrAssign<$native> for $name {
+			#[inline]
+			fn bitor_assign(&mut self, rhs: $native) {
+				*self = *self | rhs;
+			}
+		}
+
+		impl core::ops::BitXorAssign<$native> for $name {
+			#[inline]
+			fn bitxor_assign(&mut self, rhs: $native) {
+				*self = *self ^ rhs;
+			}
+		}
+
+		// --- Bitwise assign with Pod ---
+
+		impl core::ops::BitAndAssign for $name {
+			#[inline]
+			fn bitand_assign(&mut self, rhs: Self) {
+				*self = *self & rhs;
+			}
+		}
+
+		impl core::ops::BitOrAssign for $name {
+			#[inline]
+			fn bitor_assign(&mut self, rhs: Self) {
+				*self = *self | rhs;
+			}
+		}
+
+		impl core::ops::BitXorAssign for $name {
+			#[inline]
+			fn bitxor_assign(&mut self, rhs: Self) {
+				*self = *self ^ rhs;
+			}
+		}
+
+		impl core::ops::ShlAssign<u32> for $name {
+			#[inline]
+			fn shl_assign(&mut self, rhs: u32) {
+				*self = *self << rhs;
+			}
+		}
+
+		impl core::ops::ShrAssign<u32> for $name {
+			#[inline]
+			fn shr_assign(&mut self, rhs: u32) {
+				*self = *self >> rhs;
+			}
+		}
+	};
+}
+
+/// Implements `Neg` for signed Pod types.
+macro_rules! impl_pod_neg {
+	($name:ident, $native:ty) => {
+		impl core::ops::Neg for $name {
+			type Output = Self;
+
+			#[inline]
+			fn neg(self) -> Self {
+				#[cfg(debug_assertions)]
+				{
+					Self::from(
+						self.get()
+							.checked_neg()
+							.unwrap_or_else(|| panic!("attempt to negate with overflow")),
+					)
+				}
+				#[cfg(not(debug_assertions))]
+				{
+					Self::from(self.get().wrapping_neg())
+				}
+			}
+		}
+	};
+}
+
+/// Defines an unsigned Pod integer type with full operator support.
+macro_rules! define_pod_unsigned {
+	($name:ident, $native:ty, $size:expr, $doc:expr) => {
+		#[doc = $doc]
+		#[derive(Clone, Copy, Default, PartialEq, Eq, Pod, Zeroable)]
+		#[repr(transparent)]
+		pub struct $name(pub [u8; $size]);
+
+		impl_int_conversion!($name, $native);
+		impl_pod_common!($name, $native, $size);
+		impl_pod_arithmetic!($name, $native);
+
+		impl fmt::Debug for $name {
+			fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+				write!(f, "{}({})", stringify!($name), self.get())
+			}
+		}
+	};
+}
+
+/// Defines a signed Pod integer type with full operator support.
+macro_rules! define_pod_signed {
+	($name:ident, $native:ty, $size:expr, $doc:expr) => {
+		#[doc = $doc]
+		#[derive(Clone, Copy, Default, PartialEq, Eq, Pod, Zeroable)]
+		#[repr(transparent)]
+		pub struct $name(pub [u8; $size]);
+
+		impl_int_conversion!($name, $native);
+		impl_pod_common!($name, $native, $size);
+		impl_pod_arithmetic!($name, $native);
+		impl_pod_neg!($name, $native);
+
+		impl fmt::Debug for $name {
+			fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+				write!(f, "{}({})", stringify!($name), self.get())
+			}
+		}
+	};
+}
+
+define_pod_unsigned!(
+	PodU16,
+	u16,
+	2,
+	"An alignment-1 wrapper around `u16` stored as `[u8; 2]`.\n\n\
+	 Enables safe zero-copy access inside `#[repr(C)]` account structs."
+);
+
+define_pod_signed!(
+	PodI16,
+	i16,
+	2,
+	"An alignment-1 wrapper around `i16` stored as `[u8; 2]`.\n\n\
+	 Enables safe zero-copy access inside `#[repr(C)]` account structs."
+);
+
+define_pod_unsigned!(
+	PodU32,
+	u32,
+	4,
+	"An alignment-1 wrapper around `u32` stored as `[u8; 4]`.\n\n\
+	 Enables safe zero-copy access inside `#[repr(C)]` account structs."
+);
+
+define_pod_signed!(
+	PodI32,
+	i32,
+	4,
+	"An alignment-1 wrapper around `i32` stored as `[u8; 4]`.\n\n\
+	 Enables safe zero-copy access inside `#[repr(C)]` account structs."
+);
+
+define_pod_unsigned!(
+	PodU64,
+	u64,
+	8,
+	"An alignment-1 wrapper around `u64` stored as `[u8; 8]`.\n\n\
+	 Enables safe zero-copy access inside `#[repr(C)]` account structs."
+);
+
+define_pod_signed!(
+	PodI64,
+	i64,
+	8,
+	"An alignment-1 wrapper around `i64` stored as `[u8; 8]`.\n\n\
+	 Enables safe zero-copy access inside `#[repr(C)]` account structs."
+);
+
+define_pod_unsigned!(
+	PodU128,
+	u128,
+	16,
+	"An alignment-1 wrapper around `u128` stored as `[u8; 16]`.\n\n\
+	 Enables safe zero-copy access inside `#[repr(C)]` account structs."
+);
+
+define_pod_signed!(
+	PodI128,
+	i128,
+	16,
+	"An alignment-1 wrapper around `i128` stored as `[u8; 16]`.\n\n\
+	 Enables safe zero-copy access inside `#[repr(C)]` account structs."
+);
+
+// Compile-time invariant: all Pod types must have alignment 1 and correct
+// size. These assertions guard against future changes that could break
+// zero-copy access.
+const _: () = assert!(align_of::<PodU16>() == 1);
+const _: () = assert!(size_of::<PodU16>() == 2);
+const _: () = assert!(align_of::<PodI16>() == 1);
+const _: () = assert!(size_of::<PodI16>() == 2);
+const _: () = assert!(align_of::<PodU32>() == 1);
+const _: () = assert!(size_of::<PodU32>() == 4);
+const _: () = assert!(align_of::<PodI32>() == 1);
+const _: () = assert!(size_of::<PodI32>() == 4);
+const _: () = assert!(align_of::<PodU64>() == 1);
+const _: () = assert!(size_of::<PodU64>() == 8);
+const _: () = assert!(align_of::<PodI64>() == 1);
+const _: () = assert!(size_of::<PodI64>() == 8);
+const _: () = assert!(align_of::<PodU128>() == 1);
+const _: () = assert!(size_of::<PodU128>() == 16);
+const _: () = assert!(align_of::<PodI128>() == 1);
+const _: () = assert!(size_of::<PodI128>() == 16);
+const _: () = assert!(align_of::<PodBool>() == 1);
+const _: () = assert!(size_of::<PodBool>() == 1);
 
 #[cfg(test)]
 extern crate std;
@@ -135,6 +752,10 @@ mod tests {
 	use bytemuck::try_from_bytes;
 
 	use super::*;
+
+	// =======================================================================
+	// PodBool tests
+	// =======================================================================
 
 	#[test]
 	fn pod_bool_roundtrip() {
@@ -206,6 +827,24 @@ mod tests {
 	}
 
 	#[test]
+	fn pod_bool_not() {
+		assert_eq!(!PodBool::from_bool(true), PodBool::from_bool(false));
+		assert_eq!(!PodBool::from_bool(false), PodBool::from_bool(true));
+		// Non-canonical values treated as true
+		assert_eq!(!PodBool(42), PodBool::from_bool(false));
+	}
+
+	#[test]
+	fn pod_bool_display() {
+		assert_eq!(std::format!("{}", PodBool::from_bool(true)), "true");
+		assert_eq!(std::format!("{}", PodBool::from_bool(false)), "false");
+	}
+
+	// =======================================================================
+	// Conversion roundtrip tests
+	// =======================================================================
+
+	#[test]
 	fn pod_u16_roundtrip() {
 		assert_eq!(1u16, u16::from(PodU16::from_primitive(1)));
 	}
@@ -244,6 +883,10 @@ mod tests {
 	fn pod_i128_roundtrip() {
 		assert_eq!(-11i128, i128::from(PodI128::from_primitive(-11)));
 	}
+
+	// =======================================================================
+	// Boundary value tests
+	// =======================================================================
 
 	#[test]
 	fn pod_u16_boundary_values() {
@@ -335,5 +978,503 @@ mod tests {
 		assert_eq!(i64::from(PodI64::default()), 0);
 		assert_eq!(u128::from(PodU128::default()), 0);
 		assert_eq!(i128::from(PodI128::default()), 0);
+	}
+
+	// =======================================================================
+	// Constants tests
+	// =======================================================================
+
+	#[test]
+	fn pod_constants_zero() {
+		assert!(PodU16::ZERO.is_zero());
+		assert!(PodU32::ZERO.is_zero());
+		assert!(PodU64::ZERO.is_zero());
+		assert!(PodU128::ZERO.is_zero());
+		assert!(PodI16::ZERO.is_zero());
+		assert!(PodI32::ZERO.is_zero());
+		assert!(PodI64::ZERO.is_zero());
+		assert!(PodI128::ZERO.is_zero());
+	}
+
+	#[test]
+	fn pod_constants_min_max() {
+		assert_eq!(PodU16::MIN.get(), u16::MIN);
+		assert_eq!(PodU16::MAX.get(), u16::MAX);
+		assert_eq!(PodU32::MIN.get(), u32::MIN);
+		assert_eq!(PodU32::MAX.get(), u32::MAX);
+		assert_eq!(PodU64::MIN.get(), u64::MIN);
+		assert_eq!(PodU64::MAX.get(), u64::MAX);
+		assert_eq!(PodU128::MIN.get(), u128::MIN);
+		assert_eq!(PodU128::MAX.get(), u128::MAX);
+		assert_eq!(PodI16::MIN.get(), i16::MIN);
+		assert_eq!(PodI16::MAX.get(), i16::MAX);
+		assert_eq!(PodI32::MIN.get(), i32::MIN);
+		assert_eq!(PodI32::MAX.get(), i32::MAX);
+		assert_eq!(PodI64::MIN.get(), i64::MIN);
+		assert_eq!(PodI64::MAX.get(), i64::MAX);
+		assert_eq!(PodI128::MIN.get(), i128::MIN);
+		assert_eq!(PodI128::MAX.get(), i128::MAX);
+	}
+
+	#[test]
+	fn pod_is_zero_false_for_nonzero() {
+		assert!(!PodU64::from_primitive(1).is_zero());
+		assert!(!PodI64::from_primitive(-1).is_zero());
+		assert!(!PodU128::MAX.is_zero());
+	}
+
+	// =======================================================================
+	// Arithmetic tests (Add, Sub, Mul, Div, Rem)
+	// =======================================================================
+
+	#[test]
+	fn pod_add_native() {
+		assert_eq!((PodU64::from(10u64) + 5u64).get(), 15);
+		assert_eq!((PodI32::from(10i32) + 5i32).get(), 15);
+		assert_eq!((PodI32::from(-10i32) + 5i32).get(), -5);
+	}
+
+	#[test]
+	fn pod_add_pod() {
+		let a = PodU64::from(10u64);
+		let b = PodU64::from(20u64);
+		assert_eq!((a + b).get(), 30);
+	}
+
+	#[test]
+	fn pod_sub_native() {
+		assert_eq!((PodU64::from(10u64) - 5u64).get(), 5);
+		assert_eq!((PodI32::from(-10i32) - 5i32).get(), -15);
+	}
+
+	#[test]
+	fn pod_sub_pod() {
+		let a = PodU64::from(20u64);
+		let b = PodU64::from(5u64);
+		assert_eq!((a - b).get(), 15);
+	}
+
+	#[test]
+	fn pod_mul_native() {
+		assert_eq!((PodU64::from(6u64) * 7u64).get(), 42);
+		assert_eq!((PodI32::from(-3i32) * 4i32).get(), -12);
+	}
+
+	#[test]
+	fn pod_mul_pod() {
+		let a = PodU32::from(6u32);
+		let b = PodU32::from(7u32);
+		assert_eq!((a * b).get(), 42);
+	}
+
+	#[test]
+	fn pod_div_native() {
+		assert_eq!((PodU64::from(42u64) / 7u64).get(), 6);
+		assert_eq!((PodI32::from(-12i32) / 4i32).get(), -3);
+	}
+
+	#[test]
+	fn pod_div_pod() {
+		let a = PodU64::from(42u64);
+		let b = PodU64::from(7u64);
+		assert_eq!((a / b).get(), 6);
+	}
+
+	#[test]
+	fn pod_rem_native() {
+		assert_eq!((PodU64::from(10u64) % 3u64).get(), 1);
+		assert_eq!((PodI32::from(-10i32) % 3i32).get(), -1);
+	}
+
+	#[test]
+	fn pod_rem_pod() {
+		let a = PodU64::from(10u64);
+		let b = PodU64::from(3u64);
+		assert_eq!((a % b).get(), 1);
+	}
+
+	// =======================================================================
+	// Assign operators
+	// =======================================================================
+
+	#[test]
+	fn pod_add_assign_native() {
+		let mut v = PodU64::from(10u64);
+		v += 5u64;
+		assert_eq!(v.get(), 15);
+	}
+
+	#[test]
+	fn pod_add_assign_pod() {
+		let mut v = PodU64::from(10u64);
+		v += PodU64::from(5u64);
+		assert_eq!(v.get(), 15);
+	}
+
+	#[test]
+	fn pod_sub_assign_native() {
+		let mut v = PodU64::from(10u64);
+		v -= 3u64;
+		assert_eq!(v.get(), 7);
+	}
+
+	#[test]
+	fn pod_sub_assign_pod() {
+		let mut v = PodU64::from(10u64);
+		v -= PodU64::from(3u64);
+		assert_eq!(v.get(), 7);
+	}
+
+	#[test]
+	fn pod_mul_assign_native() {
+		let mut v = PodU32::from(5u32);
+		v *= 4u32;
+		assert_eq!(v.get(), 20);
+	}
+
+	#[test]
+	fn pod_mul_assign_pod() {
+		let mut v = PodU32::from(5u32);
+		v *= PodU32::from(4u32);
+		assert_eq!(v.get(), 20);
+	}
+
+	#[test]
+	fn pod_div_assign_native() {
+		let mut v = PodU64::from(20u64);
+		v /= 5u64;
+		assert_eq!(v.get(), 4);
+	}
+
+	#[test]
+	fn pod_div_assign_pod() {
+		let mut v = PodU64::from(20u64);
+		v /= PodU64::from(5u64);
+		assert_eq!(v.get(), 4);
+	}
+
+	#[test]
+	fn pod_rem_assign_native() {
+		let mut v = PodU64::from(10u64);
+		v %= 3u64;
+		assert_eq!(v.get(), 1);
+	}
+
+	#[test]
+	fn pod_rem_assign_pod() {
+		let mut v = PodU64::from(10u64);
+		v %= PodU64::from(3u64);
+		assert_eq!(v.get(), 1);
+	}
+
+	// =======================================================================
+	// Bitwise tests
+	// =======================================================================
+
+	#[test]
+	fn pod_bitand_native() {
+		assert_eq!((PodU32::from(0xFF00u32) & 0x0FF0u32).get(), 0x0F00);
+	}
+
+	#[test]
+	fn pod_bitand_pod() {
+		let a = PodU32::from(0xFF00u32);
+		let b = PodU32::from(0x0FF0u32);
+		assert_eq!((a & b).get(), 0x0F00);
+	}
+
+	#[test]
+	fn pod_bitor_native() {
+		assert_eq!((PodU32::from(0xFF00u32) | 0x00FFu32).get(), 0xFFFF);
+	}
+
+	#[test]
+	fn pod_bitor_pod() {
+		let a = PodU32::from(0xFF00u32);
+		let b = PodU32::from(0x00FFu32);
+		assert_eq!((a | b).get(), 0xFFFF);
+	}
+
+	#[test]
+	fn pod_bitxor_native() {
+		assert_eq!((PodU32::from(0xFFFFu32) ^ 0xFF00u32).get(), 0x00FF);
+	}
+
+	#[test]
+	fn pod_bitxor_pod() {
+		let a = PodU32::from(0xFFFFu32);
+		let b = PodU32::from(0xFF00u32);
+		assert_eq!((a ^ b).get(), 0x00FF);
+	}
+
+	#[test]
+	fn pod_shl() {
+		assert_eq!((PodU32::from(1u32) << 4).get(), 16);
+	}
+
+	#[test]
+	fn pod_shr() {
+		assert_eq!((PodU32::from(16u32) >> 4).get(), 1);
+	}
+
+	#[test]
+	fn pod_not() {
+		assert_eq!((!PodU16::from(0u16)).get(), u16::MAX);
+		assert_eq!((!PodI16::from(0i16)).get(), -1i16);
+	}
+
+	// --- Bitwise assign ---
+
+	#[test]
+	fn pod_bitand_assign_native() {
+		let mut v = PodU32::from(0xFF00u32);
+		v &= 0x0FF0u32;
+		assert_eq!(v.get(), 0x0F00);
+	}
+
+	#[test]
+	fn pod_bitand_assign_pod() {
+		let mut v = PodU32::from(0xFF00u32);
+		v &= PodU32::from(0x0FF0u32);
+		assert_eq!(v.get(), 0x0F00);
+	}
+
+	#[test]
+	fn pod_bitor_assign_native() {
+		let mut v = PodU32::from(0xFF00u32);
+		v |= 0x00FFu32;
+		assert_eq!(v.get(), 0xFFFF);
+	}
+
+	#[test]
+	fn pod_bitor_assign_pod() {
+		let mut v = PodU32::from(0xFF00u32);
+		v |= PodU32::from(0x00FFu32);
+		assert_eq!(v.get(), 0xFFFF);
+	}
+
+	#[test]
+	fn pod_bitxor_assign_native() {
+		let mut v = PodU32::from(0xFFFFu32);
+		v ^= 0xFF00u32;
+		assert_eq!(v.get(), 0x00FF);
+	}
+
+	#[test]
+	fn pod_bitxor_assign_pod() {
+		let mut v = PodU32::from(0xFFFFu32);
+		v ^= PodU32::from(0xFF00u32);
+		assert_eq!(v.get(), 0x00FF);
+	}
+
+	#[test]
+	fn pod_shl_assign() {
+		let mut v = PodU32::from(1u32);
+		v <<= 4;
+		assert_eq!(v.get(), 16);
+	}
+
+	#[test]
+	fn pod_shr_assign() {
+		let mut v = PodU32::from(16u32);
+		v >>= 4;
+		assert_eq!(v.get(), 1);
+	}
+
+	// =======================================================================
+	// Neg for signed types
+	// =======================================================================
+
+	#[test]
+	fn pod_neg_i16() {
+		assert_eq!((-PodI16::from(5i16)).get(), -5);
+		assert_eq!((-PodI16::from(-5i16)).get(), 5);
+		assert_eq!((-PodI16::from(0i16)).get(), 0);
+	}
+
+	#[test]
+	fn pod_neg_i32() {
+		assert_eq!((-PodI32::from(42i32)).get(), -42);
+	}
+
+	#[test]
+	fn pod_neg_i64() {
+		assert_eq!((-PodI64::from(100i64)).get(), -100);
+	}
+
+	#[test]
+	fn pod_neg_i128() {
+		assert_eq!((-PodI128::from(999i128)).get(), -999);
+	}
+
+	// =======================================================================
+	// Checked arithmetic
+	// =======================================================================
+
+	#[test]
+	fn pod_checked_add_ok() {
+		assert_eq!(PodU64::from(10u64).checked_add(5u64), Some(PodU64::from(15u64)));
+	}
+
+	#[test]
+	fn pod_checked_add_overflow() {
+		assert_eq!(PodU64::MAX.checked_add(1u64), None);
+	}
+
+	#[test]
+	fn pod_checked_add_pod() {
+		assert_eq!(
+			PodU32::from(10u32).checked_add(PodU32::from(5u32)),
+			Some(PodU32::from(15u32))
+		);
+	}
+
+	#[test]
+	fn pod_checked_sub_ok() {
+		assert_eq!(PodU64::from(10u64).checked_sub(5u64), Some(PodU64::from(5u64)));
+	}
+
+	#[test]
+	fn pod_checked_sub_underflow() {
+		assert_eq!(PodU64::from(5u64).checked_sub(10u64), None);
+	}
+
+	#[test]
+	fn pod_checked_mul_ok() {
+		assert_eq!(PodU64::from(6u64).checked_mul(7u64), Some(PodU64::from(42u64)));
+	}
+
+	#[test]
+	fn pod_checked_mul_overflow() {
+		assert_eq!(PodU64::MAX.checked_mul(2u64), None);
+	}
+
+	#[test]
+	fn pod_checked_div_ok() {
+		assert_eq!(PodU64::from(42u64).checked_div(7u64), Some(PodU64::from(6u64)));
+	}
+
+	#[test]
+	fn pod_checked_div_by_zero() {
+		assert_eq!(PodU64::from(42u64).checked_div(0u64), None);
+	}
+
+	#[test]
+	fn pod_checked_signed_overflow() {
+		assert_eq!(PodI64::MIN.checked_sub(1i64), None);
+		assert_eq!(PodI64::MAX.checked_add(1i64), None);
+	}
+
+	// =======================================================================
+	// Saturating arithmetic
+	// =======================================================================
+
+	#[test]
+	fn pod_saturating_add() {
+		assert_eq!(PodU64::MAX.saturating_add(100u64), PodU64::MAX);
+		assert_eq!(PodU64::from(10u64).saturating_add(5u64), PodU64::from(15u64));
+	}
+
+	#[test]
+	fn pod_saturating_sub() {
+		assert_eq!(PodU64::from(5u64).saturating_sub(10u64), PodU64::ZERO);
+		assert_eq!(PodU64::from(10u64).saturating_sub(5u64), PodU64::from(5u64));
+	}
+
+	#[test]
+	fn pod_saturating_mul() {
+		assert_eq!(PodU64::MAX.saturating_mul(2u64), PodU64::MAX);
+		assert_eq!(PodU64::from(6u64).saturating_mul(7u64), PodU64::from(42u64));
+	}
+
+	#[test]
+	fn pod_saturating_signed() {
+		assert_eq!(PodI64::MAX.saturating_add(100i64), PodI64::MAX);
+		assert_eq!(PodI64::MIN.saturating_sub(100i64), PodI64::MIN);
+		assert_eq!(PodI64::MAX.saturating_mul(2i64), PodI64::MAX);
+		assert_eq!(PodI64::MIN.saturating_mul(2i64), PodI64::MIN);
+	}
+
+	// =======================================================================
+	// Ordering tests
+	// =======================================================================
+
+	#[test]
+	fn pod_ordering() {
+		assert!(PodU64::from(10u64) > PodU64::from(5u64));
+		assert!(PodU64::from(5u64) < PodU64::from(10u64));
+		assert!(PodU64::from(5u64) == PodU64::from(5u64));
+
+		assert!(PodI64::from(-10i64) < PodI64::from(5i64));
+		assert!(PodI64::from(5i64) > PodI64::from(-10i64));
+	}
+
+	#[test]
+	fn pod_partial_eq_native() {
+		assert!(PodU64::from(42u64) == 42u64);
+		assert!(PodI32::from(-5i32) == -5i32);
+		assert!(PodU64::from(42u64) != 43u64);
+	}
+
+	#[test]
+	fn pod_partial_ord_native() {
+		assert!(PodU64::from(10u64) > 5u64);
+		assert!(PodU64::from(5u64) < 10u64);
+		assert!(PodI32::from(-10i32) < 0i32);
+	}
+
+	// =======================================================================
+	// Display / Debug tests
+	// =======================================================================
+
+	#[test]
+	fn pod_display() {
+		assert_eq!(std::format!("{}", PodU64::from(42u64)), "42");
+		assert_eq!(std::format!("{}", PodI32::from(-7i32)), "-7");
+		assert_eq!(std::format!("{}", PodU128::from(0u128)), "0");
+	}
+
+	#[test]
+	fn pod_debug() {
+		assert_eq!(std::format!("{:?}", PodU64::from(42u64)), "PodU64(42)");
+		assert_eq!(std::format!("{:?}", PodI32::from(-7i32)), "PodI32(-7)");
+	}
+
+	// =======================================================================
+	// Get method tests
+	// =======================================================================
+
+	#[test]
+	fn pod_get_method() {
+		assert_eq!(PodU16::from(1337u16).get(), 1337);
+		assert_eq!(PodI16::from(-42i16).get(), -42);
+		assert_eq!(PodU32::from(0xDEAD_BEEFu32).get(), 0xDEAD_BEEF);
+		assert_eq!(PodI32::from(i32::MIN).get(), i32::MIN);
+		assert_eq!(PodU64::from(u64::MAX).get(), u64::MAX);
+		assert_eq!(PodI64::from(i64::MAX).get(), i64::MAX);
+		assert_eq!(PodU128::from(u128::MAX).get(), u128::MAX);
+		assert_eq!(PodI128::from(i128::MIN).get(), i128::MIN);
+	}
+
+	// =======================================================================
+	// Ergonomic usage pattern: counter increment (the motivating use case)
+	// =======================================================================
+
+	#[test]
+	fn ergonomic_counter_increment() {
+		// Simulates struct field usage: my_account.count += 1;
+		let mut count = PodU64::from(0u64);
+		count += 1u64;
+		assert_eq!(count.get(), 1);
+		count += 1u64;
+		assert_eq!(count.get(), 2);
+	}
+
+	#[test]
+	fn ergonomic_balance_arithmetic() {
+		let mut balance = PodU64::from(1000u64);
+		let fee = PodU64::from(25u64);
+		balance -= fee;
+		assert_eq!(balance.get(), 975);
 	}
 }

--- a/crates/pina_pod_primitives/src/lib.rs
+++ b/crates/pina_pod_primitives/src/lib.rs
@@ -18,11 +18,12 @@
 //!
 //! Each Pod integer type provides `ZERO`, `MIN`, and `MAX` constants.
 
-use bytemuck::Pod;
-use bytemuck::Zeroable;
 use core::fmt;
 use core::mem::align_of;
 use core::mem::size_of;
+
+use bytemuck::Pod;
+use bytemuck::Zeroable;
 
 /// The standard `bool` is not a `Pod`, define a replacement that is.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
@@ -127,22 +128,12 @@ macro_rules! impl_int_conversion {
 macro_rules! impl_pod_common {
 	($name:ident, $native:ty, $size:expr) => {
 		impl $name {
+			/// The largest value representable by the underlying integer type.
+			pub const MAX: Self = Self(<$native>::MAX.to_le_bytes());
+			/// The smallest value representable by the underlying integer type.
+			pub const MIN: Self = Self(<$native>::MIN.to_le_bytes());
 			/// The zero value.
 			pub const ZERO: Self = Self([0u8; $size]);
-
-			#[doc = concat!(
-				"The largest value representable by [`",
-				stringify!($native),
-				"`]."
-			)]
-			pub const MAX: Self = Self(<$native>::MAX.to_le_bytes());
-
-			#[doc = concat!(
-				"The smallest value representable by [`",
-				stringify!($native),
-				"`]."
-			)]
-			pub const MIN: Self = Self(<$native>::MIN.to_le_bytes());
 
 			/// Returns `true` if the value is zero.
 			#[inline]
@@ -662,64 +653,64 @@ define_pod_unsigned!(
 	PodU16,
 	u16,
 	2,
-	"An alignment-1 wrapper around `u16` stored as `[u8; 2]`.\n\n\
-	 Enables safe zero-copy access inside `#[repr(C)]` account structs."
+	"An alignment-1 wrapper around `u16` stored as `[u8; 2]`.\n\nEnables safe zero-copy access \
+	 inside `#[repr(C)]` account structs."
 );
 
 define_pod_signed!(
 	PodI16,
 	i16,
 	2,
-	"An alignment-1 wrapper around `i16` stored as `[u8; 2]`.\n\n\
-	 Enables safe zero-copy access inside `#[repr(C)]` account structs."
+	"An alignment-1 wrapper around `i16` stored as `[u8; 2]`.\n\nEnables safe zero-copy access \
+	 inside `#[repr(C)]` account structs."
 );
 
 define_pod_unsigned!(
 	PodU32,
 	u32,
 	4,
-	"An alignment-1 wrapper around `u32` stored as `[u8; 4]`.\n\n\
-	 Enables safe zero-copy access inside `#[repr(C)]` account structs."
+	"An alignment-1 wrapper around `u32` stored as `[u8; 4]`.\n\nEnables safe zero-copy access \
+	 inside `#[repr(C)]` account structs."
 );
 
 define_pod_signed!(
 	PodI32,
 	i32,
 	4,
-	"An alignment-1 wrapper around `i32` stored as `[u8; 4]`.\n\n\
-	 Enables safe zero-copy access inside `#[repr(C)]` account structs."
+	"An alignment-1 wrapper around `i32` stored as `[u8; 4]`.\n\nEnables safe zero-copy access \
+	 inside `#[repr(C)]` account structs."
 );
 
 define_pod_unsigned!(
 	PodU64,
 	u64,
 	8,
-	"An alignment-1 wrapper around `u64` stored as `[u8; 8]`.\n\n\
-	 Enables safe zero-copy access inside `#[repr(C)]` account structs."
+	"An alignment-1 wrapper around `u64` stored as `[u8; 8]`.\n\nEnables safe zero-copy access \
+	 inside `#[repr(C)]` account structs."
 );
 
 define_pod_signed!(
 	PodI64,
 	i64,
 	8,
-	"An alignment-1 wrapper around `i64` stored as `[u8; 8]`.\n\n\
-	 Enables safe zero-copy access inside `#[repr(C)]` account structs."
+	"An alignment-1 wrapper around `i64` stored as `[u8; 8]`.\n\nEnables safe zero-copy access \
+	 inside `#[repr(C)]` account structs."
 );
 
 define_pod_unsigned!(
 	PodU128,
 	u128,
 	16,
-	"An alignment-1 wrapper around `u128` stored as `[u8; 16]`.\n\n\
-	 Enables safe zero-copy access inside `#[repr(C)]` account structs."
+	"An alignment-1 wrapper around `u128` stored as `[u8; 16]`.\n\nEnables safe zero-copy access \
+	 inside `#[repr(C)]` account structs."
 );
 
 define_pod_signed!(
 	PodI128,
 	i128,
 	16,
-	"An alignment-1 wrapper around `i128` stored as `[u8; 16]`.\n\n\
-	 Enables safe zero-copy access inside `#[repr(C)]` account structs."
+	"An alignment-1 wrapper around `i128` stored as `[u8; 16]`.\n\nEnables safe zero-copy access \
+	 inside `#[repr(C)]` account structs."
 );
 
 // Compile-time invariant: all Pod types must have alignment 1 and correct
@@ -1313,7 +1304,10 @@ mod tests {
 
 	#[test]
 	fn pod_checked_add_ok() {
-		assert_eq!(PodU64::from(10u64).checked_add(5u64), Some(PodU64::from(15u64)));
+		assert_eq!(
+			PodU64::from(10u64).checked_add(5u64),
+			Some(PodU64::from(15u64))
+		);
 	}
 
 	#[test]
@@ -1331,7 +1325,10 @@ mod tests {
 
 	#[test]
 	fn pod_checked_sub_ok() {
-		assert_eq!(PodU64::from(10u64).checked_sub(5u64), Some(PodU64::from(5u64)));
+		assert_eq!(
+			PodU64::from(10u64).checked_sub(5u64),
+			Some(PodU64::from(5u64))
+		);
 	}
 
 	#[test]
@@ -1341,7 +1338,10 @@ mod tests {
 
 	#[test]
 	fn pod_checked_mul_ok() {
-		assert_eq!(PodU64::from(6u64).checked_mul(7u64), Some(PodU64::from(42u64)));
+		assert_eq!(
+			PodU64::from(6u64).checked_mul(7u64),
+			Some(PodU64::from(42u64))
+		);
 	}
 
 	#[test]
@@ -1351,7 +1351,10 @@ mod tests {
 
 	#[test]
 	fn pod_checked_div_ok() {
-		assert_eq!(PodU64::from(42u64).checked_div(7u64), Some(PodU64::from(6u64)));
+		assert_eq!(
+			PodU64::from(42u64).checked_div(7u64),
+			Some(PodU64::from(6u64))
+		);
 	}
 
 	#[test]
@@ -1372,7 +1375,10 @@ mod tests {
 	#[test]
 	fn pod_saturating_add() {
 		assert_eq!(PodU64::MAX.saturating_add(100u64), PodU64::MAX);
-		assert_eq!(PodU64::from(10u64).saturating_add(5u64), PodU64::from(15u64));
+		assert_eq!(
+			PodU64::from(10u64).saturating_add(5u64),
+			PodU64::from(15u64)
+		);
 	}
 
 	#[test]

--- a/crates/pina_pod_primitives/tests/fuzz_pod.rs
+++ b/crates/pina_pod_primitives/tests/fuzz_pod.rs
@@ -1,5 +1,6 @@
 //! Property-based fuzz tests for Pod type deserialization, round-trip
-//! correctness, and safety under arbitrary byte patterns.
+//! correctness, arithmetic operations, and safety under arbitrary byte
+//! patterns.
 
 use bytemuck::try_from_bytes;
 use pina_pod_primitives::PodBool;
@@ -305,5 +306,226 @@ proptest! {
 		.into();
 		let re_encoded = PodU128::from_primitive(val);
 		prop_assert_eq!(re_encoded.0, bytes);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Arithmetic property tests: Pod ops match native ops
+// ---------------------------------------------------------------------------
+
+/// Helper macro to generate arithmetic property tests for a Pod type.
+macro_rules! arithmetic_property_tests {
+	($mod_name:ident, $pod:ty, $native:ty) => {
+		mod $mod_name {
+			use super::*;
+			use proptest::prelude::*;
+
+			proptest! {
+				/// checked_add on Pod matches checked_add on native.
+				#[test]
+				fn checked_add_matches_native(a: $native, b: $native) {
+					let pod_result = <$pod>::from(a).checked_add(b);
+					let native_result = a.checked_add(b);
+					match (pod_result, native_result) {
+						(Some(pod_val), Some(native_val)) => {
+							prop_assert_eq!(pod_val.get(), native_val);
+						}
+						(None, None) => {} // both overflow
+						_ => {
+							prop_assert!(false, "checked_add mismatch: pod={pod_result:?}, native={native_result:?}");
+						}
+					}
+				}
+
+				/// checked_sub on Pod matches checked_sub on native.
+				#[test]
+				fn checked_sub_matches_native(a: $native, b: $native) {
+					let pod_result = <$pod>::from(a).checked_sub(b);
+					let native_result = a.checked_sub(b);
+					match (pod_result, native_result) {
+						(Some(pod_val), Some(native_val)) => {
+							prop_assert_eq!(pod_val.get(), native_val);
+						}
+						(None, None) => {}
+						_ => {
+							prop_assert!(false, "checked_sub mismatch");
+						}
+					}
+				}
+
+				/// checked_mul on Pod matches checked_mul on native.
+				#[test]
+				fn checked_mul_matches_native(a: $native, b: $native) {
+					let pod_result = <$pod>::from(a).checked_mul(b);
+					let native_result = a.checked_mul(b);
+					match (pod_result, native_result) {
+						(Some(pod_val), Some(native_val)) => {
+							prop_assert_eq!(pod_val.get(), native_val);
+						}
+						(None, None) => {}
+						_ => {
+							prop_assert!(false, "checked_mul mismatch");
+						}
+					}
+				}
+
+				/// checked_div on Pod matches checked_div on native.
+				#[test]
+				fn checked_div_matches_native(a: $native, b: $native) {
+					let pod_result = <$pod>::from(a).checked_div(b);
+					let native_result = a.checked_div(b);
+					match (pod_result, native_result) {
+						(Some(pod_val), Some(native_val)) => {
+							prop_assert_eq!(pod_val.get(), native_val);
+						}
+						(None, None) => {}
+						_ => {
+							prop_assert!(false, "checked_div mismatch");
+						}
+					}
+				}
+
+				/// saturating_add on Pod matches saturating_add on native.
+				#[test]
+				fn saturating_add_matches_native(a: $native, b: $native) {
+					let pod_result = <$pod>::from(a).saturating_add(b);
+					let native_result = a.saturating_add(b);
+					prop_assert_eq!(pod_result.get(), native_result);
+				}
+
+				/// saturating_sub on Pod matches saturating_sub on native.
+				#[test]
+				fn saturating_sub_matches_native(a: $native, b: $native) {
+					let pod_result = <$pod>::from(a).saturating_sub(b);
+					let native_result = a.saturating_sub(b);
+					prop_assert_eq!(pod_result.get(), native_result);
+				}
+
+				/// saturating_mul on Pod matches saturating_mul on native.
+				#[test]
+				fn saturating_mul_matches_native(a: $native, b: $native) {
+					let pod_result = <$pod>::from(a).saturating_mul(b);
+					let native_result = a.saturating_mul(b);
+					prop_assert_eq!(pod_result.get(), native_result);
+				}
+
+				/// Bitwise AND on Pod matches native.
+				#[test]
+				fn bitand_matches_native(a: $native, b: $native) {
+					let result = (<$pod>::from(a) & b).get();
+					prop_assert_eq!(result, a & b);
+				}
+
+				/// Bitwise OR on Pod matches native.
+				#[test]
+				fn bitor_matches_native(a: $native, b: $native) {
+					let result = (<$pod>::from(a) | b).get();
+					prop_assert_eq!(result, a | b);
+				}
+
+				/// Bitwise XOR on Pod matches native.
+				#[test]
+				fn bitxor_matches_native(a: $native, b: $native) {
+					let result = (<$pod>::from(a) ^ b).get();
+					prop_assert_eq!(result, a ^ b);
+				}
+
+				/// NOT on Pod matches native.
+				#[test]
+				fn not_matches_native(a: $native) {
+					let result = (!<$pod>::from(a)).get();
+					prop_assert_eq!(result, !a);
+				}
+
+				/// Ordering on Pod matches native.
+				#[test]
+				fn ordering_matches_native(a: $native, b: $native) {
+					let pod_a = <$pod>::from(a);
+					let pod_b = <$pod>::from(b);
+					prop_assert_eq!(pod_a.cmp(&pod_b), a.cmp(&b));
+				}
+
+				/// is_zero correctness.
+				#[test]
+				fn is_zero_correctness(a: $native) {
+					let pod = <$pod>::from(a);
+					prop_assert_eq!(pod.is_zero(), a == 0);
+				}
+			}
+		}
+	};
+}
+
+arithmetic_property_tests!(arith_u16, PodU16, u16);
+arithmetic_property_tests!(arith_i16, PodI16, i16);
+arithmetic_property_tests!(arith_u32, PodU32, u32);
+arithmetic_property_tests!(arith_i32, PodI32, i32);
+arithmetic_property_tests!(arith_u64, PodU64, u64);
+arithmetic_property_tests!(arith_i64, PodI64, i64);
+arithmetic_property_tests!(arith_u128, PodU128, u128);
+arithmetic_property_tests!(arith_i128, PodI128, i128);
+
+// ---------------------------------------------------------------------------
+// Neg property tests for signed types
+// ---------------------------------------------------------------------------
+
+proptest! {
+	#[test]
+	fn neg_i16_matches_native(a: i16) {
+		// Skip i16::MIN because checked_neg overflows
+		prop_assume!(a != i16::MIN);
+		let result = (-PodI16::from(a)).get();
+		prop_assert_eq!(result, -a);
+	}
+
+	#[test]
+	fn neg_i32_matches_native(a: i32) {
+		prop_assume!(a != i32::MIN);
+		let result = (-PodI32::from(a)).get();
+		prop_assert_eq!(result, -a);
+	}
+
+	#[test]
+	fn neg_i64_matches_native(a: i64) {
+		prop_assume!(a != i64::MIN);
+		let result = (-PodI64::from(a)).get();
+		prop_assert_eq!(result, -a);
+	}
+
+	#[test]
+	fn neg_i128_matches_native(a: i128) {
+		prop_assume!(a != i128::MIN);
+		let result = (-PodI128::from(a)).get();
+		prop_assert_eq!(result, -a);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Shift property tests
+// ---------------------------------------------------------------------------
+
+proptest! {
+	#[test]
+	fn shl_u64_matches_native(a: u64, shift in 0u32..64) {
+		let result = (PodU64::from(a) << shift).get();
+		prop_assert_eq!(result, a << shift);
+	}
+
+	#[test]
+	fn shr_u64_matches_native(a: u64, shift in 0u32..64) {
+		let result = (PodU64::from(a) >> shift).get();
+		prop_assert_eq!(result, a >> shift);
+	}
+
+	#[test]
+	fn shl_i64_matches_native(a: i64, shift in 0u32..64) {
+		let result = (PodI64::from(a) << shift).get();
+		prop_assert_eq!(result, a << shift);
+	}
+
+	#[test]
+	fn shr_i64_matches_native(a: i64, shift in 0u32..64) {
+		let result = (PodI64::from(a) >> shift).get();
+		prop_assert_eq!(result, a >> shift);
 	}
 }

--- a/crates/pina_profile/Cargo.toml
+++ b/crates/pina_profile/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "pina_profile"
+version = { workspace = true }
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme = "readme.md"
+repository.workspace = true
+description = "Static CU profiler for Solana SBF programs"
+
+[dependencies]
+object = { version = "0.36", default-features = false, features = ["read", "elf", "std"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true, default-features = true }
+
+[dev-dependencies]
+tempfile = "3"
+
+[lints]
+workspace = true

--- a/crates/pina_profile/Cargo.toml
+++ b/crates/pina_profile/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true, default-features = true }
 
 [dev-dependencies]
+object = { version = "0.36", features = ["read", "elf", "std", "write"] }
 tempfile = "3"
 
 [lints]

--- a/crates/pina_profile/readme.md
+++ b/crates/pina_profile/readme.md
@@ -1,0 +1,29 @@
+# pina_profile
+
+Static CU (Compute Unit) profiler for Solana SBF programs.
+
+Analyzes compiled `.so` ELF binaries to estimate per-function compute unit
+costs without requiring a running validator.
+
+## Usage
+
+```sh
+pina profile target/deploy/my_program.so
+pina profile target/deploy/my_program.so --json
+pina profile target/deploy/my_program.so --output report.json
+```
+
+## How it works
+
+Solana's SBF instruction set has deterministic CU costs. This tool:
+
+1. Parses the ELF binary to extract `.text` sections
+2. Walks the SBF instruction stream, counting instructions per symbol
+3. Estimates CU cost based on the known per-opcode cost model
+4. Outputs a summary (text or JSON) with per-function breakdowns
+
+## Limitations
+
+- Static analysis only — does not account for runtime branching
+- Best-effort symbol resolution (works best with unstripped binaries)
+- CU estimates represent worst-case / single-path costs

--- a/crates/pina_profile/readme.md
+++ b/crates/pina_profile/readme.md
@@ -2,8 +2,7 @@
 
 Static CU (Compute Unit) profiler for Solana SBF programs.
 
-Analyzes compiled `.so` ELF binaries to estimate per-function compute unit
-costs without requiring a running validator.
+Analyzes compiled `.so` ELF binaries to estimate per-function compute unit costs without requiring a running validator.
 
 ## Usage
 

--- a/crates/pina_profile/readme.md
+++ b/crates/pina_profile/readme.md
@@ -18,7 +18,7 @@ Solana's SBF instruction set has deterministic CU costs. This tool:
 
 1. Parses the ELF binary to extract `.text` sections
 2. Walks the SBF instruction stream, counting instructions per symbol
-3. Estimates CU cost based on the known per-opcode cost model
+3. Estimates CU cost using a static per-instruction baseline model
 4. Outputs a summary (text or JSON) with per-function breakdowns
 
 ## Limitations

--- a/crates/pina_profile/src/cost.rs
+++ b/crates/pina_profile/src/cost.rs
@@ -1,0 +1,45 @@
+//! CU cost model and profile data structures.
+//!
+//! Solana's SBF runtime assigns deterministic CU costs to each instruction
+//! class. This module defines the cost model and the profile output structs.
+
+use serde::Serialize;
+
+/// CU cost per regular instruction (ALU, memory, branch).
+///
+/// The SBF VM charges 1 CU per instruction by default.
+/// Some syscalls have higher costs, but for static analysis of the
+/// instruction stream this is the baseline.
+pub const CU_PER_INSTRUCTION: u64 = 1;
+
+/// Per-function CU profile.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct FunctionProfile {
+	/// Function name (symbol name or `<unknown+offset>`).
+	pub name: String,
+	/// Byte offset of the function within the `.text` section.
+	pub offset: u64,
+	/// Size of the function in bytes.
+	pub size: u64,
+	/// Number of SBF instructions in the function.
+	pub instruction_count: u64,
+	/// Estimated CU cost (`instruction_count * CU_PER_INSTRUCTION`).
+	pub estimated_cu: u64,
+}
+
+/// Complete profile for a program binary.
+#[derive(Debug, Clone, Serialize)]
+pub struct ProgramProfile {
+	/// Program name (derived from the ELF filename).
+	pub program_name: String,
+	/// Total binary size in bytes.
+	pub binary_size: u64,
+	/// Size of the `.text` section(s) in bytes.
+	pub text_size: u64,
+	/// Total SBF instruction count across all functions.
+	pub total_instructions: u64,
+	/// Total estimated CU across all functions.
+	pub total_cu: u64,
+	/// Per-function profiles, sorted by estimated CU (descending).
+	pub functions: Vec<FunctionProfile>,
+}

--- a/crates/pina_profile/src/elf.rs
+++ b/crates/pina_profile/src/elf.rs
@@ -40,22 +40,26 @@ pub struct ElfInfo {
 
 /// Parse an ELF binary and extract profiling-relevant information.
 pub fn parse_elf(data: &[u8], path: &Path) -> Result<ElfInfo, ProfileError> {
-	let obj = object::File::parse(data).map_err(|e| ProfileError::Elf {
-		path: path.to_path_buf(),
-		message: e.to_string(),
+	let obj = object::File::parse(data).map_err(|e| {
+		ProfileError::Elf {
+			path: path.to_path_buf(),
+			message: e.to_string(),
+		}
 	})?;
 
 	// Find the .text section.
-	let text_section = obj
-		.section_by_name(".text")
-		.ok_or_else(|| ProfileError::NoTextSection {
+	let text_section = obj.section_by_name(".text").ok_or_else(|| {
+		ProfileError::NoTextSection {
 			path: path.to_path_buf(),
-		})?;
+		}
+	})?;
 
 	let text_vaddr = text_section.address();
-	let text_bytes = text_section.data().map_err(|e| ProfileError::Elf {
-		path: path.to_path_buf(),
-		message: format!("Failed to read .text section data: {e}"),
+	let text_bytes = text_section.data().map_err(|e| {
+		ProfileError::Elf {
+			path: path.to_path_buf(),
+			message: format!("Failed to read .text section data: {e}"),
+		}
 	})?;
 	let text_size = text_bytes.len() as u64;
 

--- a/crates/pina_profile/src/elf.rs
+++ b/crates/pina_profile/src/elf.rs
@@ -1,0 +1,131 @@
+//! ELF parsing for SBF binaries.
+//!
+//! Extracts symbol tables, `.text` section boundaries, and program metadata
+//! from compiled Solana program `.so` files using the `object` crate.
+
+use std::path::Path;
+
+use object::Object;
+use object::ObjectSection;
+use object::ObjectSymbol;
+use object::SymbolKind;
+
+use crate::ProfileError;
+
+/// A resolved symbol from the ELF symbol table.
+#[derive(Debug, Clone)]
+pub struct Symbol {
+	/// Symbol name.
+	pub name: String,
+	/// Virtual address of the symbol.
+	pub address: u64,
+	/// Size of the symbol in bytes (0 if unknown).
+	pub size: u64,
+}
+
+/// Parsed ELF information relevant to profiling.
+#[derive(Debug)]
+pub struct ElfInfo {
+	/// Program name (derived from filename).
+	pub program_name: String,
+	/// Raw bytes of the `.text` section.
+	pub text_bytes: Vec<u8>,
+	/// Virtual address of the `.text` section start.
+	pub text_vaddr: u64,
+	/// Size of the `.text` section in bytes.
+	pub text_size: u64,
+	/// Symbols from the ELF symbol table, sorted by address.
+	pub symbols: Vec<Symbol>,
+}
+
+/// Parse an ELF binary and extract profiling-relevant information.
+pub fn parse_elf(data: &[u8], path: &Path) -> Result<ElfInfo, ProfileError> {
+	let obj = object::File::parse(data).map_err(|e| ProfileError::Elf {
+		path: path.to_path_buf(),
+		message: e.to_string(),
+	})?;
+
+	// Find the .text section.
+	let text_section = obj
+		.section_by_name(".text")
+		.ok_or_else(|| ProfileError::NoTextSection {
+			path: path.to_path_buf(),
+		})?;
+
+	let text_vaddr = text_section.address();
+	let text_bytes = text_section.data().map_err(|e| ProfileError::Elf {
+		path: path.to_path_buf(),
+		message: format!("Failed to read .text section data: {e}"),
+	})?;
+	let text_size = text_bytes.len() as u64;
+
+	// Extract function symbols sorted by address.
+	let mut symbols: Vec<Symbol> = obj
+		.symbols()
+		.filter(|sym| sym.kind() == SymbolKind::Text && sym.size() > 0)
+		.filter_map(|sym| {
+			let name = sym.name().ok()?;
+			if name.is_empty() {
+				return None;
+			}
+			Some(Symbol {
+				name: name.to_owned(),
+				address: sym.address(),
+				size: sym.size(),
+			})
+		})
+		.collect();
+
+	symbols.sort_by_key(|s| s.address);
+
+	let program_name = path
+		.file_stem()
+		.and_then(|s| s.to_str())
+		.unwrap_or("unknown")
+		.to_owned();
+
+	Ok(ElfInfo {
+		program_name,
+		text_bytes: text_bytes.to_vec(),
+		text_vaddr,
+		text_size,
+		symbols,
+	})
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn parse_elf_rejects_empty_data() {
+		let result = parse_elf(&[], Path::new("empty.so"));
+		assert!(result.is_err());
+	}
+
+	#[test]
+	fn parse_elf_rejects_garbage_data() {
+		let garbage = vec![0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01, 0x02, 0x03];
+		let result = parse_elf(&garbage, Path::new("garbage.so"));
+		assert!(result.is_err());
+	}
+
+	#[test]
+	fn symbol_sorting() {
+		let mut symbols = vec![
+			Symbol {
+				name: "b".to_owned(),
+				address: 200,
+				size: 10,
+			},
+			Symbol {
+				name: "a".to_owned(),
+				address: 100,
+				size: 20,
+			},
+		];
+		symbols.sort_by_key(|s| s.address);
+		assert_eq!(symbols[0].name, "a");
+		assert_eq!(symbols[1].name, "b");
+	}
+}

--- a/crates/pina_profile/src/elf.rs
+++ b/crates/pina_profile/src/elf.rs
@@ -5,6 +5,8 @@
 
 use std::path::Path;
 
+use object::Architecture;
+use object::BinaryFormat;
 use object::Object;
 use object::ObjectSection;
 use object::ObjectSymbol;
@@ -47,6 +49,24 @@ pub fn parse_elf(data: &[u8], path: &Path) -> Result<ElfInfo, ProfileError> {
 		}
 	})?;
 
+	// Validate this is an ELF targeting SBF/BPF.
+	if obj.format() != BinaryFormat::Elf {
+		return Err(ProfileError::Elf {
+			path: path.to_path_buf(),
+			message: format!("expected ELF format, got {:?}", obj.format()),
+		});
+	}
+
+	match obj.architecture() {
+		Architecture::Bpf | Architecture::Sbf => {}
+		arch => {
+			return Err(ProfileError::Elf {
+				path: path.to_path_buf(),
+				message: format!("expected SBF/BPF architecture, got {arch:?}"),
+			});
+		}
+	}
+
 	// Find the .text section.
 	let text_section = obj.section_by_name(".text").ok_or_else(|| {
 		ProfileError::NoTextSection {
@@ -64,17 +84,24 @@ pub fn parse_elf(data: &[u8], path: &Path) -> Result<ElfInfo, ProfileError> {
 	let text_size = text_bytes.len() as u64;
 
 	// Extract function symbols sorted by address.
+	// Keep zero-sized symbols so downstream span inference can run.
+	// Filter to the `.text` virtual address range.
+	let text_end = text_vaddr.saturating_add(text_size);
 	let mut symbols: Vec<Symbol> = obj
 		.symbols()
-		.filter(|sym| sym.kind() == SymbolKind::Text && sym.size() > 0)
+		.filter(|sym| sym.kind() == SymbolKind::Text)
 		.filter_map(|sym| {
 			let name = sym.name().ok()?;
 			if name.is_empty() {
 				return None;
 			}
+			let address = sym.address();
+			if !(text_vaddr..text_end).contains(&address) {
+				return None;
+			}
 			Some(Symbol {
 				name: name.to_owned(),
-				address: sym.address(),
+				address,
 				size: sym.size(),
 			})
 		})

--- a/crates/pina_profile/src/lib.rs
+++ b/crates/pina_profile/src/lib.rs
@@ -1,0 +1,64 @@
+//! Static CU profiler for Solana SBF programs.
+//!
+//! Analyzes compiled `.so` ELF binaries to estimate per-function compute unit
+//! costs without requiring a running validator.
+
+pub mod cost;
+pub mod elf;
+pub mod output;
+pub mod sbf;
+
+use std::path::Path;
+
+pub use cost::FunctionProfile;
+pub use cost::ProgramProfile;
+pub use output::OutputFormat;
+
+/// Profile a compiled SBF program at the given path.
+///
+/// Returns a [`ProgramProfile`] containing per-function CU estimates and
+/// binary metadata.
+///
+/// # Errors
+///
+/// Returns a [`ProfileError`] if the file cannot be read, is not a valid ELF,
+/// or contains no SBF text sections.
+pub fn profile_program(path: &Path) -> Result<ProgramProfile, ProfileError> {
+	let data = std::fs::read(path).map_err(|e| ProfileError::Io {
+		path: path.to_path_buf(),
+		source: e,
+	})?;
+
+	let elf_info = elf::parse_elf(&data, path)?;
+	let functions = sbf::analyze_functions(&elf_info);
+	let total_instructions = functions.iter().map(|f| f.instruction_count).sum();
+	let total_cu = functions.iter().map(|f| f.estimated_cu).sum();
+
+	Ok(ProgramProfile {
+		program_name: elf_info.program_name,
+		binary_size: data.len() as u64,
+		text_size: elf_info.text_size,
+		total_instructions,
+		total_cu,
+		functions,
+	})
+}
+
+/// Errors produced during profiling.
+#[derive(Debug, thiserror::Error)]
+pub enum ProfileError {
+	#[error("IO error at {path}: {source}")]
+	Io {
+		path: std::path::PathBuf,
+		source: std::io::Error,
+	},
+
+	#[error("Failed to parse ELF at {path}: {message}")]
+	Elf {
+		path: std::path::PathBuf,
+		message: String,
+	},
+
+	#[error("No SBF text section found in {path}")]
+	NoTextSection { path: std::path::PathBuf },
+}

--- a/crates/pina_profile/src/lib.rs
+++ b/crates/pina_profile/src/lib.rs
@@ -24,9 +24,11 @@ pub use output::OutputFormat;
 /// Returns a [`ProfileError`] if the file cannot be read, is not a valid ELF,
 /// or contains no SBF text sections.
 pub fn profile_program(path: &Path) -> Result<ProgramProfile, ProfileError> {
-	let data = std::fs::read(path).map_err(|e| ProfileError::Io {
-		path: path.to_path_buf(),
-		source: e,
+	let data = std::fs::read(path).map_err(|e| {
+		ProfileError::Io {
+			path: path.to_path_buf(),
+			source: e,
+		}
 	})?;
 
 	let elf_info = elf::parse_elf(&data, path)?;

--- a/crates/pina_profile/src/output.rs
+++ b/crates/pina_profile/src/output.rs
@@ -90,9 +90,8 @@ pub enum OutputError {
 
 #[cfg(test)]
 mod tests {
-	use crate::cost::FunctionProfile;
-
 	use super::*;
+	use crate::cost::FunctionProfile;
 
 	fn sample_profile() -> ProgramProfile {
 		ProgramProfile {

--- a/crates/pina_profile/src/output.rs
+++ b/crates/pina_profile/src/output.rs
@@ -1,0 +1,211 @@
+//! Output formatting for profile results.
+
+use std::io::Write;
+
+use crate::cost::ProgramProfile;
+
+/// Output format selection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputFormat {
+	/// Human-readable text summary.
+	Text,
+	/// Machine-readable JSON.
+	Json,
+}
+
+/// Write the profile in the requested format.
+///
+/// # Errors
+///
+/// Returns an IO error if writing fails, or a serialization error if JSON
+/// formatting fails.
+pub fn write_profile(
+	profile: &ProgramProfile,
+	format: OutputFormat,
+	writer: &mut dyn Write,
+) -> Result<(), OutputError> {
+	match format {
+		OutputFormat::Text => write_text(profile, writer),
+		OutputFormat::Json => write_json(profile, writer),
+	}
+}
+
+fn write_text(profile: &ProgramProfile, w: &mut dyn Write) -> Result<(), OutputError> {
+	writeln!(w, "Program: {}", profile.program_name)?;
+	writeln!(w, "Binary size: {} bytes", profile.binary_size)?;
+	writeln!(w, "Text section: {} bytes", profile.text_size)?;
+	writeln!(w, "Total instructions: {}", profile.total_instructions)?;
+	writeln!(w, "Total estimated CU: {}", profile.total_cu)?;
+	writeln!(w)?;
+
+	if profile.functions.is_empty() {
+		writeln!(w, "No functions found.")?;
+		return Ok(());
+	}
+
+	// Column header.
+	writeln!(w, "{:<50} {:>10} {:>10}", "Function", "Instrs", "Est. CU")?;
+	writeln!(w, "{}", "-".repeat(72))?;
+
+	for func in &profile.functions {
+		writeln!(
+			w,
+			"{:<50} {:>10} {:>10}",
+			truncate_name(&func.name, 50),
+			func.instruction_count,
+			func.estimated_cu,
+		)?;
+	}
+
+	Ok(())
+}
+
+fn write_json(profile: &ProgramProfile, w: &mut dyn Write) -> Result<(), OutputError> {
+	let json = serde_json::to_string_pretty(profile).map_err(OutputError::Json)?;
+	write!(w, "{json}")?;
+	Ok(())
+}
+
+/// Truncate a function name to fit in a column, adding `..` if needed.
+fn truncate_name(name: &str, max_len: usize) -> String {
+	if name.len() <= max_len {
+		name.to_owned()
+	} else if max_len <= 2 {
+		name.chars().take(max_len).collect()
+	} else {
+		let truncated: String = name.chars().take(max_len - 2).collect();
+		format!("{truncated}..")
+	}
+}
+
+/// Errors during output formatting.
+#[derive(Debug, thiserror::Error)]
+pub enum OutputError {
+	#[error("IO error: {0}")]
+	Io(#[from] std::io::Error),
+
+	#[error("JSON serialization error: {0}")]
+	Json(serde_json::Error),
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::cost::FunctionProfile;
+
+	use super::*;
+
+	fn sample_profile() -> ProgramProfile {
+		ProgramProfile {
+			program_name: "my_program".to_owned(),
+			binary_size: 1024,
+			text_size: 800,
+			total_instructions: 100,
+			total_cu: 100,
+			functions: vec![
+				FunctionProfile {
+					name: "process_instruction".to_owned(),
+					offset: 0,
+					size: 640,
+					instruction_count: 80,
+					estimated_cu: 80,
+				},
+				FunctionProfile {
+					name: "helper".to_owned(),
+					offset: 640,
+					size: 160,
+					instruction_count: 20,
+					estimated_cu: 20,
+				},
+			],
+		}
+	}
+
+	#[test]
+	fn text_output_contains_program_name() {
+		let profile = sample_profile();
+		let mut buf = Vec::new();
+		write_profile(&profile, OutputFormat::Text, &mut buf).unwrap();
+		let output = String::from_utf8(buf).unwrap();
+		assert!(output.contains("my_program"));
+		assert!(output.contains("1024"));
+		assert!(output.contains("process_instruction"));
+		assert!(output.contains("helper"));
+	}
+
+	#[test]
+	fn text_output_shows_totals() {
+		let profile = sample_profile();
+		let mut buf = Vec::new();
+		write_profile(&profile, OutputFormat::Text, &mut buf).unwrap();
+		let output = String::from_utf8(buf).unwrap();
+		assert!(output.contains("Total instructions: 100"));
+		assert!(output.contains("Total estimated CU: 100"));
+	}
+
+	#[test]
+	fn json_output_is_valid() {
+		let profile = sample_profile();
+		let mut buf = Vec::new();
+		write_profile(&profile, OutputFormat::Json, &mut buf).unwrap();
+		let output = String::from_utf8(buf).unwrap();
+		let parsed: serde_json::Value =
+			serde_json::from_str(&output).unwrap_or_else(|e| panic!("Invalid JSON: {e}"));
+		assert_eq!(parsed["program_name"], "my_program");
+		assert_eq!(parsed["total_cu"], 100);
+		assert!(parsed["functions"].is_array());
+	}
+
+	#[test]
+	fn empty_functions_handled() {
+		let profile = ProgramProfile {
+			program_name: "empty".to_owned(),
+			binary_size: 0,
+			text_size: 0,
+			total_instructions: 0,
+			total_cu: 0,
+			functions: vec![],
+		};
+		let mut buf = Vec::new();
+		write_profile(&profile, OutputFormat::Text, &mut buf).unwrap();
+		let output = String::from_utf8(buf).unwrap();
+		assert!(output.contains("No functions found."));
+	}
+
+	#[test]
+	fn truncate_name_short() {
+		assert_eq!(truncate_name("hello", 50), "hello");
+	}
+
+	#[test]
+	fn truncate_name_exact() {
+		let name = "a".repeat(50);
+		assert_eq!(truncate_name(&name, 50), name);
+	}
+
+	#[test]
+	fn truncate_name_long() {
+		let name = "a".repeat(60);
+		let result = truncate_name(&name, 50);
+		assert_eq!(result.len(), 50);
+		assert!(result.ends_with(".."));
+	}
+
+	#[test]
+	fn json_contains_all_fields() {
+		let profile = sample_profile();
+		let mut buf = Vec::new();
+		write_profile(&profile, OutputFormat::Json, &mut buf).unwrap();
+		let output = String::from_utf8(buf).unwrap();
+		let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+		assert!(parsed["binary_size"].is_number());
+		assert!(parsed["text_size"].is_number());
+		assert!(parsed["total_instructions"].is_number());
+
+		let func = &parsed["functions"][0];
+		assert!(func["name"].is_string());
+		assert!(func["offset"].is_number());
+		assert!(func["size"].is_number());
+		assert!(func["instruction_count"].is_number());
+		assert!(func["estimated_cu"].is_number());
+	}
+}

--- a/crates/pina_profile/src/sbf.rs
+++ b/crates/pina_profile/src/sbf.rs
@@ -1,0 +1,299 @@
+//! SBF instruction stream analysis.
+//!
+//! Walks the `.text` section byte-by-byte (in 8-byte SBF instruction units)
+//! and counts instructions per function symbol.
+
+use crate::cost::CU_PER_INSTRUCTION;
+use crate::cost::FunctionProfile;
+use crate::elf::ElfInfo;
+
+/// Size of a single SBF instruction in bytes.
+pub const SBF_INSTRUCTION_SIZE: u64 = 8;
+
+/// Analyze the `.text` section and produce per-function profiles.
+///
+/// Uses the symbol table to attribute instructions to named functions.
+/// Instructions not covered by any symbol are grouped under
+/// `<unknown+offset>`.
+pub fn analyze_functions(elf: &ElfInfo) -> Vec<FunctionProfile> {
+	let text_len = elf.text_bytes.len() as u64;
+
+	if text_len == 0 {
+		return vec![];
+	}
+
+	let total_instructions = text_len / SBF_INSTRUCTION_SIZE;
+
+	if elf.symbols.is_empty() {
+		// No symbols — report the entire .text section as one block.
+		return vec![FunctionProfile {
+			name: "<entire .text>".to_owned(),
+			offset: 0,
+			size: text_len,
+			instruction_count: total_instructions,
+			estimated_cu: total_instructions * CU_PER_INSTRUCTION,
+		}];
+	}
+
+	let mut functions = Vec::new();
+
+	// Track coverage to find gaps.
+	let mut covered_up_to: u64 = 0;
+
+	for (i, sym) in elf.symbols.iter().enumerate() {
+		// Symbol addresses are virtual; convert to .text-relative offset.
+		let sym_offset = sym.address.saturating_sub(elf.text_vaddr);
+
+		// If there's a gap before this symbol, create an unknown entry.
+		if sym_offset > covered_up_to {
+			let gap_size = sym_offset - covered_up_to;
+			let gap_instructions = gap_size / SBF_INSTRUCTION_SIZE;
+			if gap_instructions > 0 {
+				functions.push(FunctionProfile {
+					name: format!("<unknown+0x{covered_up_to:x}>"),
+					offset: covered_up_to,
+					size: gap_size,
+					instruction_count: gap_instructions,
+					estimated_cu: gap_instructions * CU_PER_INSTRUCTION,
+				});
+			}
+		}
+
+		// Determine the function's size.
+		let func_size = if sym.size > 0 {
+			sym.size
+		} else {
+			// Estimate from next symbol or end of .text.
+			let next_offset = elf
+				.symbols
+				.get(i + 1)
+				.map_or(text_len, |s| s.address.saturating_sub(elf.text_vaddr));
+			next_offset.saturating_sub(sym_offset)
+		};
+
+		// Clamp to .text bounds.
+		let func_size = func_size.min(text_len.saturating_sub(sym_offset));
+		let instruction_count = func_size / SBF_INSTRUCTION_SIZE;
+
+		functions.push(FunctionProfile {
+			name: sym.name.clone(),
+			offset: sym_offset,
+			size: func_size,
+			instruction_count,
+			estimated_cu: instruction_count * CU_PER_INSTRUCTION,
+		});
+
+		covered_up_to = sym_offset + func_size;
+	}
+
+	// Trailing bytes after the last symbol.
+	if covered_up_to < text_len {
+		let trailing_size = text_len - covered_up_to;
+		let trailing_instructions = trailing_size / SBF_INSTRUCTION_SIZE;
+		if trailing_instructions > 0 {
+			functions.push(FunctionProfile {
+				name: format!("<unknown+0x{covered_up_to:x}>"),
+				offset: covered_up_to,
+				size: trailing_size,
+				instruction_count: trailing_instructions,
+				estimated_cu: trailing_instructions * CU_PER_INSTRUCTION,
+			});
+		}
+	}
+
+	// Sort by CU descending for the output.
+	functions.sort_by_key(|f| std::cmp::Reverse(f.estimated_cu));
+
+	functions
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::elf::ElfInfo;
+	use crate::elf::Symbol;
+
+	use super::*;
+
+	fn make_elf(text_size: u64, symbols: Vec<Symbol>) -> ElfInfo {
+		ElfInfo {
+			program_name: "test".to_owned(),
+			text_bytes: vec![0u8; text_size as usize],
+			text_vaddr: 0x1000,
+			text_size,
+			symbols,
+		}
+	}
+
+	#[test]
+	fn empty_text_section() {
+		let elf = make_elf(0, vec![]);
+		let result = analyze_functions(&elf);
+		assert!(result.is_empty());
+	}
+
+	#[test]
+	fn no_symbols_reports_entire_text() {
+		let elf = make_elf(80, vec![]);
+		let result = analyze_functions(&elf);
+		assert_eq!(result.len(), 1);
+		assert_eq!(result[0].name, "<entire .text>");
+		assert_eq!(result[0].instruction_count, 10); // 80 / 8
+		assert_eq!(result[0].estimated_cu, 10);
+	}
+
+	#[test]
+	fn single_symbol_covers_entire_text() {
+		let elf = make_elf(
+			80,
+			vec![Symbol {
+				name: "entrypoint".to_owned(),
+				address: 0x1000,
+				size: 80,
+			}],
+		);
+		let result = analyze_functions(&elf);
+		assert_eq!(result.len(), 1);
+		assert_eq!(result[0].name, "entrypoint");
+		assert_eq!(result[0].instruction_count, 10);
+	}
+
+	#[test]
+	fn multiple_symbols_partitioned() {
+		let elf = make_elf(
+			160,
+			vec![
+				Symbol {
+					name: "func_a".to_owned(),
+					address: 0x1000,
+					size: 80,
+				},
+				Symbol {
+					name: "func_b".to_owned(),
+					address: 0x1050,
+					size: 80,
+				},
+			],
+		);
+		let result = analyze_functions(&elf);
+		assert_eq!(result.len(), 2);
+		// Sorted by CU descending — both equal, so order may vary.
+		let names: Vec<&str> = result.iter().map(|f| f.name.as_str()).collect();
+		assert!(names.contains(&"func_a"));
+		assert!(names.contains(&"func_b"));
+		assert_eq!(result[0].instruction_count, 10);
+		assert_eq!(result[1].instruction_count, 10);
+	}
+
+	#[test]
+	fn gap_between_symbols_reported_as_unknown() {
+		let elf = make_elf(
+			240,
+			vec![
+				Symbol {
+					name: "func_a".to_owned(),
+					address: 0x1000,
+					size: 80,
+				},
+				Symbol {
+					name: "func_b".to_owned(),
+					address: 0x10A0, // gap of 80 bytes (0x50 to 0xA0)
+					size: 80,
+				},
+			],
+		);
+		let result = analyze_functions(&elf);
+		// func_a (80B), unknown gap (80B), func_b (80B)
+		assert_eq!(result.len(), 3);
+		let unknown = result.iter().find(|f| f.name.starts_with("<unknown"));
+		assert!(unknown.is_some());
+		assert_eq!(unknown.unwrap().instruction_count, 10);
+	}
+
+	#[test]
+	fn zero_size_symbol_inferred_from_next() {
+		let elf = make_elf(
+			160,
+			vec![
+				Symbol {
+					name: "func_a".to_owned(),
+					address: 0x1000,
+					size: 0, // unknown size — infer from next
+				},
+				Symbol {
+					name: "func_b".to_owned(),
+					address: 0x1050,
+					size: 0, // unknown size — infer from end
+				},
+			],
+		);
+		let result = analyze_functions(&elf);
+		assert_eq!(result.len(), 2);
+		for func in &result {
+			assert_eq!(func.instruction_count, 10);
+		}
+	}
+
+	#[test]
+	fn trailing_bytes_after_last_symbol() {
+		let elf = make_elf(
+			160,
+			vec![Symbol {
+				name: "func_a".to_owned(),
+				address: 0x1000,
+				size: 80,
+			}],
+		);
+		let result = analyze_functions(&elf);
+		// func_a (80B) + trailing unknown (80B)
+		assert_eq!(result.len(), 2);
+		let trailing = result.iter().find(|f| f.name.starts_with("<unknown"));
+		assert!(trailing.is_some());
+	}
+
+	#[test]
+	fn results_sorted_by_cu_descending() {
+		let elf = make_elf(
+			240,
+			vec![
+				Symbol {
+					name: "small".to_owned(),
+					address: 0x1000,
+					size: 16,
+				},
+				Symbol {
+					name: "large".to_owned(),
+					address: 0x1010,
+					size: 160,
+				},
+			],
+		);
+		let result = analyze_functions(&elf);
+		assert!(result[0].estimated_cu >= result[1].estimated_cu);
+		// Largest function should be first.
+		assert_eq!(result[0].name, "large");
+	}
+
+	#[test]
+	fn non_aligned_text_ignores_partial_instruction() {
+		// 13 bytes = 1 full instruction (8B) + 5 leftover bytes
+		let elf = make_elf(13, vec![]);
+		let result = analyze_functions(&elf);
+		assert_eq!(result.len(), 1);
+		assert_eq!(result[0].instruction_count, 1); // 13 / 8 = 1
+	}
+
+	#[test]
+	fn cu_calculation_uses_cost_constant() {
+		let elf = make_elf(
+			800,
+			vec![Symbol {
+				name: "big_fn".to_owned(),
+				address: 0x1000,
+				size: 800,
+			}],
+		);
+		let result = analyze_functions(&elf);
+		assert_eq!(result[0].instruction_count, 100);
+		assert_eq!(result[0].estimated_cu, 100 * CU_PER_INSTRUCTION);
+	}
+}

--- a/crates/pina_profile/src/sbf.rs
+++ b/crates/pina_profile/src/sbf.rs
@@ -71,19 +71,25 @@ pub fn analyze_functions(elf: &ElfInfo) -> Vec<FunctionProfile> {
 			next_offset.saturating_sub(sym_offset)
 		};
 
-		// Clamp to .text bounds.
-		let func_size = func_size.min(text_len.saturating_sub(sym_offset));
-		let instruction_count = func_size / SBF_INSTRUCTION_SIZE;
+		// Clamp to the uncovered part of `.text` to avoid double-counting
+		// overlapping or nested symbols.
+		let func_end = sym_offset.saturating_add(func_size).min(text_len);
+		let func_start = sym_offset.max(covered_up_to);
+		if func_start >= func_end {
+			continue;
+		}
+		let clamped_size = func_end - func_start;
+		let instruction_count = clamped_size / SBF_INSTRUCTION_SIZE;
 
 		functions.push(FunctionProfile {
 			name: sym.name.clone(),
-			offset: sym_offset,
-			size: func_size,
+			offset: func_start,
+			size: clamped_size,
 			instruction_count,
 			estimated_cu: instruction_count * CU_PER_INSTRUCTION,
 		});
 
-		covered_up_to = sym_offset + func_size;
+		covered_up_to = func_end;
 	}
 
 	// Trailing bytes after the last symbol.
@@ -279,6 +285,55 @@ mod tests {
 		let result = analyze_functions(&elf);
 		assert_eq!(result.len(), 1);
 		assert_eq!(result[0].instruction_count, 1); // 13 / 8 = 1
+	}
+
+	#[test]
+	fn overlapping_symbols_not_double_counted() {
+		// Two symbols overlap: func_a covers [0, 80) and func_b covers [40, 120).
+		// Total .text is 120 bytes = 15 instructions.
+		// Without dedup: 10 + 10 = 20 (wrong). With dedup: 10 + 5 = 15 (correct).
+		let elf = make_elf(
+			120,
+			vec![
+				Symbol {
+					name: "func_a".to_owned(),
+					address: 0x1000,
+					size: 80,
+				},
+				Symbol {
+					name: "func_b".to_owned(),
+					address: 0x1028, // overlaps func_a
+					size: 80,
+				},
+			],
+		);
+		let result = analyze_functions(&elf);
+		let total: u64 = result.iter().map(|f| f.instruction_count).sum();
+		// Total should never exceed actual instructions in .text.
+		assert_eq!(total, 120 / SBF_INSTRUCTION_SIZE);
+	}
+
+	#[test]
+	fn nested_symbol_skipped() {
+		// func_b is entirely inside func_a.
+		let elf = make_elf(
+			160,
+			vec![
+				Symbol {
+					name: "func_a".to_owned(),
+					address: 0x1000,
+					size: 160,
+				},
+				Symbol {
+					name: "func_b".to_owned(),
+					address: 0x1010, // inside func_a
+					size: 16,
+				},
+			],
+		);
+		let result = analyze_functions(&elf);
+		let total: u64 = result.iter().map(|f| f.instruction_count).sum();
+		assert_eq!(total, 160 / SBF_INSTRUCTION_SIZE);
 	}
 
 	#[test]

--- a/crates/pina_profile/src/sbf.rs
+++ b/crates/pina_profile/src/sbf.rs
@@ -109,10 +109,9 @@ pub fn analyze_functions(elf: &ElfInfo) -> Vec<FunctionProfile> {
 
 #[cfg(test)]
 mod tests {
+	use super::*;
 	use crate::elf::ElfInfo;
 	use crate::elf::Symbol;
-
-	use super::*;
 
 	fn make_elf(text_size: u64, symbols: Vec<Symbol>) -> ElfInfo {
 		ElfInfo {

--- a/crates/pina_profile/tests/integration.rs
+++ b/crates/pina_profile/tests/integration.rs
@@ -1,0 +1,170 @@
+//! Integration tests for the `pina_profile` crate.
+//!
+//! These tests build minimal synthetic SBF ELF binaries using the `object`
+//! crate's write module, write them to temp files, and exercise the full
+//! `profile_program` pipeline end-to-end.
+
+use std::io::Write;
+use std::path::Path;
+
+use object::Architecture;
+use object::BinaryFormat;
+use object::Endianness;
+use object::SectionKind;
+use object::SymbolFlags;
+use object::SymbolKind;
+use object::SymbolScope;
+use object::write::Object;
+use object::write::Symbol;
+use object::write::SymbolSection;
+use pina_profile::OutputFormat;
+
+/// Build a minimal SBF ELF binary with a `.text` section and optional symbols.
+fn build_sbf_elf(text_size: usize, symbols: &[(&str, u64, u64)]) -> Vec<u8> {
+	let mut obj = Object::new(BinaryFormat::Elf, Architecture::Sbf, Endianness::Little);
+
+	let section = obj.add_section(Vec::new(), b".text".to_vec(), SectionKind::Text);
+
+	// Fill .text with NOP-like bytes (0x00 repeated).
+	let text_data = vec![0u8; text_size];
+	obj.set_section_data(section, text_data, 8);
+
+	for &(name, offset, size) in symbols {
+		let sym_id = obj.add_symbol(Symbol {
+			name: name.as_bytes().to_vec(),
+			value: offset,
+			size,
+			kind: SymbolKind::Text,
+			scope: SymbolScope::Dynamic,
+			weak: false,
+			section: SymbolSection::Section(section),
+			flags: SymbolFlags::None,
+		});
+		let _ = sym_id;
+	}
+
+	obj.write()
+		.unwrap_or_else(|e| panic!("failed to write ELF: {e}"))
+}
+
+/// Write bytes to a temp file and return the path.
+fn write_temp_elf(data: &[u8]) -> tempfile::NamedTempFile {
+	let mut file = tempfile::Builder::new()
+		.suffix(".so")
+		.tempfile()
+		.unwrap_or_else(|e| panic!("failed to create temp file: {e}"));
+	file.write_all(data)
+		.unwrap_or_else(|e| panic!("failed to write temp ELF: {e}"));
+	file.flush()
+		.unwrap_or_else(|e| panic!("failed to flush temp ELF: {e}"));
+	file
+}
+
+// =========================================================================
+// End-to-end profile_program tests
+// =========================================================================
+
+#[test]
+fn profile_program_with_symbols() {
+	let elf_data = build_sbf_elf(160, &[("entrypoint", 0, 80), ("helper", 80, 80)]);
+	let file = write_temp_elf(&elf_data);
+
+	let profile = pina_profile::profile_program(file.path())
+		.unwrap_or_else(|e| panic!("profile failed: {e}"));
+
+	assert_eq!(profile.text_size, 160);
+	assert_eq!(profile.total_instructions, 20); // 160 / 8
+	assert_eq!(profile.total_cu, 20);
+	assert!(!profile.functions.is_empty());
+
+	// Both symbols should be present.
+	let names: Vec<&str> = profile.functions.iter().map(|f| f.name.as_str()).collect();
+	assert!(
+		names.contains(&"entrypoint"),
+		"missing entrypoint: {names:?}"
+	);
+	assert!(names.contains(&"helper"), "missing helper: {names:?}");
+}
+
+#[test]
+fn profile_program_no_symbols() {
+	let elf_data = build_sbf_elf(80, &[]);
+	let file = write_temp_elf(&elf_data);
+
+	let profile = pina_profile::profile_program(file.path())
+		.unwrap_or_else(|e| panic!("profile failed: {e}"));
+
+	assert_eq!(profile.text_size, 80);
+	assert_eq!(profile.total_instructions, 10);
+	assert_eq!(profile.functions.len(), 1);
+	assert_eq!(profile.functions[0].name, "<entire .text>");
+}
+
+#[test]
+fn profile_program_rejects_nonexistent_file() {
+	let result = pina_profile::profile_program(Path::new("/nonexistent/path.so"));
+	assert!(result.is_err());
+}
+
+#[test]
+fn profile_program_rejects_non_elf() {
+	let mut file = tempfile::Builder::new()
+		.suffix(".so")
+		.tempfile()
+		.unwrap_or_else(|e| panic!("failed to create temp file: {e}"));
+	file.write_all(b"this is not an ELF file")
+		.unwrap_or_else(|e| panic!("write failed: {e}"));
+	file.flush().unwrap_or_else(|e| panic!("flush failed: {e}"));
+
+	let result = pina_profile::profile_program(file.path());
+	assert!(result.is_err());
+}
+
+// =========================================================================
+// Output format tests (end-to-end through write_profile)
+// =========================================================================
+
+#[test]
+fn text_output_end_to_end() {
+	let elf_data = build_sbf_elf(80, &[("my_func", 0, 80)]);
+	let file = write_temp_elf(&elf_data);
+
+	let profile = pina_profile::profile_program(file.path())
+		.unwrap_or_else(|e| panic!("profile failed: {e}"));
+
+	let mut buf = Vec::new();
+	pina_profile::output::write_profile(&profile, OutputFormat::Text, &mut buf)
+		.unwrap_or_else(|e| panic!("write failed: {e}"));
+
+	let output = String::from_utf8(buf).unwrap_or_else(|e| panic!("non-UTF8 output: {e}"));
+	assert!(
+		output.contains("my_func"),
+		"output should contain function name"
+	);
+	assert!(
+		output.contains("Total estimated CU"),
+		"output should contain CU summary"
+	);
+}
+
+#[test]
+fn json_output_end_to_end() {
+	let elf_data = build_sbf_elf(80, &[("my_func", 0, 80)]);
+	let file = write_temp_elf(&elf_data);
+
+	let profile = pina_profile::profile_program(file.path())
+		.unwrap_or_else(|e| panic!("profile failed: {e}"));
+
+	let mut buf = Vec::new();
+	pina_profile::output::write_profile(&profile, OutputFormat::Json, &mut buf)
+		.unwrap_or_else(|e| panic!("write failed: {e}"));
+
+	let output = String::from_utf8(buf).unwrap_or_else(|e| panic!("non-UTF8 output: {e}"));
+	let parsed: serde_json::Value =
+		serde_json::from_str(&output).unwrap_or_else(|e| panic!("invalid JSON: {e}"));
+
+	assert_eq!(parsed["text_size"], 80);
+	assert_eq!(parsed["total_instructions"], 10);
+	assert!(parsed["functions"].is_array());
+	assert!(parsed["functions"][0]["name"].as_str().is_some());
+}


### PR DESCRIPTION
## Summary

Three features inspired by [blueshift-gg/quasar](https://github.com/blueshift-gg/quasar), a zero-copy Solana program framework.

### 1. Pod Arithmetic (`pina_pod_primitives`)

Full operator surface for all Pod integer types:

- **Arithmetic**: `Add`, `Sub`, `Mul`, `Div`, `Rem` (Pod+Pod and Pod+native) with assign variants
- **Bitwise**: `BitAnd`, `BitOr`, `BitXor`, `Shl`, `Shr`, `Not` with assign variants
- **Signed**: `Neg` for `PodI16`/`PodI32`/`PodI64`/`PodI128`
- **Checked**: `checked_add`, `checked_sub`, `checked_mul`, `checked_div`
- **Saturating**: `saturating_add`, `saturating_sub`, `saturating_mul`
- **Constants**: `ZERO`, `MIN`, `MAX`
- **Helpers**: `get()`, `is_zero()`, `Display`, improved `Debug`, `Ord`, `PartialOrd<native>`
- **PodBool**: `Not` + `Display`

Debug builds panic on overflow; release builds wrap for CU efficiency.

### 2. IDL Parser Hardening (`pina_cli`)

Static validation added to `assemble_program_ir()`:

- Discriminator collision detection (within accounts and within instructions)
- Duplicate input field detection (account names vs argument names)
- Human-readable error formatting

### 3. Static CU Profiler (`pina_profile` + CLI)

New `pina profile` command for static CU analysis of compiled SBF binaries:

```sh
pina profile target/deploy/my_program.so          # text summary
pina profile target/deploy/my_program.so --json    # JSON for CI
pina profile target/deploy/my_program.so -o r.json # file output
```

v1: ELF parsing via `object` crate (no unsafe), per-function CU estimation, best-effort symbol resolution. Flamegraph UI planned for v2.

## Test Coverage

| Crate | New Tests |
|-------|-----------|
| `pina_pod_primitives` | 141 (unit + property-based fuzz) |
| `pina_cli` | 18 (collision detection) |
| `pina_profile` | 21 (ELF, SBF, output) |
| **Total** | **180** |

## Changes

- 15 files changed, +2,743 lines
- New crate: `crates/pina_profile`
- Zero new clippy warnings
- Backward compatible (no breaking API changes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pod integer types gain arithmetic/bitwise operators, constants (ZERO/MIN/MAX), checked/saturating helpers, ordering, and display
  * Added `pina profile` CLI to statically estimate compute units from SBF binaries with text/JSON output and optional report file

* **Improvements**
  * IDL parser now reports discriminator collisions and duplicate instruction input field names as human-readable diagnostics

* **Tests**
  * Expanded property and integration tests for Pod primitives, CLI profile command, and profiler parsing/output
<!-- end of auto-generated comment: release notes by coderabbit.ai -->