### PR TITLE
docs: comprehensive documentation update across workspace

### DIFF
--- a/.changeset/comprehensive_docs_update.md
+++ b/.changeset/comprehensive_docs_update.md
@@ -1,0 +1,24 @@
+---
+default: patch
+pina: patch
+pina_cli: patch
+pina_profile: patch
+---
+
+Comprehensive documentation update across workspace.
+
+New mdt providers (template.t.md):
+
+- `pinaCliCommands` — CLI command reference table
+- `pinaIntrospectionDescription` — introspection module overview
+- `pinaProfileDescription` — static CU profiler overview
+
+Updated documentation:
+
+- `docs/src/crates-and-features.md` — added `pina_profile`, CLI commands table, multi-file parser note, pod arithmetic, codama renderer module structure
+- `docs/src/core-concepts.md` — added Pod types table, arithmetic description, introspection section; fixed stale `loaders.rs` → `impls.rs` reference
+- `readme.md` — added Pod arithmetic examples, static CU profiler section, replaced outdated 3-crate table with full workspace packages table
+- `crates/pina_cli/readme.md` — added `pina profile` command, multi-file note
+- Fixed missing `CU_PER_INSTRUCTION` import in profiler tests
+
+mdt provider/consumer counts: 23/46 → 26/56.

--- a/.changeset/introspection_tests.md
+++ b/.changeset/introspection_tests.md
@@ -5,9 +5,7 @@ pina: patch
 
 Add 12 integration tests for `pina::introspection` module (previously 0% coverage).
 
-Tests construct fake Instructions sysvar account data following the exact binary
-layout that pinocchio's `Instructions` parser expects, then exercise each
-introspection function end-to-end:
+Tests construct fake Instructions sysvar account data following the exact binary layout that pinocchio's `Instructions` parser expects, then exercise each introspection function end-to-end:
 
 - `get_instruction_count`: single and multiple instructions
 - `get_current_instruction_index`: correct index returned

--- a/crates/pina_cli/readme.md
+++ b/crates/pina_cli/readme.md
@@ -54,6 +54,18 @@ pina init my_program
 pina init my_program --path ./programs/my_program --force
 ```
 
+### `pina profile`
+
+<br>
+
+Static CU profiler for compiled SBF programs.
+
+```bash
+pina profile target/deploy/my_program.so
+pina profile target/deploy/my_program.so --json
+pina profile target/deploy/my_program.so --output report.json
+```
+
 ### `pina codama generate`
 
 <br>
@@ -118,6 +130,8 @@ cargo run --manifest-path ./crates/pina_codama_renderer/Cargo.toml -- \
 ## Parser Expectations
 
 <br>
+
+The IDL parser supports multi-file programs — it follows `mod` declarations from `src/lib.rs` to discover accounts, instructions, and discriminators across all source files.
 
 For best IDL extraction fidelity, follow the rules documented in [`crates/pina_cli/rules.md`](./rules.md).
 

--- a/crates/pina_profile/src/sbf.rs
+++ b/crates/pina_profile/src/sbf.rs
@@ -151,6 +151,7 @@ pub fn analyze_functions(elf: &ElfInfo) -> Vec<FunctionProfile> {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::cost::CU_PER_INSTRUCTION;
 	use crate::cost::CU_PER_SYSCALL;
 	use crate::elf::ElfInfo;
 	use crate::elf::Symbol;

--- a/docs/src/core-concepts.md
+++ b/docs/src/core-concepts.md
@@ -20,8 +20,55 @@ This pattern improves readability while keeping checks explicit and audit-able.
 
 ## Typed account conversions
 
-Traits in `crates/pina/src/loaders.rs` provide typed conversion paths from raw `AccountView` values into strongly typed account states.
+Traits in `crates/pina/src/impls.rs` provide typed conversion paths from raw `AccountView` values into strongly typed account states.
 
 ## Entrypoint model
 
 `nostd_entrypoint!` wires BPF entrypoint plumbing while preserving `no_std` constraints for on-chain builds.
+
+## Pod types
+
+<!-- {=podTypesTable} -->
+
+| Type      | Wraps  | Size     |
+| --------- | ------ | -------- |
+| `PodBool` | `bool` | 1 byte   |
+| `PodU16`  | `u16`  | 2 bytes  |
+| `PodI16`  | `i16`  | 2 bytes  |
+| `PodU32`  | `u32`  | 4 bytes  |
+| `PodI32`  | `i32`  | 4 bytes  |
+| `PodU64`  | `u64`  | 8 bytes  |
+| `PodI64`  | `i64`  | 8 bytes  |
+| `PodU128` | `u128` | 16 bytes |
+| `PodI128` | `i128` | 16 bytes |
+
+All types are `#[repr(transparent)]` over byte arrays (or `u8` for `PodBool`) and implement `bytemuck::Pod` + `bytemuck::Zeroable`.
+
+<!-- {/podTypesTable} -->
+
+<!-- {=podArithmeticDescription} -->
+
+Arithmetic operators (`+`, `-`, `*`) use **wrapping** semantics in release builds for CU efficiency and **panic on overflow** in debug builds. Use `checked_add`, `checked_sub`, `checked_mul`, `checked_div` where overflow must be detected in all build profiles.
+
+Each Pod integer type provides `ZERO`, `MIN`, and `MAX` constants.
+
+<!-- {/podArithmeticDescription} -->
+
+This means you can write ergonomic code like:
+
+```rust
+my_account.count += 1u64;
+let fee = balance.checked_mul(3u64).unwrap_or(PodU64::MAX);
+```
+
+## Instruction introspection
+
+<!-- {=pinaIntrospectionDescription} -->
+
+The `pina::introspection` module provides helpers for reading the Instructions sysvar at runtime. This enables:
+
+- **Flash loan guards** — verify the current instruction is not being invoked via CPI (`assert_no_cpi`)
+- **Transaction inspection** — count instructions (`get_instruction_count`) or find the current index (`get_current_instruction_index`)
+- **Sandwich detection** — check whether a specific program appears before or after the current instruction (`has_instruction_before`, `has_instruction_after`)
+
+<!-- {/pinaIntrospectionDescription} -->

