### PR TITLE
feat(pina_cli): multi-file module resolution for IDL parser

### DIFF
--- a/.changeset/multifile_idl_parser.md
+++ b/.changeset/multifile_idl_parser.md
@@ -1,0 +1,18 @@
+---
+default: minor
+pina_cli: minor
+---
+
+Add multi-file module resolution to the IDL parser.
+
+`parse_program()` now follows `mod` declarations from `src/lib.rs` to
+discover and parse additional source files. This enables IDL generation
+for programs that split code across multiple modules (e.g.
+`src/state.rs`, `src/instructions/mod.rs`).
+
+New module: `crates/pina_cli/src/parse/module_resolver.rs` with 5 unit
+tests covering single-file crates, child modules, `mod.rs` style,
+missing modules, and inline modules.
+
+The existing `assemble_program_ir()` function is preserved for backward
+compatibility and now delegates to the new `assemble_program_ir_multi()`.

--- a/crates/pina_cli/src/parse/mod.rs
+++ b/crates/pina_cli/src/parse/mod.rs
@@ -6,6 +6,7 @@ pub mod doc_comments;
 pub mod entrypoint;
 pub mod error_enum;
 pub mod instruction_data;
+pub mod module_resolver;
 pub mod program_id;
 pub mod seeds;
 pub mod types;
@@ -19,12 +20,17 @@ use heck::ToSnakeCase;
 use crate::error::IdlError;
 use crate::ir::AccountIr;
 use crate::ir::DiscriminatorIr;
+use crate::ir::ErrorIr;
 use crate::ir::InstructionAccountIr;
 use crate::ir::InstructionIr;
 use crate::ir::PdaIr;
 use crate::ir::ProgramIr;
 
 /// Parse a program crate directory and assemble a `ProgramIr`.
