### PR TITLE
feat(pina_profile): opcode-aware CU cost model

### DIFF
--- a/.changeset/opcode_cu_profiler.md
+++ b/.changeset/opcode_cu_profiler.md
@@ -1,0 +1,19 @@
+---
+default: minor
+pina_profile: minor
+---
+
+Implement opcode-aware CU cost model for the static profiler.
+
+The profiler now decodes each 8-byte SBF instruction's opcode and assigns
+costs based on the instruction class:
+
+- Regular instructions (ALU, memory, branch): 1 CU each
+- Syscall instructions (`call imm` with `src_reg=0`): 100 CU each
+
+Per-function profiles now include `syscall_count` and the text output
+shows a Syscall column. The JSON output includes `total_syscalls` and
+per-function `syscall_count`.
+
+This replaces the previous flat 1-CU-per-instruction model which could
+underestimate programs with heavy syscall usage by 10-100x.

--- a/crates/pina_profile/readme.md
+++ b/crates/pina_profile/readme.md
@@ -17,12 +17,15 @@ pina profile target/deploy/my_program.so --output report.json
 Solana's SBF instruction set has deterministic CU costs. This tool:
 
 1. Parses the ELF binary to extract `.text` sections
-2. Walks the SBF instruction stream, counting instructions per symbol
-3. Estimates CU cost using a static per-instruction baseline model
+2. Decodes each 8-byte SBF instruction's opcode
+3. Estimates CU cost using an opcode-aware cost model:
+   - Regular instructions (ALU, memory, branch): 1 CU each
+   - Syscall instructions (`call imm` with src_reg=0): 100 CU each
 4. Outputs a summary (text or JSON) with per-function breakdowns
 
 ## Limitations
 
-- Static analysis only — does not account for runtime branching
-- Best-effort symbol resolution (works best with unstripped binaries)
-- CU estimates represent worst-case / single-path costs
+- **Static analysis only** — does not account for runtime branching or loops
+- **Flat syscall cost** — all syscalls estimated at 100 CU regardless of actual cost
+- **Best-effort symbol resolution** — works best with unstripped binaries
+- **No path analysis** — CU is the sum of all instructions, not worst-case path

--- a/crates/pina_profile/src/cost.rs
+++ b/crates/pina_profile/src/cost.rs
@@ -2,15 +2,71 @@
 //!
 //! Solana's SBF runtime assigns deterministic CU costs to each instruction
 //! class. This module defines the cost model and the profile output structs.
+//!
+//! ## Cost model
+//!
+//! The static profiler estimates compute unit (CU) costs by decoding each
+//! 8-byte SBF instruction's opcode and assigning a cost based on the
+//! instruction class:
+//!
+//! | Class | Opcodes | Cost |
+//! |-------|---------|------|
+//! | ALU (add, sub, mul, div, mod, xor, or, and, lsh, rsh, arsh, neg, le, be) | 0x04–0xDC | 1 CU |
+//! | Memory load/store (ldxb, ldxh, ldxw, ldxdw, stb, sth, stw, stdw, stxb, stxh, stxw, stxdw) | 0x61–0x7B | 1 CU |
+//! | Branch (ja, jeq, jgt, jge, jlt, jle, jne, jset, jsgt, jsge, jslt, jsle, call, exit) | 0x05–0x9D | 1 CU |
+//! | Syscall (call imm with known syscall hash) | 0x85 | 100 CU |
+//! | Load immediate (lddw — 16-byte wide load) | 0x18 | 1 CU |
+//!
+//! Syscalls are identified by opcode 0x85 (`BPF_CALL` with immediate operand).
+//! The actual on-chain syscall cost varies (e.g. `sol_log` ~100 CU,
+//! `sol_invoke_signed` ~thousands), but we use a flat 100 CU estimate since
+//! static analysis cannot determine the exact syscall target without symbol
+//! resolution of the immediate.
+//!
+//! ## Limitations
+//!
+//! - **Static analysis only** — does not account for runtime branching. The
+//!   reported CU is the sum of all instructions, not the worst-case or
+//!   average-case path.
+//! - **Flat syscall cost** — all syscalls are estimated at 100 CU regardless
+//!   of their actual on-chain cost.
+//! - **No loop analysis** — loops are counted once; actual CU depends on
+//!   iteration count at runtime.
 
 use serde::Serialize;
 
 /// CU cost per regular instruction (ALU, memory, branch).