--- a/docs/src/crates-and-features.md
+++ b/docs/src/crates-and-features.md
@@ -1,5 +1,19 @@
 # Crates and Features
 
+<!-- {=pinaWorkspacePackages} -->
+
+| Crate                  | Path                          | Description                                                       |
+| ---------------------- | ----------------------------- | ----------------------------------------------------------------- |
+| `pina`                 | `crates/pina`                 | Core framework — traits, account loaders, CPI helpers, Pod types. |
+| `pina_macros`          | `crates/pina_macros`          | Proc macros — `#[account]`, `#[instruction]`, `#[event]`, etc.    |
+| `pina_cli`             | `crates/pina_cli`             | CLI/library for IDL generation, Codama integration, scaffolding.  |
+| `pina_codama_renderer` | `crates/pina_codama_renderer` | Repository-local Codama Rust renderer for Pina-style clients.     |
+| `pina_pod_primitives`  | `crates/pina_pod_primitives`  | Alignment-safe `no_std` POD primitive wrappers.                   |
+| `pina_profile`         | `crates/pina_profile`         | Static CU profiler for compiled SBF programs.                     |
+| `pina_sdk_ids`         | `crates/pina_sdk_ids`         | Typed constants for well-known Solana program/sysvar IDs.         |
+
+<!-- {/pinaWorkspacePackages} -->
+
 ## `crates/pina`
 
 Core runtime crate for on-chain program logic.
@@ -10,6 +24,8 @@ Includes:
 - Typed account loaders and discriminator checks.
 - CPI/system/token helper utilities.
 - `nostd_entrypoint!` and instruction parsing helpers.
+- Instruction introspection (flash loan guards, sandwich detection).
+- Pod types with full arithmetic operator support.
 
 Feature flags:
 
@@ -42,27 +58,67 @@ Developer CLI and library.
 
 Commands:
 
-- `pina init`: scaffold a new Pina program crate.
-- `pina idl`: parse a Pina program and output Codama JSON.
-- `pina codama generate`: generate Codama IDLs plus Rust/JS clients for examples.
+<!-- {=pinaCliCommands} -->
+
+| Command                  | Description                                           |
+| ------------------------ | ----------------------------------------------------- |
+| `pina init <name>`       | Scaffold a new Pina program project                   |
+| `pina idl --path <dir>`  | Generate a Codama IDL JSON from a Pina program        |
+| `pina profile <path.so>` | Static CU profiler for compiled SBF binaries          |
+| `pina codama generate`   | Generate Codama IDLs and Rust/JS clients for examples |
+
+<!-- {/pinaCliCommands} -->
+
+The IDL parser supports multi-file programs — it follows `mod` declarations from `src/lib.rs` to discover accounts, instructions, and discriminators across all source files.
 
 Library surface:
 
 - `pina_cli::generate_idl(program_path, name_override)`
 - `pina_cli::init_project(path, package_name, force)`
 
