### PR TITLE
chore: add default bump to all changeset frontmatter

### DIFF
--- a/.changeset/account_reallocation_helpers.md
+++ b/.changeset/account_reallocation_helpers.md
@@ -1,4 +1,5 @@
 ---
+default: minor
 pina: minor
 ---
 

--- a/.changeset/benchmark_suite.md
+++ b/.changeset/benchmark_suite.md
@@ -1,4 +1,5 @@
 ---
+default: note
 pina: note
 ---
 

--- a/.changeset/ci-devenv-retry-hardening.md
+++ b/.changeset/ci-devenv-retry-hardening.md
@@ -1,4 +1,5 @@
 ---
+default: note
 pina: note
 ---
 

--- a/.changeset/codama-root-mod-unused-imports.md
+++ b/.changeset/codama-root-mod-unused-imports.md
@@ -1,4 +1,5 @@
 ---
+default: patch
 pina_codama_renderer: patch
 ---
 

--- a/.changeset/expand_snapshot_tests.md
+++ b/.changeset/expand_snapshot_tests.md
@@ -1,4 +1,5 @@
 ---
+default: patch
 pina_macros: patch
 ---
 

--- a/.changeset/fix-mdt-doc-comments.md
+++ b/.changeset/fix-mdt-doc-comments.md
@@ -1,4 +1,5 @@
 ---
+default: patch
 pina: patch
 pina_cli: patch
 ---

--- a/.changeset/fuzz_testing.md
+++ b/.changeset/fuzz_testing.md
@@ -1,4 +1,5 @@
 ---
+default: patch
 pina_pod_primitives: patch
 pina: patch
 ---

--- a/.changeset/instruction_introspection.md
+++ b/.changeset/instruction_introspection.md
@@ -1,4 +1,5 @@
 ---
+default: minor
 pina: minor
 ---
 

--- a/.changeset/integration_tests.md
+++ b/.changeset/integration_tests.md
@@ -1,4 +1,5 @@
 ---
+default: patch
 pina: patch
 ---
 

--- a/.changeset/parse-instruction-remap-diagnostics.md
+++ b/.changeset/parse-instruction-remap-diagnostics.md
@@ -1,4 +1,5 @@
 ---
+default: patch
 pina: patch
 ---
 

--- a/.changeset/pina-cli-escrow-idl-snapshot.md
+++ b/.changeset/pina-cli-escrow-idl-snapshot.md
@@ -1,4 +1,5 @@
 ---
+default: patch
 pina_cli: patch
 ---
 

--- a/.changeset/pina_init_command.md
+++ b/.changeset/pina_init_command.md
@@ -1,4 +1,5 @@
 ---
+default: minor
 pina_cli: minor
 ---
 

--- a/.changeset/reenable-anchor-parity-bpf-ci.md
+++ b/.changeset/reenable-anchor-parity-bpf-ci.md
@@ -1,4 +1,5 @@
 ---
+default: note
 pina: note
 ---
 

--- a/.changeset/security_ci_node_tooling_and_pastey.md
+++ b/.changeset/security_ci_node_tooling_and_pastey.md
@@ -1,4 +1,5 @@
 ---
+default: patch
 pina: patch
 ---
 

--- a/.changeset/transaction_builder_helpers.md
+++ b/.changeset/transaction_builder_helpers.md
@@ -1,4 +1,5 @@
 ---
+default: minor
 pina: minor
 ---
 

--- a/.changeset/workspace_tooling_pnpm_node_version.md
+++ b/.changeset/workspace_tooling_pnpm_node_version.md
@@ -1,4 +1,5 @@
 ---
+default: note
 pina: note
 ---
 


### PR DESCRIPTION
Ensure every changeset file includes a `default: <highest change>` key in its TOML frontmatter for consistent release automation.

16 files updated — no code changes, only changeset metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release management configuration metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->