-///
-/// The SBF VM charges 1 CU per instruction by default.
-/// Some syscalls have higher costs, but for static analysis of the
-/// instruction stream this is the baseline.
 pub const CU_PER_INSTRUCTION: u64 = 1;
+
+/// Estimated CU cost per syscall invocation.
+///
+/// The actual cost varies by syscall (`sol_log` ~100, `sol_invoke_signed`
+/// ~thousands), but 100 CU is a reasonable baseline for static estimation.
+pub const CU_PER_SYSCALL: u64 = 100;
+
+/// SBF opcode for `call imm` (`BPF_JMP` | `BPF_CALL`).
+///
+/// When the source register is 0, this is a syscall (call to an external
+/// function resolved by the runtime). When the source register is non-zero,
+/// it's an internal function call.
+pub const BPF_CALL_IMM: u8 = 0x85;
+
+/// Estimate the CU cost of a single SBF instruction from its 8-byte encoding.
+///
+/// Returns [`CU_PER_SYSCALL`] for syscall instructions (opcode `0x85` with
+/// `src_reg == 0`), and [`CU_PER_INSTRUCTION`] for all other instructions.
+#[must_use]
+pub fn estimate_instruction_cu(instruction_bytes: &[u8; 8]) -> u64 {
+	let opcode = instruction_bytes[0];
+	// src_reg is the high nibble of byte 1
+	let src_reg = instruction_bytes[1] >> 4;
+
+	if opcode == BPF_CALL_IMM && src_reg == 0 {
+		CU_PER_SYSCALL
+	} else {
+		CU_PER_INSTRUCTION
+	}
+}
 
 /// Per-function CU profile.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -23,7 +79,9 @@ pub struct FunctionProfile {
 	pub size: u64,
 	/// Number of SBF instructions in the function.
 	pub instruction_count: u64,
-	/// Estimated CU cost (`instruction_count * CU_PER_INSTRUCTION`).
+	/// Number of syscall instructions detected.
+	pub syscall_count: u64,
+	/// Estimated CU cost (sum of per-instruction costs).
 	pub estimated_cu: u64,
 }
 