+## `crates/pina_pod_primitives`
+
+`no_std` crate containing alignment-safe POD primitive wrappers (`PodBool`, `PodU*`, `PodI*`) and conversion macro helpers shared by `pina` and generated clients.
+
+<!-- {=podArithmeticDescription} -->
+
+Arithmetic operators (`+`, `-`, `*`) use **wrapping** semantics in release builds for CU efficiency and **panic on overflow** in debug builds. Use `checked_add`, `checked_sub`, `checked_mul`, `checked_div` where overflow must be detected in all build profiles.
+
+Each Pod integer type provides `ZERO`, `MIN`, and `MAX` constants.
+
+<!-- {/podArithmeticDescription} -->
+
+## `crates/pina_profile`
+
+<!-- {=pinaProfileDescription} -->
+
+The `pina profile` command analyzes compiled SBF `.so` binaries to estimate per-function compute unit costs without requiring a running validator.
+
+```sh
+pina profile target/deploy/my_program.so          # text summary
+pina profile target/deploy/my_program.so --json    # JSON for CI
+pina profile target/deploy/my_program.so -o r.json # write to file
+```
+
+The profiler decodes each SBF instruction opcode and assigns costs: regular instructions cost 1 CU, syscalls cost 100 CU.
+
+<!-- {/pinaProfileDescription} -->
+
+## `crates/pina_codama_renderer`
+
+Repository-local renderer that generates Pina-style Rust client code from Codama JSON IDLs. The renderer is organized into focused modules under `src/render/`:
+
+- `accounts.rs` — account page and PDA helpers
+- `instructions.rs` — instruction page, account metas
+- `types.rs` — Pod type rendering, defined types
+- `errors.rs` — error page rendering
+- `discriminator.rs` — discriminator rendering
+- `seeds.rs` — seed parameter/constant rendering
+
+Use this when you want generated Rust models to match Pina's fixed-size discriminator-first/bytemuck conventions.
+
 ## `crates/pina_sdk_ids`
 
 `no_std` crate that exports well-known Solana program/sysvar IDs as typed constants.
 
 Use this crate to avoid hardcoded base58 literals in validation logic.
-
-## `crates/pina_pod_primitives`
-
-`no_std` crate containing alignment-safe POD primitive wrappers (`PodBool`, `PodU*`, `PodI*`) and conversion macro helpers shared by `pina` and generated clients.
-
-## `crates/pina_codama_renderer`
-
-Repository-local renderer binary that generates Pina-style Rust client code from Codama JSON.
-
-Use this when you want generated Rust models to match Pina's fixed-size discriminator-first/bytemuck conventions.

--- a/readme.md
+++ b/readme.md
@@ -436,9 +436,6 @@ pub struct MyAccounts<'a> {
 
 Alignment-safe primitive wrappers for use in `#[repr(C)]` account structs. Solana account data is byte-aligned, so standard Rust integers cannot be placed directly in `Pod` structs.
 
-| Type | Wraps | Size |
-| ---- | ----- | ---- |
-
 <!-- {=podTypesTable} -->
 
 | Type      | Wraps  | Size     |
@@ -474,7 +471,23 @@ let amount = PodU64::from_primitive(1_000_000);
 
 // Convert back.
 let raw: u64 = amount.into();
+
+// Ergonomic arithmetic (debug: checked, release: wrapping).
+let mut count = PodU64::from(0u64);
+count += 1u64;
+
+// Checked/saturating variants for explicit overflow handling.
+let fee = amount.checked_mul(3u64);
+let clamped = amount.saturating_add(PodU64::MAX);
 ```
+
+<!-- {=podArithmeticDescription} -->
+
+Arithmetic operators (`+`, `-`, `*`) use **wrapping** semantics in release builds for CU efficiency and **panic on overflow** in debug builds. Use `checked_add`, `checked_sub`, `checked_mul`, `checked_div` where overflow must be detected in all build profiles.
+
+Each Pod integer type provides `ZERO`, `MIN`, and `MAX` constants.
+
+<!-- {/podArithmeticDescription} -->
 
 ### CPI helpers
 
@@ -568,15 +581,41 @@ cargo nextest run  # Faster parallel test execution
 
 <!-- {/pinaTestingInstructions} -->
 
+## Static CU Profiling
+
+<br>
+
+<!-- {=pinaProfileDescription} -->
+
+The `pina profile` command analyzes compiled SBF `.so` binaries to estimate per-function compute unit costs without requiring a running validator.
+
+```sh
+pina profile target/deploy/my_program.so          # text summary
+pina profile target/deploy/my_program.so --json    # JSON for CI
+pina profile target/deploy/my_program.so -o r.json # write to file
+```
+
+The profiler decodes each SBF instruction opcode and assigns costs: regular instructions cost 1 CU, syscalls cost 100 CU.
+
+<!-- {/pinaProfileDescription} -->
+
 ## Crates
 
 <br>
 
-| Crate                                 | Description                                                                |
-| ------------------------------------- | -------------------------------------------------------------------------- |
-| [`pina`](crates/pina)                 | Core framework — traits, account loaders, CPI helpers, Pod types, macros.  |
-| [`pina_macros`](crates/pina_macros)   | Proc macros — `#[account]`, `#[instruction]`, `#[event]`, `#[error]`, etc. |
-| [`pina_sdk_ids`](crates/pina_sdk_ids) | Well-known Solana program and sysvar IDs.                                  |
+<!-- {=pinaWorkspacePackages} -->
+
+| Crate                  | Path                          | Description                                                       |
+| ---------------------- | ----------------------------- | ----------------------------------------------------------------- |
+| `pina`                 | `crates/pina`                 | Core framework — traits, account loaders, CPI helpers, Pod types. |
+| `pina_macros`          | `crates/pina_macros`          | Proc macros — `#[account]`, `#[instruction]`, `#[event]`, etc.    |
+| `pina_cli`             | `crates/pina_cli`             | CLI/library for IDL generation, Codama integration, scaffolding.  |
+| `pina_codama_renderer` | `crates/pina_codama_renderer` | Repository-local Codama Rust renderer for Pina-style clients.     |
+| `pina_pod_primitives`  | `crates/pina_pod_primitives`  | Alignment-safe `no_std` POD primitive wrappers.                   |
+| `pina_profile`         | `crates/pina_profile`         | Static CU profiler for compiled SBF programs.                     |
+| `pina_sdk_ids`         | `crates/pina_sdk_ids`         | Typed constants for well-known Solana program/sysvar IDs.         |
+
+<!-- {/pinaWorkspacePackages} -->
 
 ## Ideology
 

