### PR TITLE
fix: align mdt workspace table with dprint formatting

### DIFF
--- a/.changeset/mdt_documentation_reuse.md
+++ b/.changeset/mdt_documentation_reuse.md
@@ -7,6 +7,7 @@ pina_pod_primitives: patch
 Expand mdt documentation reuse across the workspace.
 
 Added 10 new mdt provider blocks in `template.t.md`:
+
 - `pinaProjectDescription` — single-source project tagline
 - `pinaInstallation` — cargo add instructions
 - `podTypesTable` — Pod types reference table
@@ -19,6 +20,7 @@ Added 10 new mdt provider blocks in `template.t.md`:
 - `pinaSecurityBestPractices` — security checklist
 
 Wired 15 new consumers across:
+
 - `readme.md` (root) — 10 consumer blocks
 - `crates/pina/readme.md` — feature flags table + badge links
 - `crates/pina_pod_primitives/readme.md` — pod types table + arithmetic description

--- a/readme.md
+++ b/readme.md
@@ -32,15 +32,15 @@ A performant Solana smart contract framework built on top of [pinocchio](https:/
 
 <!-- {=pinaWorkspacePackages} -->
 
-| Crate                  | Path                         | Description                                                        |
-| ---------------------- | ---------------------------- | ------------------------------------------------------------------ |
-| `pina`                 | `crates/pina`                | Core framework — traits, account loaders, CPI helpers, Pod types.  |
-| `pina_macros`          | `crates/pina_macros`         | Proc macros — `#[account]`, `#[instruction]`, `#[event]`, etc.     |
-| `pina_cli`             | `crates/pina_cli`            | CLI/library for IDL generation, Codama integration, scaffolding.   |
-| `pina_codama_renderer` | `crates/pina_codama_renderer`| Repository-local Codama Rust renderer for Pina-style clients.      |
-| `pina_pod_primitives`  | `crates/pina_pod_primitives` | Alignment-safe `no_std` POD primitive wrappers.                    |
-| `pina_profile`         | `crates/pina_profile`        | Static CU profiler for compiled SBF programs.                      |
-| `pina_sdk_ids`         | `crates/pina_sdk_ids`        | Typed constants for well-known Solana program/sysvar IDs.          |
+| Crate                  | Path                          | Description                                                       |
+| ---------------------- | ----------------------------- | ----------------------------------------------------------------- |
+| `pina`                 | `crates/pina`                 | Core framework — traits, account loaders, CPI helpers, Pod types. |
+| `pina_macros`          | `crates/pina_macros`          | Proc macros — `#[account]`, `#[instruction]`, `#[event]`, etc.    |
+| `pina_cli`             | `crates/pina_cli`             | CLI/library for IDL generation, Codama integration, scaffolding.  |
+| `pina_codama_renderer` | `crates/pina_codama_renderer` | Repository-local Codama Rust renderer for Pina-style clients.     |
+| `pina_pod_primitives`  | `crates/pina_pod_primitives`  | Alignment-safe `no_std` POD primitive wrappers.                   |
+| `pina_profile`         | `crates/pina_profile`         | Static CU profiler for compiled SBF programs.                     |
+| `pina_sdk_ids`         | `crates/pina_sdk_ids`         | Typed constants for well-known Solana program/sysvar IDs.         |
 
 <!-- {/pinaWorkspacePackages} -->
 

--- a/template.t.md
+++ b/template.t.md
@@ -137,15 +137,15 @@ Each Pod integer type provides `ZERO`, `MIN`, and `MAX` constants.
 
 <!-- {@pinaWorkspacePackages} -->
 
-| Crate                  | Path                         | Description                                                        |
-| ---------------------- | ---------------------------- | ------------------------------------------------------------------ |
-| `pina`                 | `crates/pina`                | Core framework — traits, account loaders, CPI helpers, Pod types.  |
-| `pina_macros`          | `crates/pina_macros`         | Proc macros — `#[account]`, `#[instruction]`, `#[event]`, etc.     |
-| `pina_cli`             | `crates/pina_cli`            | CLI/library for IDL generation, Codama integration, scaffolding.   |
-| `pina_codama_renderer` | `crates/pina_codama_renderer`| Repository-local Codama Rust renderer for Pina-style clients.      |
-| `pina_pod_primitives`  | `crates/pina_pod_primitives` | Alignment-safe `no_std` POD primitive wrappers.                    |
-| `pina_profile`         | `crates/pina_profile`        | Static CU profiler for compiled SBF programs.                      |
-| `pina_sdk_ids`         | `crates/pina_sdk_ids`        | Typed constants for well-known Solana program/sysvar IDs.          |
+| Crate                  | Path                          | Description                                                       |
+| ---------------------- | ----------------------------- | ----------------------------------------------------------------- |
+| `pina`                 | `crates/pina`                 | Core framework — traits, account loaders, CPI helpers, Pod types. |
+| `pina_macros`          | `crates/pina_macros`          | Proc macros — `#[account]`, `#[instruction]`, `#[event]`, etc.    |
+| `pina_cli`             | `crates/pina_cli`             | CLI/library for IDL generation, Codama integration, scaffolding.  |
+| `pina_codama_renderer` | `crates/pina_codama_renderer` | Repository-local Codama Rust renderer for Pina-style clients.     |
+| `pina_pod_primitives`  | `crates/pina_pod_primitives`  | Alignment-safe `no_std` POD primitive wrappers.                   |
+| `pina_profile`         | `crates/pina_profile`         | Static CU profiler for compiled SBF programs.                     |
+| `pina_sdk_ids`         | `crates/pina_sdk_ids`         | Typed constants for well-known Solana program/sysvar IDs.         |
 
 <!-- {/pinaWorkspacePackages} -->
 


### PR DESCRIPTION
Fix the pinaWorkspacePackages table in template.t.md to match dprint's column width output, preventing format/sync cycles in CI lint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded documentation reuse with additional reusable content blocks across workspace and crate-level documentation, including new security best practices content.
  * Improved table formatting and column alignment throughout documentation pages for enhanced readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->