+///
+/// Resolves all source files starting from `src/lib.rs`, following `mod`
+/// declarations to discover additional files. All discovered files are
+/// parsed and their contents merged for IDL extraction.
 pub fn parse_program(
 	program_path: &Path,
 	name_override: Option<&str>,
@@ -36,27 +42,94 @@ pub fn parse_program(
 	let package_name =
 		extract_package_name(&cargo_contents).unwrap_or_else(|| "unknown_program".to_owned());
 
-	let src_path = program_path.join("src/lib.rs");
-	let source = std::fs::read_to_string(&src_path).map_err(|e| IdlError::io(&src_path, e))?;
-	let file = syn::parse_file(&source).map_err(|e| IdlError::parse(&src_path, &e))?;
+	let src_dir = program_path.join("src");
+	let lib_path = src_dir.join("lib.rs");
 
-	assemble_program_ir(&file, name_override.unwrap_or(&package_name))
+	let resolved_files = module_resolver::resolve_crate(&src_dir, &lib_path)?;
+	let syn_files: Vec<&syn::File> = resolved_files.iter().map(|rf| &rf.file).collect();
+
+	assemble_program_ir_multi(&syn_files, name_override.unwrap_or(&package_name))
 }
 
-/// Assemble a `ProgramIr` from a parsed syn `File`.
-pub fn assemble_program_ir(file: &syn::File, program_name: &str) -> Result<ProgramIr, IdlError> {
-	// Step 1: Extract all pieces.
-	let public_key = program_id::extract_program_id(file).ok_or(IdlError::NoProgramId)?;
-	let disc_enums = discriminator::extract_discriminator_enums(file);
-	let account_structs = account_state::extract_account_structs(file);
-	let instruction_structs = instruction_data::extract_instruction_structs(file);
-	let ix_accounts_structs = accounts_struct::extract_accounts_structs(file);
-	let errors = error_enum::extract_error_enums(file);
-	let dispatch = entrypoint::extract_dispatch_map(file);
-	let validation_props = validation::extract_validation_properties(file);
-	let seed_constants = seeds::extract_seed_constants(file);
-	let pdas_ir = seeds::extract_pda_from_seed_macros(file, &seed_constants);
+/// Assemble a `ProgramIr` from multiple parsed syn `File`s.
+///
+/// Merges extractions from all files. The first file should be `lib.rs`
+/// (containing `declare_id!` and the entrypoint dispatch).
+pub fn assemble_program_ir_multi(
+	files: &[&syn::File],
+	program_name: &str,
+) -> Result<ProgramIr, IdlError> {
+	let mut all_disc_enums = Vec::new();
+	let mut all_account_structs = Vec::new();
+	let mut all_instruction_structs = Vec::new();
+	let mut all_ix_accounts_structs = Vec::new();
+	let mut all_errors = Vec::new();
+	let mut all_seed_constants = Vec::new();
+	let mut dispatch = Vec::new();
+	let mut all_validation_props = HashMap::new();
+	let mut public_key = None;
+	let mut pdas_ir = Vec::new();
 
+	for file in files {
+		if public_key.is_none() {
+			public_key = program_id::extract_program_id(file);
+		}
+
+		all_disc_enums.extend(discriminator::extract_discriminator_enums(file));
+		all_account_structs.extend(account_state::extract_account_structs(file));
+		all_instruction_structs.extend(instruction_data::extract_instruction_structs(file));
+		all_ix_accounts_structs.extend(accounts_struct::extract_accounts_structs(file));
+		all_errors.extend(error_enum::extract_error_enums(file));
+
+		let file_dispatch = entrypoint::extract_dispatch_map(file);
+		if !file_dispatch.is_empty() {
+			dispatch = file_dispatch;
+		}
+
+		let file_validation_props = validation::extract_validation_properties(file);
+		all_validation_props.extend(file_validation_props);
+
+		let file_seed_constants = seeds::extract_seed_constants(file);
+		let file_pdas = seeds::extract_pda_from_seed_macros(file, &file_seed_constants);
+		all_seed_constants.extend(file_seed_constants);
+		pdas_ir.extend(file_pdas);
+	}
+
+	let public_key = public_key.ok_or(IdlError::NoProgramId)?;
+
+	return assemble_from_extracted(
+		program_name,
+		public_key,
+		&all_disc_enums,
+		&all_account_structs,
+		&all_instruction_structs,
+		&all_ix_accounts_structs,
+		&all_errors,
+		&dispatch,
+		&all_validation_props,
+		&pdas_ir,
+	);
+}
+
+/// Assemble a `ProgramIr` from a single parsed syn `File`.
+pub fn assemble_program_ir(file: &syn::File, program_name: &str) -> Result<ProgramIr, IdlError> {
+	assemble_program_ir_multi(&[file], program_name)
+}
+
+/// Internal assembly from pre-extracted components.
+#[allow(clippy::too_many_arguments)]
+fn assemble_from_extracted(
+	program_name: &str,
+	public_key: String,
+	disc_enums: &[discriminator::DiscriminatorEnum],
+	account_structs: &[account_state::AccountStruct],
+	instruction_structs: &[instruction_data::InstructionStruct],
+	ix_accounts_structs: &[accounts_struct::AccountsStruct],
+	errors: &[ErrorIr],
+	dispatch: &[entrypoint::DispatchEntry],
+	validation_props: &HashMap<String, HashMap<String, validation::AccountProperties>>,
+	pdas_ir: &[PdaIr],
+) -> Result<ProgramIr, IdlError> {
 	// Step 2: Build accounts IR.
 	let accounts: Vec<AccountIr> = account_structs
 		.iter()
@@ -145,8 +218,8 @@ pub fn assemble_program_ir(file: &syn::File, program_name: &str) -> Result<Progr
 		public_key,
 		accounts,
 		instructions,
-		errors,
-		pdas: pdas_ir,
+		errors: errors.to_vec(),
+		pdas: pdas_ir.to_vec(),
 	};
 
 	// Step 4: Validate the assembled IR for collisions and duplicates.

--- a/crates/pina_cli/src/parse/module_resolver.rs
+++ b/crates/pina_cli/src/parse/module_resolver.rs
@@ -1,0 +1,180 @@
+//! Module resolution for multi-file Pina programs.
+//!
+//! Follows `mod` declarations from `src/lib.rs` to discover all source files
+//! in a program crate, parsing each into a `syn::File`.
+
+use std::path::Path;
+use std::path::PathBuf;
+
+use crate::error::IdlError;
+
+/// A resolved source file with its parsed AST.
+#[derive(Debug)]
+pub struct ResolvedFile {
+	/// Path to the source file (relative or absolute).
+	pub path: PathBuf,
+	/// Parsed AST.
+	pub file: syn::File,
+}
+
+/// Resolve all source files in a crate starting from `lib.rs`.
+///
+/// Parses `lib.rs`, then follows `mod` declarations to find and parse
+/// additional source files. Only inline modules (with a body) and file-based
+/// modules (without a body) are resolved. Conditional compilation attributes
+/// are ignored — all `mod` declarations are followed.
+pub fn resolve_crate(src_dir: &Path, lib_path: &Path) -> Result<Vec<ResolvedFile>, IdlError> {
+	let source = std::fs::read_to_string(lib_path).map_err(|e| IdlError::io(lib_path, e))?;
+	let file = syn::parse_file(&source).map_err(|e| IdlError::parse(lib_path, &e))?;
+
+	let mut files = vec![ResolvedFile {
+		path: lib_path.to_path_buf(),
+		file: file.clone(),
+	}];
+
+	// Resolve child modules declared in lib.rs.
+	resolve_modules(src_dir, &file, &mut files)?;
+
+	Ok(files)
+}
+
+/// Recursively resolve `mod` declarations in a parsed file.
+fn resolve_modules(
+	base_dir: &Path,
+	file: &syn::File,
+	files: &mut Vec<ResolvedFile>,
+) -> Result<(), IdlError> {
+	for item in &file.items {
+		if let syn::Item::Mod(item_mod) = item {
+			// Skip inline modules (they're already in the parent file's AST).
+			if item_mod.content.is_some() {
+				continue;
+			}
+
+			let mod_name = item_mod.ident.to_string();
+
+			// Try mod_name.rs first, then mod_name/mod.rs.
+			let candidates = [
+				base_dir.join(format!("{mod_name}.rs")),
+				base_dir.join(&mod_name).join("mod.rs"),
+			];
+
+			let mod_path = candidates.iter().find(|p| p.is_file());
+
+			let Some(mod_path) = mod_path else {
+				// Module file not found — skip silently (could be a cfg-gated
+				// or external module).
+				continue;
+			};
+
+			let source =
+				std::fs::read_to_string(mod_path).map_err(|e| IdlError::io(mod_path, e))?;
+			let mod_file = syn::parse_file(&source).map_err(|e| IdlError::parse(mod_path, &e))?;
+
+			files.push(ResolvedFile {
+				path: mod_path.clone(),
+				file: mod_file.clone(),
+			});
+
+			// Recurse into the resolved module's directory for nested modules.
+			let child_dir = if mod_path.file_name().is_some_and(|n| n == "mod.rs") {
+				mod_path.parent().unwrap_or(base_dir).to_path_buf()
+			} else {
+				// For foo.rs, child modules would be in foo/ directory.
+				base_dir.join(&mod_name)
+			};
+
+			if child_dir.is_dir() {
+				resolve_modules(&child_dir, &mod_file, files)?;
+			}
+		}
+	}
+
+	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use std::fs;
+
+	use super::*;
+
+	#[test]
+	fn resolves_single_file_crate() {
+		let dir = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+		let src = dir.path().join("src");
+		fs::create_dir_all(&src).unwrap_or_else(|e| panic!("mkdir: {e}"));
+		fs::write(src.join("lib.rs"), "pub fn hello() {}").unwrap_or_else(|e| panic!("write: {e}"));
+
+		let files =
+			resolve_crate(&src, &src.join("lib.rs")).unwrap_or_else(|e| panic!("resolve: {e}"));
+		assert_eq!(files.len(), 1);
+	}
+
+	#[test]
+	fn resolves_child_module_file() {
+		let dir = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+		let src = dir.path().join("src");
+		fs::create_dir_all(&src).unwrap_or_else(|e| panic!("mkdir: {e}"));
+		fs::write(src.join("lib.rs"), "mod state;\npub fn hello() {}")
+			.unwrap_or_else(|e| panic!("write: {e}"));
+		fs::write(src.join("state.rs"), "pub struct MyState {}")
+			.unwrap_or_else(|e| panic!("write: {e}"));
+
+		let files =
+			resolve_crate(&src, &src.join("lib.rs")).unwrap_or_else(|e| panic!("resolve: {e}"));
+		assert_eq!(files.len(), 2);
+		assert!(files.iter().any(|f| f.path.ends_with("state.rs")));
+	}
+
+	#[test]
+	fn resolves_mod_rs_style() {
+		let dir = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+		let src = dir.path().join("src");
+		let instructions_dir = src.join("instructions");
+		fs::create_dir_all(&instructions_dir).unwrap_or_else(|e| panic!("mkdir: {e}"));
+		fs::write(src.join("lib.rs"), "mod instructions;\npub fn hello() {}")
+			.unwrap_or_else(|e| panic!("write: {e}"));
+		fs::write(
+			instructions_dir.join("mod.rs"),
+			"pub struct MyInstruction {}",
+		)
+		.unwrap_or_else(|e| panic!("write: {e}"));
+
+		let files =
+			resolve_crate(&src, &src.join("lib.rs")).unwrap_or_else(|e| panic!("resolve: {e}"));
+		assert_eq!(files.len(), 2);
+		assert!(files.iter().any(|f| f.path.ends_with("mod.rs")));
+	}
+
+	#[test]
+	fn skips_missing_modules_gracefully() {
+		let dir = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+		let src = dir.path().join("src");
+		fs::create_dir_all(&src).unwrap_or_else(|e| panic!("mkdir: {e}"));
+		// References a module that doesn't exist on disk.
+		fs::write(src.join("lib.rs"), "mod nonexistent;\npub fn hello() {}")
+			.unwrap_or_else(|e| panic!("write: {e}"));
+
+		let files =
+			resolve_crate(&src, &src.join("lib.rs")).unwrap_or_else(|e| panic!("resolve: {e}"));
+		// Should still resolve lib.rs, just skip the missing module.
+		assert_eq!(files.len(), 1);
+	}
+
+	#[test]
+	fn skips_inline_modules() {
+		let dir = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+		let src = dir.path().join("src");
+		fs::create_dir_all(&src).unwrap_or_else(|e| panic!("mkdir: {e}"));
+		fs::write(
+			src.join("lib.rs"),
+			"mod inline { pub fn foo() {} }\npub fn hello() {}",
+		)
+		.unwrap_or_else(|e| panic!("write: {e}"));
+
+		let files =
+			resolve_crate(&src, &src.join("lib.rs")).unwrap_or_else(|e| panic!("resolve: {e}"));
+		assert_eq!(files.len(), 1); // Only lib.rs, inline module is part of it.
+	}
+}


### PR DESCRIPTION
## Summary

Add multi-file module resolution so the IDL parser can handle programs split across multiple source files.

Closes #91

### Changes
- New `module_resolver.rs`: resolves `mod` declarations from `src/lib.rs` to discover all source files
- `assemble_program_ir_multi()`: merges extractions from multiple files
- `parse_program()` now uses module resolution instead of reading only `lib.rs`
- `assemble_program_ir()` preserved for backward compatibility

### Tests
- 5 new unit tests: single-file, child modules, mod.rs style, missing modules, inline modules
- All 84 existing tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * IDL parser now supports multi-file Rust module resolution, enabling discovery and parsing of Pina programs organized across multiple source files and nested modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->