--- a/template.t.md
+++ b/template.t.md
@@ -199,6 +199,41 @@ cargo nextest run  # Faster parallel test execution
 
 <!-- {/pinaBadgeLinks} -->
 
+<!-- {@pinaCliCommands} -->
+
+| Command                  | Description                                           |
+| ------------------------ | ----------------------------------------------------- |
+| `pina init <name>`       | Scaffold a new Pina program project                   |
+| `pina idl --path <dir>`  | Generate a Codama IDL JSON from a Pina program        |
+| `pina profile <path.so>` | Static CU profiler for compiled SBF binaries          |
+| `pina codama generate`   | Generate Codama IDLs and Rust/JS clients for examples |
+
+<!-- {/pinaCliCommands} -->
+
+<!-- {@pinaIntrospectionDescription} -->
+
+The `pina::introspection` module provides helpers for reading the Instructions sysvar at runtime. This enables:
+
+- **Flash loan guards** — verify the current instruction is not being invoked via CPI (`assert_no_cpi`)
+- **Transaction inspection** — count instructions (`get_instruction_count`) or find the current index (`get_current_instruction_index`)
+- **Sandwich detection** — check whether a specific program appears before or after the current instruction (`has_instruction_before`, `has_instruction_after`)
+
+<!-- {/pinaIntrospectionDescription} -->
+
+<!-- {@pinaProfileDescription} -->
+
+The `pina profile` command analyzes compiled SBF `.so` binaries to estimate per-function compute unit costs without requiring a running validator.
+
+```sh
+pina profile target/deploy/my_program.so          # text summary
+pina profile target/deploy/my_program.so --json    # JSON for CI
+pina profile target/deploy/my_program.so -o r.json # write to file
+```
+
+The profiler decodes each SBF instruction opcode and assigns costs: regular instructions cost 1 CU, syscalls cost 100 CU.
+
+<!-- {/pinaProfileDescription} -->
+
 <!-- {@pinaSecurityBestPractices} -->
 
 - **Always call `assert_signer()`** before trusting authority accounts


### PR DESCRIPTION
## Summary

Thorough documentation pass to bring all docs up to date with the recent codebase changes (pod arithmetic, static profiler, multi-file parser, introspection tests, renderer split, impls.rs rename).

### New mdt providers (template.t.md)
- `pinaCliCommands` — CLI command reference table
- `pinaIntrospectionDescription` — introspection module overview
- `pinaProfileDescription` — static CU profiler overview

### Updated docs

| File | Changes |
|------|---------|
| `docs/src/crates-and-features.md` | Added `pina_profile`, CLI commands table, multi-file parser note, pod arithmetic, codama renderer module structure |
| `docs/src/core-concepts.md` | Added Pod types table, arithmetic, introspection sections; fixed stale `loaders.rs` → `impls.rs` reference |
| `readme.md` | Added Pod arithmetic examples, static CU profiler section, replaced outdated 3-crate table with full 7-crate workspace table |
| `crates/pina_cli/readme.md` | Added `pina profile` command, multi-file parser note |

### mdt stats
- **Before**: 23 providers, 46 consumers
- **After**: 26 providers, 56 consumers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the `pina profile` static compute-unit profiler for compiled SBF programs.
  * Expanded Pod types documentation with arithmetic operators, overflow behavior, and usage examples.
  * Documented instruction introspection module for runtime helpers and CPI guards.
  * Enhanced CLI documentation with multi-file program discovery and workspace crate references.

* **Tests**
  * Fixed test imports for compute-unit cost constants.

* **Chores**
  * Updated workspace documentation and changesets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->