@@ -38,8 +96,57 @@ pub struct ProgramProfile {
 	pub text_size: u64,
 	/// Total SBF instruction count across all functions.
 	pub total_instructions: u64,
+	/// Total syscall count across all functions.
+	pub total_syscalls: u64,
 	/// Total estimated CU across all functions.
 	pub total_cu: u64,
 	/// Per-function profiles, sorted by estimated CU (descending).
 	pub functions: Vec<FunctionProfile>,
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn regular_instruction_costs_one_cu() {
+		// ADD64 imm: opcode 0x07
+		let add = [0x07, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00];
+		assert_eq!(estimate_instruction_cu(&add), CU_PER_INSTRUCTION);
+	}
+
+	#[test]
+	fn syscall_costs_syscall_cu() {
+		// CALL imm with src_reg=0: opcode 0x85, byte1 high nibble = 0
+		let syscall = [0x85, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00];
+		assert_eq!(estimate_instruction_cu(&syscall), CU_PER_SYSCALL);
+	}
+
+	#[test]
+	fn internal_call_costs_one_cu() {
+		// CALL imm with src_reg=1 (internal function call, not syscall)
+		let internal_call = [0x85, 0x10, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00];
+		assert_eq!(estimate_instruction_cu(&internal_call), CU_PER_INSTRUCTION);
+	}
+
+	#[test]
+	fn exit_instruction_costs_one_cu() {
+		// EXIT: opcode 0x95
+		let exit = [0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+		assert_eq!(estimate_instruction_cu(&exit), CU_PER_INSTRUCTION);
+	}
+
+	#[test]
+	fn memory_load_costs_one_cu() {
+		// LDXDW: opcode 0x79
+		let load = [0x79, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+		assert_eq!(estimate_instruction_cu(&load), CU_PER_INSTRUCTION);
+	}
+
+	#[test]
+	fn branch_costs_one_cu() {
+		// JEQ imm: opcode 0x15
+		let branch = [0x15, 0x00, 0x02, 0x00, 0x05, 0x00, 0x00, 0x00];
+		assert_eq!(estimate_instruction_cu(&branch), CU_PER_INSTRUCTION);
+	}
 }

--- a/crates/pina_profile/src/lib.rs
+++ b/crates/pina_profile/src/lib.rs
@@ -34,6 +34,7 @@ pub fn profile_program(path: &Path) -> Result<ProgramProfile, ProfileError> {
 	let elf_info = elf::parse_elf(&data, path)?;
 	let functions = sbf::analyze_functions(&elf_info);
 	let total_instructions = functions.iter().map(|f| f.instruction_count).sum();
+	let total_syscalls = functions.iter().map(|f| f.syscall_count).sum();
 	let total_cu = functions.iter().map(|f| f.estimated_cu).sum();
 
 	Ok(ProgramProfile {
@@ -41,6 +42,7 @@ pub fn profile_program(path: &Path) -> Result<ProgramProfile, ProfileError> {
 		binary_size: data.len() as u64,
 		text_size: elf_info.text_size,
 		total_instructions,
+		total_syscalls,
 		total_cu,
 		functions,
 	})

--- a/crates/pina_profile/src/output.rs
+++ b/crates/pina_profile/src/output.rs
@@ -35,6 +35,7 @@ fn write_text(profile: &ProgramProfile, w: &mut dyn Write) -> Result<(), OutputE
 	writeln!(w, "Binary size: {} bytes", profile.binary_size)?;
 	writeln!(w, "Text section: {} bytes", profile.text_size)?;
 	writeln!(w, "Total instructions: {}", profile.total_instructions)?;
+	writeln!(w, "Total syscalls: {}", profile.total_syscalls)?;
 	writeln!(w, "Total estimated CU: {}", profile.total_cu)?;
 	writeln!(w)?;
 
@@ -44,15 +45,20 @@ fn write_text(profile: &ProgramProfile, w: &mut dyn Write) -> Result<(), OutputE
 	}
 
 	// Column header.
-	writeln!(w, "{:<50} {:>10} {:>10}", "Function", "Instrs", "Est. CU")?;
-	writeln!(w, "{}", "-".repeat(72))?;
+	writeln!(
+		w,
+		"{:<50} {:>10} {:>8} {:>10}",
+		"Function", "Instrs", "Syscall", "Est. CU"
+	)?;
+	writeln!(w, "{}", "-".repeat(80))?;
 
 	for func in &profile.functions {
 		writeln!(
 			w,
-			"{:<50} {:>10} {:>10}",
+			"{:<50} {:>10} {:>8} {:>10}",
 			truncate_name(&func.name, 50),
 			func.instruction_count,
+			func.syscall_count,
 			func.estimated_cu,
 		)?;
 	}
@@ -99,20 +105,23 @@ mod tests {
 			binary_size: 1024,
 			text_size: 800,
 			total_instructions: 100,
-			total_cu: 100,
+			total_syscalls: 2,
+			total_cu: 298,
 			functions: vec![
 				FunctionProfile {
 					name: "process_instruction".to_owned(),
 					offset: 0,
 					size: 640,
 					instruction_count: 80,
-					estimated_cu: 80,
+					syscall_count: 2,
+					estimated_cu: 278,
 				},
 				FunctionProfile {
 					name: "helper".to_owned(),
 					offset: 640,
 					size: 160,
 					instruction_count: 20,
+					syscall_count: 0,
 					estimated_cu: 20,
 				},
 			],
@@ -138,7 +147,8 @@ mod tests {
 		write_profile(&profile, OutputFormat::Text, &mut buf).unwrap();
 		let output = String::from_utf8(buf).unwrap();
 		assert!(output.contains("Total instructions: 100"));
-		assert!(output.contains("Total estimated CU: 100"));
+		assert!(output.contains("Total syscalls: 2"));
+		assert!(output.contains("Total estimated CU: 298"));
 	}
 
 	#[test]
@@ -150,7 +160,7 @@ mod tests {
 		let parsed: serde_json::Value =
 			serde_json::from_str(&output).unwrap_or_else(|e| panic!("Invalid JSON: {e}"));
 		assert_eq!(parsed["program_name"], "my_program");
-		assert_eq!(parsed["total_cu"], 100);
+		assert_eq!(parsed["total_cu"], 298);
 		assert!(parsed["functions"].is_array());
 	}
 
@@ -161,6 +171,7 @@ mod tests {
 			binary_size: 0,
 			text_size: 0,
 			total_instructions: 0,
+			total_syscalls: 0,
 			total_cu: 0,
 			functions: vec![],
 		};

--- a/crates/pina_profile/src/sbf.rs
+++ b/crates/pina_profile/src/sbf.rs
@@ -1,20 +1,57 @@
 //! SBF instruction stream analysis.
 //!
-//! Walks the `.text` section byte-by-byte (in 8-byte SBF instruction units)
-//! and counts instructions per function symbol.
+//! Walks the `.text` section in 8-byte SBF instruction units, decodes each
+//! opcode, and estimates per-function compute unit costs using the cost model
+//! from [`crate::cost`].
 
-use crate::cost::CU_PER_INSTRUCTION;
+use std::cmp::Reverse;
+
+use crate::cost::BPF_CALL_IMM;
 use crate::cost::FunctionProfile;
+use crate::cost::estimate_instruction_cu;
 use crate::elf::ElfInfo;
 
 /// Size of a single SBF instruction in bytes.
 pub const SBF_INSTRUCTION_SIZE: u64 = 8;
 
+/// Estimate CU and count syscalls for a byte range within the `.text` section.
+///
+/// Returns `(instruction_count, syscall_count, estimated_cu)`.
+fn estimate_range(text_bytes: &[u8], start: u64, size: u64) -> (u64, u64, u64) {
+	let start = start as usize;
+	let size = size as usize;
+	let end = (start + size).min(text_bytes.len());
+
+	let mut instruction_count: u64 = 0;
+	let mut syscall_count: u64 = 0;
+	let mut estimated_cu: u64 = 0;
+
+	let mut offset = start;
+	while offset + 8 <= end {
+		let bytes: &[u8; 8] = text_bytes[offset..offset + 8]
+			.try_into()
+			.unwrap_or_else(|_| panic!("slice length mismatch at offset {offset}"));
+
+		let cu = estimate_instruction_cu(bytes);
+		instruction_count += 1;
+		estimated_cu += cu;
+
+		if bytes[0] == BPF_CALL_IMM && (bytes[1] >> 4) == 0 {
+			syscall_count += 1;
+		}
+
+		offset += 8;
+	}
+
+	(instruction_count, syscall_count, estimated_cu)
+}
+
 /// Analyze the `.text` section and produce per-function profiles.
 ///
 /// Uses the symbol table to attribute instructions to named functions.
 /// Instructions not covered by any symbol are grouped under
-/// `<unknown+offset>`.
+/// `<unknown+offset>`. Each instruction is decoded to estimate CU costs
+/// using the opcode-aware cost model.
 pub fn analyze_functions(elf: &ElfInfo) -> Vec<FunctionProfile> {
 	let text_len = elf.text_bytes.len() as u64;
 
@@ -22,48 +59,45 @@ pub fn analyze_functions(elf: &ElfInfo) -> Vec<FunctionProfile> {
 		return vec![];
 	}
 
-	let total_instructions = text_len / SBF_INSTRUCTION_SIZE;
-
 	if elf.symbols.is_empty() {
-		// No symbols — report the entire .text section as one block.
+		let (instruction_count, syscall_count, estimated_cu) =
+			estimate_range(&elf.text_bytes, 0, text_len);
 		return vec![FunctionProfile {
 			name: "<entire .text>".to_owned(),
 			offset: 0,
 			size: text_len,
-			instruction_count: total_instructions,
-			estimated_cu: total_instructions * CU_PER_INSTRUCTION,
+			instruction_count,
+			syscall_count,
+			estimated_cu,
 		}];
 	}
 
 	let mut functions = Vec::new();
-
-	// Track coverage to find gaps.
 	let mut covered_up_to: u64 = 0;
 
 	for (i, sym) in elf.symbols.iter().enumerate() {
-		// Symbol addresses are virtual; convert to .text-relative offset.
 		let sym_offset = sym.address.saturating_sub(elf.text_vaddr);
 
-		// If there's a gap before this symbol, create an unknown entry.
+		// Gap before this symbol → unknown region.
 		if sym_offset > covered_up_to {
 			let gap_size = sym_offset - covered_up_to;
-			let gap_instructions = gap_size / SBF_INSTRUCTION_SIZE;
-			if gap_instructions > 0 {
+			let (ic, sc, cu) = estimate_range(&elf.text_bytes, covered_up_to, gap_size);
+			if ic > 0 {
 				functions.push(FunctionProfile {
 					name: format!("<unknown+0x{covered_up_to:x}>"),
 					offset: covered_up_to,
 					size: gap_size,
-					instruction_count: gap_instructions,
-					estimated_cu: gap_instructions * CU_PER_INSTRUCTION,
+					instruction_count: ic,
+					syscall_count: sc,
+					estimated_cu: cu,
 				});
 			}
 		}
 
-		// Determine the function's size.
+		// Determine function size.
 		let func_size = if sym.size > 0 {
 			sym.size
 		} else {
-			// Estimate from next symbol or end of .text.
 			let next_offset = elf
 				.symbols
 				.get(i + 1)
@@ -71,44 +105,45 @@ pub fn analyze_functions(elf: &ElfInfo) -> Vec<FunctionProfile> {
 			next_offset.saturating_sub(sym_offset)
 		};
 
-		// Clamp to the uncovered part of `.text` to avoid double-counting
-		// overlapping or nested symbols.
+		// Clamp to uncovered region to avoid double-counting.
 		let func_end = sym_offset.saturating_add(func_size).min(text_len);
 		let func_start = sym_offset.max(covered_up_to);
 		if func_start >= func_end {
 			continue;
 		}
 		let clamped_size = func_end - func_start;
-		let instruction_count = clamped_size / SBF_INSTRUCTION_SIZE;
+
+		let (ic, sc, cu) = estimate_range(&elf.text_bytes, func_start, clamped_size);
 
 		functions.push(FunctionProfile {
 			name: sym.name.clone(),
 			offset: func_start,
 			size: clamped_size,
-			instruction_count,
-			estimated_cu: instruction_count * CU_PER_INSTRUCTION,
+			instruction_count: ic,
+			syscall_count: sc,
+			estimated_cu: cu,
 		});
 
 		covered_up_to = func_end;
 	}
 
-	// Trailing bytes after the last symbol.
+	// Trailing bytes after last symbol.
 	if covered_up_to < text_len {
 		let trailing_size = text_len - covered_up_to;
-		let trailing_instructions = trailing_size / SBF_INSTRUCTION_SIZE;
-		if trailing_instructions > 0 {
+		let (ic, sc, cu) = estimate_range(&elf.text_bytes, covered_up_to, trailing_size);
+		if ic > 0 {
 			functions.push(FunctionProfile {
 				name: format!("<unknown+0x{covered_up_to:x}>"),
 				offset: covered_up_to,
 				size: trailing_size,
-				instruction_count: trailing_instructions,
-				estimated_cu: trailing_instructions * CU_PER_INSTRUCTION,
+				instruction_count: ic,
+				syscall_count: sc,
+				estimated_cu: cu,
 			});
 		}
 	}
 
-	// Sort by CU descending for the output.
-	functions.sort_by_key(|f| std::cmp::Reverse(f.estimated_cu));
+	functions.sort_by_key(|f| Reverse(f.estimated_cu));
 
 	functions
 }
@@ -116,40 +151,80 @@ pub fn analyze_functions(elf: &ElfInfo) -> Vec<FunctionProfile> {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::cost::CU_PER_SYSCALL;
 	use crate::elf::ElfInfo;
 	use crate::elf::Symbol;
 
-	fn make_elf(text_size: u64, symbols: Vec<Symbol>) -> ElfInfo {
+	fn make_elf(text_bytes: Vec<u8>, symbols: Vec<Symbol>) -> ElfInfo {
+		let text_size = text_bytes.len() as u64;
 		ElfInfo {
 			program_name: "test".to_owned(),
-			text_bytes: vec![0u8; text_size as usize],
+			text_bytes,
 			text_vaddr: 0x1000,
 			text_size,
 			symbols,
 		}
 	}
 
+	/// Build a .text section with `n` NOP-like instructions (opcode 0x07 =
+	/// ADD64 imm).
+	fn nop_text(n: usize) -> Vec<u8> {
+		let mut bytes = Vec::with_capacity(n * 8);
+		for _ in 0..n {
+			bytes.extend_from_slice(&[0x07, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00]);
+		}
+		bytes
+	}
+
+	/// Build a .text section with `n_regular` regular instructions followed by
+	/// `n_syscalls` syscall instructions.
+	fn mixed_text(n_regular: usize, n_syscalls: usize) -> Vec<u8> {
+		let mut bytes = Vec::with_capacity((n_regular + n_syscalls) * 8);
+		for _ in 0..n_regular {
+			bytes.extend_from_slice(&[0x07, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00]);
+		}
+		for _ in 0..n_syscalls {
+			// syscall: opcode 0x85, src_reg=0
+			bytes.extend_from_slice(&[0x85, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00]);
+		}
+		bytes
+	}
+
 	#[test]
 	fn empty_text_section() {
-		let elf = make_elf(0, vec![]);
+		let elf = make_elf(vec![], vec![]);
 		let result = analyze_functions(&elf);
 		assert!(result.is_empty());
 	}
 
 	#[test]
 	fn no_symbols_reports_entire_text() {
-		let elf = make_elf(80, vec![]);
+		let elf = make_elf(nop_text(10), vec![]);
 		let result = analyze_functions(&elf);
 		assert_eq!(result.len(), 1);
 		assert_eq!(result[0].name, "<entire .text>");
-		assert_eq!(result[0].instruction_count, 10); // 80 / 8
+		assert_eq!(result[0].instruction_count, 10);
 		assert_eq!(result[0].estimated_cu, 10);
+		assert_eq!(result[0].syscall_count, 0);
+	}
+
+	#[test]
+	fn syscalls_increase_cu_estimate() {
+		// 5 regular + 3 syscalls
+		let elf = make_elf(mixed_text(5, 3), vec![]);
+		let result = analyze_functions(&elf);
+		assert_eq!(result[0].instruction_count, 8);
+		assert_eq!(result[0].syscall_count, 3);
+		assert_eq!(
+			result[0].estimated_cu,
+			5 * CU_PER_INSTRUCTION + 3 * CU_PER_SYSCALL
+		);
 	}
 
 	#[test]
 	fn single_symbol_covers_entire_text() {
 		let elf = make_elf(
-			80,
+			nop_text(10),
 			vec![Symbol {
 				name: "entrypoint".to_owned(),
 				address: 0x1000,
@@ -165,7 +240,7 @@ mod tests {
 	#[test]
 	fn multiple_symbols_partitioned() {
 		let elf = make_elf(
-			160,
+			nop_text(20),
 			vec![
 				Symbol {
 					name: "func_a".to_owned(),
@@ -181,18 +256,15 @@ mod tests {
 		);
 		let result = analyze_functions(&elf);
 		assert_eq!(result.len(), 2);
-		// Sorted by CU descending — both equal, so order may vary.
 		let names: Vec<&str> = result.iter().map(|f| f.name.as_str()).collect();
 		assert!(names.contains(&"func_a"));
 		assert!(names.contains(&"func_b"));
-		assert_eq!(result[0].instruction_count, 10);
-		assert_eq!(result[1].instruction_count, 10);
 	}
 
 	#[test]
 	fn gap_between_symbols_reported_as_unknown() {
 		let elf = make_elf(
-			240,
+			nop_text(30),
 			vec![
 				Symbol {
 					name: "func_a".to_owned(),
@@ -201,47 +273,42 @@ mod tests {
 				},
 				Symbol {
 					name: "func_b".to_owned(),
-					address: 0x10A0, // gap of 80 bytes (0x50 to 0xA0)
+					address: 0x10A0,
 					size: 80,
 				},
 			],
 		);
 		let result = analyze_functions(&elf);
-		// func_a (80B), unknown gap (80B), func_b (80B)
 		assert_eq!(result.len(), 3);
 		let unknown = result.iter().find(|f| f.name.starts_with("<unknown"));
 		assert!(unknown.is_some());
-		assert_eq!(unknown.unwrap().instruction_count, 10);
 	}
 
 	#[test]
 	fn zero_size_symbol_inferred_from_next() {
 		let elf = make_elf(
-			160,
+			nop_text(20),
 			vec![
 				Symbol {
 					name: "func_a".to_owned(),
 					address: 0x1000,
-					size: 0, // unknown size — infer from next
+					size: 0,
 				},
 				Symbol {
 					name: "func_b".to_owned(),
 					address: 0x1050,
-					size: 0, // unknown size — infer from end
+					size: 0,
 				},
 			],
 		);
 		let result = analyze_functions(&elf);
 		assert_eq!(result.len(), 2);
-		for func in &result {
-			assert_eq!(func.instruction_count, 10);
-		}
 	}
 
 	#[test]
 	fn trailing_bytes_after_last_symbol() {
 		let elf = make_elf(
-			160,
+			nop_text(20),
 			vec![Symbol {
 				name: "func_a".to_owned(),
 				address: 0x1000,
@@ -249,7 +316,6 @@ mod tests {
 			}],
 		);
 		let result = analyze_functions(&elf);
-		// func_a (80B) + trailing unknown (80B)
 		assert_eq!(result.len(), 2);
 		let trailing = result.iter().find(|f| f.name.starts_with("<unknown"));
 		assert!(trailing.is_some());
@@ -257,43 +323,43 @@ mod tests {
 
 	#[test]
 	fn results_sorted_by_cu_descending() {
+		// func with syscalls should have higher CU than func without
+		let mut text = nop_text(5); // func_small: 5 regular
+		text.extend_from_slice(&mixed_text(2, 3).as_slice()); // func_large: 2 regular + 3 syscalls
 		let elf = make_elf(
-			240,
+			text,
 			vec![
 				Symbol {
 					name: "small".to_owned(),
 					address: 0x1000,
-					size: 16,
+					size: 40, // 5 instructions
 				},
 				Symbol {
 					name: "large".to_owned(),
-					address: 0x1010,
-					size: 160,
+					address: 0x1028,
+					size: 40, // 5 instructions but with syscalls
 				},
 			],
 		);
 		let result = analyze_functions(&elf);
 		assert!(result[0].estimated_cu >= result[1].estimated_cu);
-		// Largest function should be first.
 		assert_eq!(result[0].name, "large");
 	}
 
 	#[test]
 	fn non_aligned_text_ignores_partial_instruction() {
-		// 13 bytes = 1 full instruction (8B) + 5 leftover bytes
-		let elf = make_elf(13, vec![]);
+		// 13 bytes = 1 full instruction + 5 leftover
+		let mut text = vec![0x07, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00];
+		text.extend_from_slice(&[0x00; 5]);
+		let elf = make_elf(text, vec![]);
 		let result = analyze_functions(&elf);
-		assert_eq!(result.len(), 1);
-		assert_eq!(result[0].instruction_count, 1); // 13 / 8 = 1
+		assert_eq!(result[0].instruction_count, 1);
 	}
 
 	#[test]
 	fn overlapping_symbols_not_double_counted() {
-		// Two symbols overlap: func_a covers [0, 80) and func_b covers [40, 120).
-		// Total .text is 120 bytes = 15 instructions.
-		// Without dedup: 10 + 10 = 20 (wrong). With dedup: 10 + 5 = 15 (correct).
 		let elf = make_elf(
-			120,
+			nop_text(15),
 			vec![
 				Symbol {
 					name: "func_a".to_owned(),
@@ -302,22 +368,20 @@ mod tests {
 				},
 				Symbol {
 					name: "func_b".to_owned(),
-					address: 0x1028, // overlaps func_a
+					address: 0x1028,
 					size: 80,
 				},
 			],
 		);
 		let result = analyze_functions(&elf);
 		let total: u64 = result.iter().map(|f| f.instruction_count).sum();
-		// Total should never exceed actual instructions in .text.
-		assert_eq!(total, 120 / SBF_INSTRUCTION_SIZE);
+		assert_eq!(total, 15);
 	}
 
 	#[test]
 	fn nested_symbol_skipped() {
-		// func_b is entirely inside func_a.
 		let elf = make_elf(
-			160,
+			nop_text(20),
 			vec![
 				Symbol {
 					name: "func_a".to_owned(),
@@ -326,28 +390,44 @@ mod tests {
 				},
 				Symbol {
 					name: "func_b".to_owned(),
-					address: 0x1010, // inside func_a
+					address: 0x1010,
 					size: 16,
 				},
 			],
 		);
 		let result = analyze_functions(&elf);
 		let total: u64 = result.iter().map(|f| f.instruction_count).sum();
-		assert_eq!(total, 160 / SBF_INSTRUCTION_SIZE);
+		assert_eq!(total, 20);
 	}
 
 	#[test]
-	fn cu_calculation_uses_cost_constant() {
+	fn per_function_syscall_attribution() {
+		// func_a: 5 regular, func_b: 2 regular + 3 syscalls
+		let mut text = nop_text(5);
+		text.extend(mixed_text(2, 3));
 		let elf = make_elf(
-			800,
-			vec![Symbol {
-				name: "big_fn".to_owned(),
-				address: 0x1000,
-				size: 800,
-			}],
+			text,
+			vec![
+				Symbol {
+					name: "func_a".to_owned(),
+					address: 0x1000,
+					size: 40,
+				},
+				Symbol {
+					name: "func_b".to_owned(),
+					address: 0x1028,
+					size: 40,
+				},
+			],
 		);
 		let result = analyze_functions(&elf);
-		assert_eq!(result[0].instruction_count, 100);
-		assert_eq!(result[0].estimated_cu, 100 * CU_PER_INSTRUCTION);
+		let func_a = result.iter().find(|f| f.name == "func_a").unwrap();
+		let func_b = result.iter().find(|f| f.name == "func_b").unwrap();
+
+		assert_eq!(func_a.syscall_count, 0);
+		assert_eq!(func_a.estimated_cu, 5);
+
+		assert_eq!(func_b.syscall_count, 3);
+		assert_eq!(func_b.estimated_cu, 2 + 3 * CU_PER_SYSCALL);
 	}
 }


### PR DESCRIPTION
## Summary

Implement opcode-aware CU cost estimation for the static profiler.

Closes #90

### Before
Flat 1 CU per instruction — could underestimate programs with heavy syscall usage by 10-100x.

### After
Decode each 8-byte SBF instruction's opcode:
- Regular instructions (ALU, memory, branch): **1 CU**
- Syscall instructions (`call imm` with `src_reg=0`): **100 CU**

### Changes
- `cost.rs`: New `estimate_instruction_cu()`, `BPF_CALL_IMM`, `CU_PER_SYSCALL` constants, cost model documentation
- `sbf.rs`: Actual opcode decoding per instruction instead of flat multiplication
- `FunctionProfile`: New `syscall_count` field
- `ProgramProfile`: New `total_syscalls` field
- Text output: New Syscall column
- Readme: Updated to describe opcode-aware model

### Tests
- 6 new opcode unit tests (regular, syscall, internal call, exit, memory, branch)
- 2 new integration tests (syscall CU increase, per-function attribution)
- All 42 tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced profiler with opcode-aware cost estimation for more accurate CU calculations.
  * Added syscall detection and tracking; syscalls now cost 100 CU each versus 1 CU for regular instructions.
  * Profiler output now displays syscall counts and totals.

* **Documentation**
  * Updated profiler documentation to reflect the new cost model and limitations.

* **Tests**
  * Added unit tests for instruction classification and cost estimation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->