### PR TITLE
fix: add compile-time width/packing checks and docs

### DIFF
--- a/crates/pina_macros/src/lib.rs
+++ b/crates/pina_macros/src/lib.rs
@@ -407,6 +407,20 @@ fn discriminator_impl(
 		item_enum.attrs.push(new_derive_attr);
 	}
 
+	let primitive_width_assertion = quote! {
+		const _: () = {
+			::core::assert!(
+				::core::mem::size_of::<#primitive>()
+					<= #crate_path::MAX_DISCRIMINATOR_SPACE,
+				concat!(
+					"A discriminator with primitive `",
+					stringify!(#primitive),
+					"` exceeds `MAX_DISCRIMINATOR_SPACE` and cannot be safely used for zero-copy layouts."
+				)
+			);
+		};
+	};
+
 	let mut consts = Vec::new();
 	let mut match_arms = Vec::new();
 	for variant in &item_enum.variants {
@@ -432,6 +446,8 @@ fn discriminator_impl(
 	}
 
 	let implementations = quote! {
+		#primitive_width_assertion
+
 		impl ::core::convert::From<#enum_name> for #primitive {
 			#[inline]
 			fn from(enum_value: #enum_name) -> Self {
@@ -785,10 +801,22 @@ fn account_impl(
 			quote! {
 				::core::assert!(
 					::core::mem::align_of::<#field_type>() == 1,
-					concat!("The alignment of field `", #field_name_str, "` with type `", stringify!(#field_type), "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+					concat!(
+						"The alignment of field `",
+						#field_name_str,
+						"` with type `",
+						stringify!(#field_type),
+						"` should be one. Consider using one of the exported `Pod*` types from the `pina` crate."
+					)
 				);
 			}
 		});
+
+		let mut struct_size_expr = quote! { 0usize };
+		for field in named_fields.named.iter() {
+			let field_type = &field.ty;
+			struct_size_expr = quote! { #struct_size_expr + ::core::mem::size_of::<#field_type>() };
+		}
 
 		let assertion_const_name = format_ident!(
 			"__{}_ALIGNMENT_ASSERTIONS__",
@@ -797,6 +825,22 @@ fn account_impl(
 		quote! {
 			const #assertion_const_name: () = {
 				#(#field_assertions)*
+				::core::assert!(
+					::core::mem::align_of::<#struct_name>() == 1,
+					concat!(
+						"The alignment of struct `",
+						stringify!(#struct_name),
+						"` should be one so it can be used for zero-copy Pod casts."
+					)
+				);
+				::core::assert!(
+					::core::mem::size_of::<#struct_name>() == (#struct_size_expr),
+					concat!(
+						"`",
+						stringify!(#struct_name),
+						"` layout is padded. `#[pina]` discriminator-first POD layouts must be tightly packed."
+					)
+				);
 			};
 		}
 	} else {
@@ -1140,10 +1184,22 @@ fn instruction_impl(
 			quote! {
 				::core::assert!(
 					::core::mem::align_of::<#field_type>() == 1,
-					concat!("The alignment of field `", #field_name_str, "` with type `", stringify!(#field_type), "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+					concat!(
+						"The alignment of field `",
+						#field_name_str,
+						"` with type `",
+						stringify!(#field_type),
+						"` should be one. Consider using one of the exported `Pod*` types from the `pina` crate."
+					)
 				);
 			}
 		});
+
+		let mut struct_size_expr = quote! { 0usize };
+		for field in named_fields.named.iter() {
+			let field_type = &field.ty;
+			struct_size_expr = quote! { #struct_size_expr + ::core::mem::size_of::<#field_type>() };
+		}
 
 		let assertion_const_name = format_ident!(
 			"__{}_ALIGNMENT_ASSERTIONS__",
@@ -1152,6 +1208,22 @@ fn instruction_impl(
 		quote! {
 			const #assertion_const_name: () = {
 				#(#field_assertions)*
+				::core::assert!(
+					::core::mem::align_of::<#struct_name>() == 1,
+					concat!(
+						"The alignment of struct `",
+						stringify!(#struct_name),
+						"` should be one so it can be used for zero-copy Pod casts."
+					)
+				);
+				::core::assert!(
+					::core::mem::size_of::<#struct_name>() == (#struct_size_expr),
+					concat!(
+						"`",
+						stringify!(#struct_name),
+						"` layout is padded. `#[pina]` discriminator-first POD layouts must be tightly packed."
+					)
+				);
 			};
 		}
 	} else {
@@ -1405,10 +1477,22 @@ fn event_impl(
 			quote! {
 				::core::assert!(
 					::core::mem::align_of::<#field_type>() == 1,
-					concat!("The alignment of field `", #field_name_str, "` with type `", stringify!(#field_type), "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
+					concat!(
+						"The alignment of field `",
+						#field_name_str,
+						"` with type `",
+						stringify!(#field_type),
+						"` should be one. Consider using one of the exported `Pod*` types from the `pina` crate."
+					)
 				);
 			}
 		});
+
+		let mut struct_size_expr = quote! { 0usize };
+		for field in named_fields.named.iter() {
+			let field_type = &field.ty;
+			struct_size_expr = quote! { #struct_size_expr + ::core::mem::size_of::<#field_type>() };
+		}
 
 		let assertion_const_name = format_ident!(
 			"__{}_ALIGNMENT_ASSERTIONS__",
@@ -1417,6 +1501,22 @@ fn event_impl(
 		quote! {
 			const #assertion_const_name: () = {
 				#(#field_assertions)*
+				::core::assert!(
+					::core::mem::align_of::<#struct_name>() == 1,
+					concat!(
+						"The alignment of struct `",
+						stringify!(#struct_name),
+						"` should be one so it can be used for zero-copy Pod casts."
+					)
+				);
+				::core::assert!(
+					::core::mem::size_of::<#struct_name>() == (#struct_size_expr),
+					concat!(
+						"`",
+						stringify!(#struct_name),
+						"` layout is padded. `#[pina]` discriminator-first POD layouts must be tightly packed."
+					)
+				);
 			};
 		}
 	} else {

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__account_basic.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__account_basic.snap
@@ -38,6 +38,17 @@ const __CONFIGSTATE_ALIGNMENT_ASSERTIONS__: () = {
         "bump", "` with type `", stringify!(u8),
         "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
     );
+    ::core::assert!(
+        ::core::mem::align_of:: < ConfigState > () == 1,
+        concat!("The alignment of struct `", stringify!(ConfigState),
+        "` should be one so it can be used for zero-copy Pod casts.")
+    );
+    ::core::assert!(
+        ::core::mem::size_of:: < ConfigState > () == (0usize + ::core::mem::size_of:: <
+        [u8; MyAccount::BYTES] > () + ::core::mem::size_of:: < u8 > () +
+        ::core::mem::size_of:: < u8 > ()), concat!("`", stringify!(ConfigState),
+        "` layout is padded. `#[pina]` discriminator-first POD layouts must be tightly packed.")
+    );
 };
 impl ConfigState {
     /// Zero out all bytes in the struct including padding bytes. This can be useful when closing an account.

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__account_many_fields.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__account_many_fields.snap
@@ -76,6 +76,20 @@ const __LARGESTATE_ALIGNMENT_ASSERTIONS__: () = {
         "name", "` with type `", stringify!([u8; 32]),
         "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
     );
+    ::core::assert!(
+        ::core::mem::align_of:: < LargeState > () == 1,
+        concat!("The alignment of struct `", stringify!(LargeState),
+        "` should be one so it can be used for zero-copy Pod casts.")
+    );
+    ::core::assert!(
+        ::core::mem::size_of:: < LargeState > () == (0usize + ::core::mem::size_of:: <
+        [u8; MyAccount::BYTES] > () + ::core::mem::size_of:: < [u8; 32] > () +
+        ::core::mem::size_of:: < u8 > () + ::core::mem::size_of:: < u8 > () +
+        ::core::mem::size_of:: < u8 > () + ::core::mem::size_of:: < u8 > () +
+        ::core::mem::size_of:: < [u8; 3] > () + ::core::mem::size_of:: < PodU64 > () +
+        ::core::mem::size_of:: < [u8; 32] > ()), concat!("`", stringify!(LargeState),
+        "` layout is padded. `#[pina]` discriminator-first POD layouts must be tightly packed.")
+    );
 };
 impl LargeState {
     /// Zero out all bytes in the struct including padding bytes. This can be useful when closing an account.

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__account_with_array_fields.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__account_with_array_fields.snap
@@ -46,6 +46,18 @@ const __DATAACCOUNT_ALIGNMENT_ASSERTIONS__: () = {
         "flags", "` with type `", stringify!([u8; 4]),
         "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
     );
+    ::core::assert!(
+        ::core::mem::align_of:: < DataAccount > () == 1,
+        concat!("The alignment of struct `", stringify!(DataAccount),
+        "` should be one so it can be used for zero-copy Pod casts.")
+    );
+    ::core::assert!(
+        ::core::mem::size_of:: < DataAccount > () == (0usize + ::core::mem::size_of:: <
+        [u8; AccountDiscriminator::BYTES] > () + ::core::mem::size_of:: < [u8; 32] > () +
+        ::core::mem::size_of:: < [u8; 64] > () + ::core::mem::size_of:: < [u8; 4] > ()),
+        concat!("`", stringify!(DataAccount),
+        "` layout is padded. `#[pina]` discriminator-first POD layouts must be tightly packed.")
+    );
 };
 impl DataAccount {
     /// Zero out all bytes in the struct including padding bytes. This can be useful when closing an account.

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__account_with_custom_variant.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__account_with_custom_variant.snap
@@ -32,6 +32,17 @@ const __MYSTRUCT_ALIGNMENT_ASSERTIONS__: () = {
         "value", "` with type `", stringify!(u8),
         "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
     );
+    ::core::assert!(
+        ::core::mem::align_of:: < MyStruct > () == 1,
+        concat!("The alignment of struct `", stringify!(MyStruct),
+        "` should be one so it can be used for zero-copy Pod casts.")
+    );
+    ::core::assert!(
+        ::core::mem::size_of:: < MyStruct > () == (0usize + ::core::mem::size_of:: < [u8;
+        AcctDisc::BYTES] > () + ::core::mem::size_of:: < u8 > ()), concat!("`",
+        stringify!(MyStruct),
+        "` layout is padded. `#[pina]` discriminator-first POD layouts must be tightly packed.")
+    );
 };
 impl MyStruct {
     /// Zero out all bytes in the struct including padding bytes. This can be useful when closing an account.

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__account_with_existing_derives.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__account_with_existing_derives.snap
@@ -39,6 +39,17 @@ const __GAMESTATE_ALIGNMENT_ASSERTIONS__: () = {
         "level", "` with type `", stringify!(u8),
         "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
     );
+    ::core::assert!(
+        ::core::mem::align_of:: < GameState > () == 1,
+        concat!("The alignment of struct `", stringify!(GameState),
+        "` should be one so it can be used for zero-copy Pod casts.")
+    );
+    ::core::assert!(
+        ::core::mem::size_of:: < GameState > () == (0usize + ::core::mem::size_of:: <
+        [u8; MyAccount::BYTES] > () + ::core::mem::size_of:: < u8 > () +
+        ::core::mem::size_of:: < u8 > ()), concat!("`", stringify!(GameState),
+        "` layout is padded. `#[pina]` discriminator-first POD layouts must be tightly packed.")
+    );
 };
 impl GameState {
     /// Zero out all bytes in the struct including padding bytes. This can be useful when closing an account.

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__account_with_pod_types.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__account_with_pod_types.snap
@@ -52,6 +52,18 @@ const __BALANCEACCOUNT_ALIGNMENT_ASSERTIONS__: () = {
         "is_frozen", "` with type `", stringify!(PodBool),
         "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
     );
+    ::core::assert!(
+        ::core::mem::align_of:: < BalanceAccount > () == 1,
+        concat!("The alignment of struct `", stringify!(BalanceAccount),
+        "` should be one so it can be used for zero-copy Pod casts.")
+    );
+    ::core::assert!(
+        ::core::mem::size_of:: < BalanceAccount > () == (0usize + ::core::mem::size_of::
+        < [u8; MyDiscriminator::BYTES] > () + ::core::mem::size_of:: < [u8; 32] > () +
+        ::core::mem::size_of:: < PodU64 > () + ::core::mem::size_of:: < u8 > () +
+        ::core::mem::size_of:: < PodBool > ()), concat!("`", stringify!(BalanceAccount),
+        "` layout is padded. `#[pina]` discriminator-first POD layouts must be tightly packed.")
+    );
 };
 impl BalanceAccount {
     /// Zero out all bytes in the struct including padding bytes. This can be useful when closing an account.

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__discriminator_final_attribute.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__discriminator_final_attribute.snap
@@ -13,6 +13,13 @@ expression: output
 pub enum FinalDiscriminator {
     Only = 0,
 }
+const _: () = {
+    ::core::assert!(
+        ::core::mem::size_of:: < u8 > () <= ::pina::MAX_DISCRIMINATOR_SPACE,
+        concat!("A discriminator with primitive `", stringify!(u8),
+        "` exceeds `MAX_DISCRIMINATOR_SPACE` and cannot be safely used for zero-copy layouts.")
+    );
+};
 impl ::core::convert::From<FinalDiscriminator> for u8 {
     #[inline]
     fn from(enum_value: FinalDiscriminator) -> Self {

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__discriminator_many_variants.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__discriminator_many_variants.snap
@@ -21,6 +21,13 @@ pub enum ManyVariants {
     Export = 6,
     Import = 7,
 }
+const _: () = {
+    ::core::assert!(
+        ::core::mem::size_of:: < u16 > () <= ::pina::MAX_DISCRIMINATOR_SPACE,
+        concat!("A discriminator with primitive `", stringify!(u16),
+        "` exceeds `MAX_DISCRIMINATOR_SPACE` and cannot be safely used for zero-copy layouts.")
+    );
+};
 impl ::core::convert::From<ManyVariants> for u16 {
     #[inline]
     fn from(enum_value: ManyVariants) -> Self {

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__discriminator_single_variant.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__discriminator_single_variant.snap
@@ -13,6 +13,13 @@ expression: output
 pub enum SingleVariant {
     Singleton = 42,
 }
+const _: () = {
+    ::core::assert!(
+        ::core::mem::size_of:: < u8 > () <= ::pina::MAX_DISCRIMINATOR_SPACE,
+        concat!("A discriminator with primitive `", stringify!(u8),
+        "` exceeds `MAX_DISCRIMINATOR_SPACE` and cannot be safely used for zero-copy layouts.")
+    );
+};
 impl ::core::convert::From<SingleVariant> for u8 {
     #[inline]
     fn from(enum_value: SingleVariant) -> Self {

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__discriminator_u16_primitive.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__discriminator_u16_primitive.snap
@@ -14,6 +14,13 @@ pub enum WideDiscriminator {
     Alpha = 100,
     Beta = 200,
 }
+const _: () = {
+    ::core::assert!(
+        ::core::mem::size_of:: < u16 > () <= ::pina::MAX_DISCRIMINATOR_SPACE,
+        concat!("A discriminator with primitive `", stringify!(u16),
+        "` exceeds `MAX_DISCRIMINATOR_SPACE` and cannot be safely used for zero-copy layouts.")
+    );
+};
 impl ::core::convert::From<WideDiscriminator> for u16 {
     #[inline]
     fn from(enum_value: WideDiscriminator) -> Self {

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__discriminator_u32_primitive.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__discriminator_u32_primitive.snap
@@ -15,6 +15,13 @@ pub enum U32Discriminator {
     B = 1000,
     C = 2000,
 }
+const _: () = {
+    ::core::assert!(
+        ::core::mem::size_of:: < u32 > () <= ::pina::MAX_DISCRIMINATOR_SPACE,
+        concat!("A discriminator with primitive `", stringify!(u32),
+        "` exceeds `MAX_DISCRIMINATOR_SPACE` and cannot be safely used for zero-copy layouts.")
+    );
+};
 impl ::core::convert::From<U32Discriminator> for u32 {
     #[inline]
     fn from(enum_value: U32Discriminator) -> Self {

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__discriminator_u64_primitive.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__discriminator_u64_primitive.snap
@@ -14,6 +14,13 @@ pub enum HugeDiscriminator {
     Mint = 0,
     Transfer = 1,
 }
+const _: () = {
+    ::core::assert!(
+        ::core::mem::size_of:: < u64 > () <= ::pina::MAX_DISCRIMINATOR_SPACE,
+        concat!("A discriminator with primitive `", stringify!(u64),
+        "` exceeds `MAX_DISCRIMINATOR_SPACE` and cannot be safely used for zero-copy layouts.")
+    );
+};
 impl ::core::convert::From<HugeDiscriminator> for u64 {
     #[inline]
     fn from(enum_value: HugeDiscriminator) -> Self {

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__discriminator_u8_default.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__discriminator_u8_default.snap
@@ -16,6 +16,13 @@ pub enum MyDiscriminator {
     Second = 1,
     Third = 2,
 }
+const _: () = {
+    ::core::assert!(
+        ::core::mem::size_of:: < u8 > () <= ::pina::MAX_DISCRIMINATOR_SPACE,
+        concat!("A discriminator with primitive `", stringify!(u8),
+        "` exceeds `MAX_DISCRIMINATOR_SPACE` and cannot be safely used for zero-copy layouts.")
+    );
+};
 impl ::core::convert::From<MyDiscriminator> for u8 {
     #[inline]
     fn from(enum_value: MyDiscriminator) -> Self {

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__event_basic.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__event_basic.snap
@@ -47,6 +47,18 @@ const __TRANSFEREVENT_ALIGNMENT_ASSERTIONS__: () = {
         "amount", "` with type `", stringify!(PodU64),
         "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
     );
+    ::core::assert!(
+        ::core::mem::align_of:: < TransferEvent > () == 1,
+        concat!("The alignment of struct `", stringify!(TransferEvent),
+        "` should be one so it can be used for zero-copy Pod casts.")
+    );
+    ::core::assert!(
+        ::core::mem::size_of:: < TransferEvent > () == (0usize + ::core::mem::size_of:: <
+        [u8; EventDisc::BYTES] > () + ::core::mem::size_of:: < [u8; 32] > () +
+        ::core::mem::size_of:: < [u8; 32] > () + ::core::mem::size_of:: < PodU64 > ()),
+        concat!("`", stringify!(TransferEvent),
+        "` layout is padded. `#[pina]` discriminator-first POD layouts must be tightly packed.")
+    );
 };
 impl TransferEvent {
     pub fn to_bytes(&self) -> &[u8] {

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__event_minimal.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__event_minimal.snap
@@ -27,6 +27,16 @@ const __EMPTYEVENT_ALIGNMENT_ASSERTIONS__: () = {
         stringify!([u8; EventDisc::BYTES]),
         "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
     );
+    ::core::assert!(
+        ::core::mem::align_of:: < EmptyEvent > () == 1,
+        concat!("The alignment of struct `", stringify!(EmptyEvent),
+        "` should be one so it can be used for zero-copy Pod casts.")
+    );
+    ::core::assert!(
+        ::core::mem::size_of:: < EmptyEvent > () == (0usize + ::core::mem::size_of:: <
+        [u8; EventDisc::BYTES] > ()), concat!("`", stringify!(EmptyEvent),
+        "` layout is padded. `#[pina]` discriminator-first POD layouts must be tightly packed.")
+    );
 };
 impl EmptyEvent {
     pub fn to_bytes(&self) -> &[u8] {

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__event_with_existing_derive.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__event_with_existing_derive.snap
@@ -39,6 +39,17 @@ const __AUDITEVENT_ALIGNMENT_ASSERTIONS__: () = {
         "timestamp", "` with type `", stringify!(PodU64),
         "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
     );
+    ::core::assert!(
+        ::core::mem::align_of:: < AuditEvent > () == 1,
+        concat!("The alignment of struct `", stringify!(AuditEvent),
+        "` should be one so it can be used for zero-copy Pod casts.")
+    );
+    ::core::assert!(
+        ::core::mem::size_of:: < AuditEvent > () == (0usize + ::core::mem::size_of:: <
+        [u8; EvtDisc::BYTES] > () + ::core::mem::size_of:: < u8 > () +
+        ::core::mem::size_of:: < PodU64 > ()), concat!("`", stringify!(AuditEvent),
+        "` layout is padded. `#[pina]` discriminator-first POD layouts must be tightly packed.")
+    );
 };
 impl AuditEvent {
     pub fn to_bytes(&self) -> &[u8] {

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__event_with_variant.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__event_with_variant.snap
@@ -35,6 +35,17 @@ const __INITIALIZEEVENT_ALIGNMENT_ASSERTIONS__: () = {
         "choice", "` with type `", stringify!(u8),
         "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
     );
+    ::core::assert!(
+        ::core::mem::align_of:: < InitializeEvent > () == 1,
+        concat!("The alignment of struct `", stringify!(InitializeEvent),
+        "` should be one so it can be used for zero-copy Pod casts.")
+    );
+    ::core::assert!(
+        ::core::mem::size_of:: < InitializeEvent > () == (0usize + ::core::mem::size_of::
+        < [u8; EventKind::BYTES] > () + ::core::mem::size_of:: < u8 > ()), concat!("`",
+        stringify!(InitializeEvent),
+        "` layout is padded. `#[pina]` discriminator-first POD layouts must be tightly packed.")
+    );
 };
 impl InitializeEvent {
     pub fn to_bytes(&self) -> &[u8] {

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__instruction_many_fields.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__instruction_many_fields.snap
@@ -53,6 +53,18 @@ const __FLIPBIT_ALIGNMENT_ASSERTIONS__: () = {
         "value", "` with type `", stringify!(u8),
         "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
     );
+    ::core::assert!(
+        ::core::mem::align_of:: < FlipBit > () == 1, concat!("The alignment of struct `",
+        stringify!(FlipBit),
+        "` should be one so it can be used for zero-copy Pod casts.")
+    );
+    ::core::assert!(
+        ::core::mem::size_of:: < FlipBit > () == (0usize + ::core::mem::size_of:: < [u8;
+        MyInstruction::BYTES] > () + ::core::mem::size_of:: < u8 > () +
+        ::core::mem::size_of:: < u8 > () + ::core::mem::size_of:: < u8 > () +
+        ::core::mem::size_of:: < u8 > ()), concat!("`", stringify!(FlipBit),
+        "` layout is padded. `#[pina]` discriminator-first POD layouts must be tightly packed.")
+    );
 };
 impl FlipBit {
     pub fn to_bytes(&self) -> &[u8] {

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__instruction_minimal.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__instruction_minimal.snap
@@ -27,6 +27,16 @@ const __INITIALIZE_ALIGNMENT_ASSERTIONS__: () = {
         stringify!([u8; MyInstruction::BYTES]),
         "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
     );
+    ::core::assert!(
+        ::core::mem::align_of:: < Initialize > () == 1,
+        concat!("The alignment of struct `", stringify!(Initialize),
+        "` should be one so it can be used for zero-copy Pod casts.")
+    );
+    ::core::assert!(
+        ::core::mem::size_of:: < Initialize > () == (0usize + ::core::mem::size_of:: <
+        [u8; MyInstruction::BYTES] > ()), concat!("`", stringify!(Initialize),
+        "` layout is padded. `#[pina]` discriminator-first POD layouts must be tightly packed.")
+    );
 };
 impl Initialize {
     pub fn to_bytes(&self) -> &[u8] {

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__instruction_with_array_and_pod.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__instruction_with_array_and_pod.snap
@@ -53,6 +53,19 @@ const __COMPLEXINSTRUCTION_ALIGNMENT_ASSERTIONS__: () = {
         "flags", "` with type `", stringify!([u8; 4]),
         "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
     );
+    ::core::assert!(
+        ::core::mem::align_of:: < ComplexInstruction > () == 1,
+        concat!("The alignment of struct `", stringify!(ComplexInstruction),
+        "` should be one so it can be used for zero-copy Pod casts.")
+    );
+    ::core::assert!(
+        ::core::mem::size_of:: < ComplexInstruction > () == (0usize +
+        ::core::mem::size_of:: < [u8; MyInstruction::BYTES] > () + ::core::mem::size_of::
+        < [u8; 32] > () + ::core::mem::size_of:: < PodU64 > () + ::core::mem::size_of:: <
+        u8 > () + ::core::mem::size_of:: < [u8; 4] > ()), concat!("`",
+        stringify!(ComplexInstruction),
+        "` layout is padded. `#[pina]` discriminator-first POD layouts must be tightly packed.")
+    );
 };
 impl ComplexInstruction {
     pub fn to_bytes(&self) -> &[u8] {

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__instruction_with_custom_variant.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__instruction_with_custom_variant.snap
@@ -39,6 +39,17 @@ const __TRANSFERDATA_ALIGNMENT_ASSERTIONS__: () = {
         "destination", "` with type `", stringify!([u8; 32]),
         "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
     );
+    ::core::assert!(
+        ::core::mem::align_of:: < TransferData > () == 1,
+        concat!("The alignment of struct `", stringify!(TransferData),
+        "` should be one so it can be used for zero-copy Pod casts.")
+    );
+    ::core::assert!(
+        ::core::mem::size_of:: < TransferData > () == (0usize + ::core::mem::size_of:: <
+        [u8; OpCode::BYTES] > () + ::core::mem::size_of:: < PodU64 > () +
+        ::core::mem::size_of:: < [u8; 32] > ()), concat!("`", stringify!(TransferData),
+        "` layout is padded. `#[pina]` discriminator-first POD layouts must be tightly packed.")
+    );
 };
 impl TransferData {
     pub fn to_bytes(&self) -> &[u8] {

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__instruction_with_existing_derive.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__instruction_with_existing_derive.snap
@@ -33,6 +33,17 @@ const __TRANSFER_ALIGNMENT_ASSERTIONS__: () = {
         "amount", "` with type `", stringify!(PodU64),
         "` should be one. Consider using one of the exported `Pod*` types from the `pina` crate.")
     );
+    ::core::assert!(
+        ::core::mem::align_of:: < Transfer > () == 1,
+        concat!("The alignment of struct `", stringify!(Transfer),
+        "` should be one so it can be used for zero-copy Pod casts.")
+    );
+    ::core::assert!(
+        ::core::mem::size_of:: < Transfer > () == (0usize + ::core::mem::size_of:: < [u8;
+        InstrDisc::BYTES] > () + ::core::mem::size_of:: < PodU64 > ()), concat!("`",
+        stringify!(Transfer),
+        "` layout is padded. `#[pina]` discriminator-first POD layouts must be tightly packed.")
+    );
 };
 impl Transfer {
     pub fn to_bytes(&self) -> &[u8] {

--- a/docs/src/core-concepts.md
+++ b/docs/src/core-concepts.md
@@ -35,13 +35,13 @@ The enum primitive width controls both on-chain layout and migration surface.
 
 ## Discriminator and payload versioning
 
-| Change | Compatibility impact |
-| --- | --- |
-| Add a new enum variant | Usually backward-compatible if old clients ignore unknown variants |
-| Change an existing variant value | **Breaking** for every historical byte slice |
-| Reorder or remove struct fields | **Breaking** (offsets change) |
-| Append fields to a struct | Mostly non-breaking, but consumers must accept the larger size |
-| Switch primitive width (`u8` → `u16`, etc.) | **Breaking** for serialized payloads at that boundary |
+| Change                                      | Compatibility impact                                               |
+| ------------------------------------------- | ------------------------------------------------------------------ |
+| Add a new enum variant                      | Usually backward-compatible if old clients ignore unknown variants |
+| Change an existing variant value            | **Breaking** for every historical byte slice                       |
+| Reorder or remove struct fields             | **Breaking** (offsets change)                                      |
+| Append fields to a struct                   | Mostly non-breaking, but consumers must accept the larger size     |
+| Switch primitive width (`u8` → `u16`, etc.) | **Breaking** for serialized payloads at that boundary              |
 
 For on-chain accounts, treat layout as part of protocol ABI:
 
@@ -63,22 +63,22 @@ For instruction payloads:
 
 The discriminator strategy determines byte layout, parser guarantees, and cross-protocol compatibility.
 
-| Goal | Recommended layout |
-| --- | --- |
-| Keep layout **minimal and zero-copy** while staying explicit | **Current Pina model**: discriminator bytes are the first field inside `#[account]`, `#[instruction]`, and `#[event]` structs. |
+| Goal                                                                                 | Recommended layout                                                                                                                     |
+| ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Keep layout **minimal and zero-copy** while staying explicit                         | **Current Pina model**: discriminator bytes are the first field inside `#[account]`, `#[instruction]`, and `#[event]` structs.         |
 | Preserve compatibility with existing Anchor-account payloads (SHA-256 hash prefixes) | **Legacy adapter model**: custom raw wrapper types parse/write the existing 8-byte external prefix before converting to typed structs. |
-| Minimize account size growth when you have many types | **Use `u8`** (default) discriminator width. |
-| You need more than 256 route variants | **Use `u16` / `u32` / `u64`** by setting `#[discriminator(primitive = ...)]`. |
-| Avoid schema migrations across existing serialized data | Keep existing field order and discriminator values; only append fields. |
+| Minimize account size growth when you have many types                                | **Use `u8`** (default) discriminator width.                                                                                            |
+| You need more than 256 route variants                                                | **Use `u16` / `u32` / `u64`** by setting `#[discriminator(primitive = ...)]`.                                                          |
+| Avoid schema migrations across existing serialized data                              | Keep existing field order and discriminator values; only append fields.                                                                |
 
 ### Raw discriminator width by use-case
 
-| Width | Max variants | Storage cost (bytes) | Recommended when |
-| --- | --- | --- | --- |
-| `u8` | 256 | 1 | Most programs and instructions |
-| `u16` | 65,536 | 2 | Medium-large routing tables and explicit version partitioning |
-| `u32` | 4,294,967,296 | 4 | Very large enums, rarely needed |
-| `u64` | 18,446,744,073,709,551,616 | 8 | Legacy interoperability shims or reserved growth |
+| Width | Max variants               | Storage cost (bytes) | Recommended when                                              |
+| ----- | -------------------------- | -------------------- | ------------------------------------------------------------- |
+| `u8`  | 256                        | 1                    | Most programs and instructions                                |
+| `u16` | 65,536                     | 2                    | Medium-large routing tables and explicit version partitioning |
+| `u32` | 4,294,967,296              | 4                    | Very large enums, rarely needed                               |
+| `u64` | 18,446,744,073,709,551,616 | 8                    | Legacy interoperability shims or reserved growth              |
 
 - Discriminator width only affects the first field bytes.
 - Widths above 8 are rejected at macro expansion time.

--- a/docs/src/core-concepts.md
+++ b/docs/src/core-concepts.md
@@ -1,8 +1,90 @@
 # Core Concepts
 
-## Discriminators
+## Discriminator layout (raw bytes)
 
-Pina uses discriminator enums as first-field tags for instruction/account/event types. This gives stable type identification at runtime and enables explicit parsing/dispatch.
+Pina stores discriminator bytes directly in the struct itself as the first field of every `#[account]`, `#[instruction]`, and `#[event]` type. This is a **discriminator-first** layout, not an external header.
+
+At runtime this means the parser does a fixed-byte read + `size_of::<T>()` validation, then a zero-copy cast.
+
+```text
+offset | size | meaning
+------ | ---- | -------
+0      | N    | discriminator (N = BYTES of enum primitive: 1/2/4/8)
+N      | ...  | payload fields
+```
+
+This contract is what enables:
+
+- deterministic `size_of::<T>()` checks,
+- zero-copy validation with `as_account()` / `try_from_bytes()`,
+- alignment-safe offsets for fixed-size Pod fields.
+
+### Why this is safer than implicit external headers
+
+External fixed-size headers require manual casting logic in each parse path and make compiler-assist checks harder. With auto-injected first-field discriminators, the compiler can guarantee the exact struct layout and validate it in type-checked assertions.
+
+## Discriminator width and compatibility
+
+The enum primitive width controls both on-chain layout and migration surface.
+
+- Width is set on the discriminator enum using `#[discriminator(primitive = u8)]` (default `u8`).
+- Allowed widths are `u8`, `u16`, `u32`, and `u64`.
+- The maximum practical width is capped at 8 bytes for zero-copy safety.
+
+<!-- {=pinaDiscriminatorVersionCompatibility} -->
+
+## Discriminator and payload versioning
+
+| Change | Compatibility impact |
+| --- | --- |
+| Add a new enum variant | Usually backward-compatible if old clients ignore unknown variants |
+| Change an existing variant value | **Breaking** for every historical byte slice |
+| Reorder or remove struct fields | **Breaking** (offsets change) |
+| Append fields to a struct | Mostly non-breaking, but consumers must accept the larger size |
+| Switch primitive width (`u8` → `u16`, etc.) | **Breaking** for serialized payloads at that boundary |
+
+For on-chain accounts, treat layout as part of protocol ABI:
+
+- Keep field order stable.
+- Introduce optional `version` fields at the tail for in-place migration strategies.
+- Never change existing discriminator values in place.
+- When incompatible layout changes are required, perform explicit migration with a new account version and an operator upgrade flow.
+
+For instruction payloads:
+
+- Prefer additive migration: add a new variant and keep legacy handlers for a release cycle.
+- Reject stale payload shapes with explicit errors rather than silently reinterpreting bytes.
+
+<!-- {/pinaDiscriminatorVersionCompatibility} -->
+
+<!-- {=pinaDiscriminatorLayoutDecisionMatrix} -->
+
+## Discriminator layout decision matrix
+
+The discriminator strategy determines byte layout, parser guarantees, and cross-protocol compatibility.
+
+| Goal | Recommended layout |
+| --- | --- |
+| Keep layout **minimal and zero-copy** while staying explicit | **Current Pina model**: discriminator bytes are the first field inside `#[account]`, `#[instruction]`, and `#[event]` structs. |
+| Preserve compatibility with existing Anchor-account payloads (SHA-256 hash prefixes) | **Legacy adapter model**: custom raw wrapper types parse/write the existing 8-byte external prefix before converting to typed structs. |
+| Minimize account size growth when you have many types | **Use `u8`** (default) discriminator width. |
+| You need more than 256 route variants | **Use `u16` / `u32` / `u64`** by setting `#[discriminator(primitive = ...)]`. |
+| Avoid schema migrations across existing serialized data | Keep existing field order and discriminator values; only append fields. |
+
+### Raw discriminator width by use-case
+
+| Width | Max variants | Storage cost (bytes) | Recommended when |
+| --- | --- | --- | --- |
+| `u8` | 256 | 1 | Most programs and instructions |
+| `u16` | 65,536 | 2 | Medium-large routing tables and explicit version partitioning |
+| `u32` | 4,294,967,296 | 4 | Very large enums, rarely needed |
+| `u64` | 18,446,744,073,709,551,616 | 8 | Legacy interoperability shims or reserved growth |
+
+- Discriminator width only affects the first field bytes.
+- Widths above 8 are rejected at macro expansion time.
+- Wider discriminators improve variant space, but increase CPI payload and account rent by the exact number of bytes.
+
+<!-- {/pinaDiscriminatorLayoutDecisionMatrix} -->
 
 ## Zero-copy account models
 

--- a/docs/src/security-model.md
+++ b/docs/src/security-model.md
@@ -9,6 +9,41 @@ Pina's safety posture is built around explicit validation and predictable state 
 - PDA correctness: seed and bump checks must gate PDA-bound operations.
 - Value correctness: arithmetic and balance mutations must be checked.
 
+## Version-safe binary layout and compatibility
+
+The discriminator-first model makes byte layout part of protocol compatibility. Treat every `#[account]` struct as ABI:
+
+- Do not reorder fields.
+- Do not change existing discriminator values.
+- Do not alter field types in-place without migration.
+- If a struct grows, treat it as a new versioned shape and migrate state explicitly.
+
+<!-- {=pinaDiscriminatorVersionCompatibility} -->
+
+## Discriminator and payload versioning
+
+| Change | Compatibility impact |
+| --- | --- |
+| Add a new enum variant | Usually backward-compatible if old clients ignore unknown variants |
+| Change an existing variant value | **Breaking** for every historical byte slice |
+| Reorder or remove struct fields | **Breaking** (offsets change) |
+| Append fields to a struct | Mostly non-breaking, but consumers must accept the larger size |
+| Switch primitive width (`u8` → `u16`, etc.) | **Breaking** for serialized payloads at that boundary |
+
+For on-chain accounts, treat layout as part of protocol ABI:
+
+- Keep field order stable.
+- Introduce optional `version` fields at the tail for in-place migration strategies.
+- Never change existing discriminator values in place.
+- When incompatible layout changes are required, perform explicit migration with a new account version and an operator upgrade flow.
+
+For instruction payloads:
+
+- Prefer additive migration: add a new variant and keep legacy handlers for a release cycle.
+- Reject stale payload shapes with explicit errors rather than silently reinterpreting bytes.
+
+<!-- {/pinaDiscriminatorVersionCompatibility} -->
+
 ## High-priority guardrails
 
 - Prefer checked arithmetic (`checked_add`, `checked_sub`) for all user-facing or balance-affecting values.

--- a/docs/src/security-model.md
+++ b/docs/src/security-model.md
@@ -22,13 +22,13 @@ The discriminator-first model makes byte layout part of protocol compatibility. 
 
 ## Discriminator and payload versioning
 
-| Change | Compatibility impact |
-| --- | --- |
-| Add a new enum variant | Usually backward-compatible if old clients ignore unknown variants |
-| Change an existing variant value | **Breaking** for every historical byte slice |
-| Reorder or remove struct fields | **Breaking** (offsets change) |
-| Append fields to a struct | Mostly non-breaking, but consumers must accept the larger size |
-| Switch primitive width (`u8` → `u16`, etc.) | **Breaking** for serialized payloads at that boundary |
+| Change                                      | Compatibility impact                                               |
+| ------------------------------------------- | ------------------------------------------------------------------ |
+| Add a new enum variant                      | Usually backward-compatible if old clients ignore unknown variants |
+| Change an existing variant value            | **Breaking** for every historical byte slice                       |
+| Reorder or remove struct fields             | **Breaking** (offsets change)                                      |
+| Append fields to a struct                   | Mostly non-breaking, but consumers must accept the larger size     |
+| Switch primitive width (`u8` → `u16`, etc.) | **Breaking** for serialized payloads at that boundary              |
 
 For on-chain accounts, treat layout as part of protocol ABI:
 

--- a/docs/src/tutorials/migrating-from-anchor.md
+++ b/docs/src/tutorials/migrating-from-anchor.md
@@ -206,6 +206,101 @@ Benefits of explicit discriminators:
 - Single byte by default (configurable to u16/u32/u64), saving space.
 - No hidden behavior -- you control the exact values.
 
+## Migration from fixed 8-byte prefixes (Anchor-compatible data)
+
+If you are coming from Anchor/Borsh with implicit 8-byte discriminators, there are two practical migration paths:
+
+### 1) Keep old on-chain layouts and add compatibility readers
+
+Use a lightweight adapter struct for legacy decoding, then convert into a pinned Pina struct in memory. This is useful when you cannot migrate all existing accounts immediately.
+
+```rust
+#[repr(C)]
+pub struct LegacyAccountV0 {
+	discriminator: [u8; 8],
+	owner: [u8; 32],
+	value: PodU64,
+}
+
+#[discriminator]
+pub enum MyAccountType {
+	MyAccountV0 = 0,
+	MyAccount = 1,
+}
+
+impl LegacyAccountV0 {
+	pub fn into_live(self) -> Result<MyAccount, ProgramError> {
+		if self.discriminator != LEGACY_ACCOUNT_DISCRIMINATOR {
+			return Err(ProgramError::InvalidAccountData);
+		}
+		Ok(MyAccount {
+			discriminator: [MyAccountType::MyAccount as u8],
+			owner: self.owner,
+			value: self.value,
+		})
+	}
+}
+```
+
+### 2) Migrate state in place (recommended for production)
+
+For long-lived accounts, add a migration instruction that rewrites every stored account from the legacy header to the new first-field discriminator layout. This gives you one canonical on-chain schema thereafter.
+
+<!-- {=pinaDiscriminatorLayoutDecisionMatrix} -->
+
+## Discriminator layout decision matrix
+
+The discriminator strategy determines byte layout, parser guarantees, and cross-protocol compatibility.
+
+| Goal | Recommended layout |
+| --- | --- |
+| Keep layout **minimal and zero-copy** while staying explicit | **Current Pina model**: discriminator bytes are the first field inside `#[account]`, `#[instruction]`, and `#[event]` structs. |
+| Preserve compatibility with existing Anchor-account payloads (SHA-256 hash prefixes) | **Legacy adapter model**: custom raw wrapper types parse/write the existing 8-byte external prefix before converting to typed structs. |
+| Minimize account size growth when you have many types | **Use `u8`** (default) discriminator width. |
+| You need more than 256 route variants | **Use `u16` / `u32` / `u64`** by setting `#[discriminator(primitive = ...)]`. |
+| Avoid schema migrations across existing serialized data | Keep existing field order and discriminator values; only append fields. |
+
+### Raw discriminator width by use-case
+
+| Width | Max variants | Storage cost (bytes) | Recommended when |
+| --- | --- | --- | --- |
+| `u8` | 256 | 1 | Most programs and instructions |
+| `u16` | 65,536 | 2 | Medium-large routing tables and explicit version partitioning |
+| `u32` | 4,294,967,296 | 4 | Very large enums, rarely needed |
+| `u64` | 18,446,744,073,709,551,616 | 8 | Legacy interoperability shims or reserved growth |
+
+- Discriminator width only affects the first field bytes.
+- Widths above 8 are rejected at macro expansion time.
+- Wider discriminators improve variant space, but increase CPI payload and account rent by the exact number of bytes.
+
+<!-- {/pinaDiscriminatorLayoutDecisionMatrix} -->
+
+<!-- {=pinaDiscriminatorVersionCompatibility} -->
+
+## Discriminator and payload versioning
+
+| Change | Compatibility impact |
+| --- | --- |
+| Add a new enum variant | Usually backward-compatible if old clients ignore unknown variants |
+| Change an existing variant value | **Breaking** for every historical byte slice |
+| Reorder or remove struct fields | **Breaking** (offsets change) |
+| Append fields to a struct | Mostly non-breaking, but consumers must accept the larger size |
+| Switch primitive width (`u8` → `u16`, etc.) | **Breaking** for serialized payloads at that boundary |
+
+For on-chain accounts, treat layout as part of protocol ABI:
+
+- Keep field order stable.
+- Introduce optional `version` fields at the tail for in-place migration strategies.
+- Never change existing discriminator values in place.
+- When incompatible layout changes are required, perform explicit migration with a new account version and an operator upgrade flow.
+
+For instruction payloads:
+
+- Prefer additive migration: add a new variant and keep legacy handlers for a release cycle.
+- Reject stale payload shapes with explicit errors rather than silently reinterpreting bytes.
+
+<!-- {/pinaDiscriminatorVersionCompatibility} -->
+
 ## Errors
 
 <br>

--- a/docs/src/tutorials/migrating-from-anchor.md
+++ b/docs/src/tutorials/migrating-from-anchor.md
@@ -252,22 +252,22 @@ For long-lived accounts, add a migration instruction that rewrites every stored 
 
 The discriminator strategy determines byte layout, parser guarantees, and cross-protocol compatibility.
 
-| Goal | Recommended layout |
-| --- | --- |
-| Keep layout **minimal and zero-copy** while staying explicit | **Current Pina model**: discriminator bytes are the first field inside `#[account]`, `#[instruction]`, and `#[event]` structs. |
+| Goal                                                                                 | Recommended layout                                                                                                                     |
+| ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Keep layout **minimal and zero-copy** while staying explicit                         | **Current Pina model**: discriminator bytes are the first field inside `#[account]`, `#[instruction]`, and `#[event]` structs.         |
 | Preserve compatibility with existing Anchor-account payloads (SHA-256 hash prefixes) | **Legacy adapter model**: custom raw wrapper types parse/write the existing 8-byte external prefix before converting to typed structs. |
-| Minimize account size growth when you have many types | **Use `u8`** (default) discriminator width. |
-| You need more than 256 route variants | **Use `u16` / `u32` / `u64`** by setting `#[discriminator(primitive = ...)]`. |
-| Avoid schema migrations across existing serialized data | Keep existing field order and discriminator values; only append fields. |
+| Minimize account size growth when you have many types                                | **Use `u8`** (default) discriminator width.                                                                                            |
+| You need more than 256 route variants                                                | **Use `u16` / `u32` / `u64`** by setting `#[discriminator(primitive = ...)]`.                                                          |
+| Avoid schema migrations across existing serialized data                              | Keep existing field order and discriminator values; only append fields.                                                                |
 
 ### Raw discriminator width by use-case
 
-| Width | Max variants | Storage cost (bytes) | Recommended when |
-| --- | --- | --- | --- |
-| `u8` | 256 | 1 | Most programs and instructions |
-| `u16` | 65,536 | 2 | Medium-large routing tables and explicit version partitioning |
-| `u32` | 4,294,967,296 | 4 | Very large enums, rarely needed |
-| `u64` | 18,446,744,073,709,551,616 | 8 | Legacy interoperability shims or reserved growth |
+| Width | Max variants               | Storage cost (bytes) | Recommended when                                              |
+| ----- | -------------------------- | -------------------- | ------------------------------------------------------------- |
+| `u8`  | 256                        | 1                    | Most programs and instructions                                |
+| `u16` | 65,536                     | 2                    | Medium-large routing tables and explicit version partitioning |
+| `u32` | 4,294,967,296              | 4                    | Very large enums, rarely needed                               |
+| `u64` | 18,446,744,073,709,551,616 | 8                    | Legacy interoperability shims or reserved growth              |
 
 - Discriminator width only affects the first field bytes.
 - Widths above 8 are rejected at macro expansion time.
@@ -279,13 +279,13 @@ The discriminator strategy determines byte layout, parser guarantees, and cross-
 
 ## Discriminator and payload versioning
 
-| Change | Compatibility impact |
-| --- | --- |
-| Add a new enum variant | Usually backward-compatible if old clients ignore unknown variants |
-| Change an existing variant value | **Breaking** for every historical byte slice |
-| Reorder or remove struct fields | **Breaking** (offsets change) |
-| Append fields to a struct | Mostly non-breaking, but consumers must accept the larger size |
-| Switch primitive width (`u8` → `u16`, etc.) | **Breaking** for serialized payloads at that boundary |
+| Change                                      | Compatibility impact                                               |
+| ------------------------------------------- | ------------------------------------------------------------------ |
+| Add a new enum variant                      | Usually backward-compatible if old clients ignore unknown variants |
+| Change an existing variant value            | **Breaking** for every historical byte slice                       |
+| Reorder or remove struct fields             | **Breaking** (offsets change)                                      |
+| Append fields to a struct                   | Mostly non-breaking, but consumers must accept the larger size     |
+| Switch primitive width (`u8` → `u16`, etc.) | **Breaking** for serialized payloads at that boundary              |
 
 For on-chain accounts, treat layout as part of protocol ABI:
 

--- a/readme.md
+++ b/readme.md
@@ -258,6 +258,65 @@ pub enum MyAccount {
 }
 ```
 
+### Discriminator layout guidance
+
+Pina supports the same discriminator-first layout in both account and instruction types. For migration planning and width tradeoffs, use this matrix:
+
+<!-- {=pinaDiscriminatorLayoutDecisionMatrix} -->
+
+## Discriminator layout decision matrix
+
+The discriminator strategy determines byte layout, parser guarantees, and cross-protocol compatibility.
+
+| Goal | Recommended layout |
+| --- | --- |
+| Keep layout **minimal and zero-copy** while staying explicit | **Current Pina model**: discriminator bytes are the first field inside `#[account]`, `#[instruction]`, and `#[event]` structs. |
+| Preserve compatibility with existing Anchor-account payloads (SHA-256 hash prefixes) | **Legacy adapter model**: custom raw wrapper types parse/write the existing 8-byte external prefix before converting to typed structs. |
+| Minimize account size growth when you have many types | **Use `u8`** (default) discriminator width. |
+| You need more than 256 route variants | **Use `u16` / `u32` / `u64`** by setting `#[discriminator(primitive = ...)]`. |
+| Avoid schema migrations across existing serialized data | Keep existing field order and discriminator values; only append fields. |
+
+### Raw discriminator width by use-case
+
+| Width | Max variants | Storage cost (bytes) | Recommended when |
+| --- | --- | --- | --- |
+| `u8` | 256 | 1 | Most programs and instructions |
+| `u16` | 65,536 | 2 | Medium-large routing tables and explicit version partitioning |
+| `u32` | 4,294,967,296 | 4 | Very large enums, rarely needed |
+| `u64` | 18,446,744,073,709,551,616 | 8 | Legacy interoperability shims or reserved growth |
+
+- Discriminator width only affects the first field bytes.
+- Widths above 8 are rejected at macro expansion time.
+- Wider discriminators improve variant space, but increase CPI payload and account rent by the exact number of bytes.
+
+<!-- {/pinaDiscriminatorLayoutDecisionMatrix} -->
+
+<!-- {=pinaDiscriminatorVersionCompatibility} -->
+
+## Discriminator and payload versioning
+
+| Change | Compatibility impact |
+| --- | --- |
+| Add a new enum variant | Usually backward-compatible if old clients ignore unknown variants |
+| Change an existing variant value | **Breaking** for every historical byte slice |
+| Reorder or remove struct fields | **Breaking** (offsets change) |
+| Append fields to a struct | Mostly non-breaking, but consumers must accept the larger size |
+| Switch primitive width (`u8` → `u16`, etc.) | **Breaking** for serialized payloads at that boundary |
+
+For on-chain accounts, treat layout as part of protocol ABI:
+
+- Keep field order stable.
+- Introduce optional `version` fields at the tail for in-place migration strategies.
+- Never change existing discriminator values in place.
+- When incompatible layout changes are required, perform explicit migration with a new account version and an operator upgrade flow.
+
+For instruction payloads:
+
+- Prefer additive migration: add a new variant and keep legacy handlers for a release cycle.
+- Reject stale payload shapes with explicit errors rather than silently reinterpreting bytes.
+
+<!-- {/pinaDiscriminatorVersionCompatibility} -->
+
 The `#[discriminator]` macro generates:
 
 - `Pod` / `Zeroable` derives for the enum

--- a/readme.md
+++ b/readme.md
@@ -268,22 +268,22 @@ Pina supports the same discriminator-first layout in both account and instructio
 
 The discriminator strategy determines byte layout, parser guarantees, and cross-protocol compatibility.
 
-| Goal | Recommended layout |
-| --- | --- |
-| Keep layout **minimal and zero-copy** while staying explicit | **Current Pina model**: discriminator bytes are the first field inside `#[account]`, `#[instruction]`, and `#[event]` structs. |
+| Goal                                                                                 | Recommended layout                                                                                                                     |
+| ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Keep layout **minimal and zero-copy** while staying explicit                         | **Current Pina model**: discriminator bytes are the first field inside `#[account]`, `#[instruction]`, and `#[event]` structs.         |
 | Preserve compatibility with existing Anchor-account payloads (SHA-256 hash prefixes) | **Legacy adapter model**: custom raw wrapper types parse/write the existing 8-byte external prefix before converting to typed structs. |
-| Minimize account size growth when you have many types | **Use `u8`** (default) discriminator width. |
-| You need more than 256 route variants | **Use `u16` / `u32` / `u64`** by setting `#[discriminator(primitive = ...)]`. |
-| Avoid schema migrations across existing serialized data | Keep existing field order and discriminator values; only append fields. |
+| Minimize account size growth when you have many types                                | **Use `u8`** (default) discriminator width.                                                                                            |
+| You need more than 256 route variants                                                | **Use `u16` / `u32` / `u64`** by setting `#[discriminator(primitive = ...)]`.                                                          |
+| Avoid schema migrations across existing serialized data                              | Keep existing field order and discriminator values; only append fields.                                                                |
 
 ### Raw discriminator width by use-case
 
-| Width | Max variants | Storage cost (bytes) | Recommended when |
-| --- | --- | --- | --- |
-| `u8` | 256 | 1 | Most programs and instructions |
-| `u16` | 65,536 | 2 | Medium-large routing tables and explicit version partitioning |
-| `u32` | 4,294,967,296 | 4 | Very large enums, rarely needed |
-| `u64` | 18,446,744,073,709,551,616 | 8 | Legacy interoperability shims or reserved growth |
+| Width | Max variants               | Storage cost (bytes) | Recommended when                                              |
+| ----- | -------------------------- | -------------------- | ------------------------------------------------------------- |
+| `u8`  | 256                        | 1                    | Most programs and instructions                                |
+| `u16` | 65,536                     | 2                    | Medium-large routing tables and explicit version partitioning |
+| `u32` | 4,294,967,296              | 4                    | Very large enums, rarely needed                               |
+| `u64` | 18,446,744,073,709,551,616 | 8                    | Legacy interoperability shims or reserved growth              |
 
 - Discriminator width only affects the first field bytes.
 - Widths above 8 are rejected at macro expansion time.
@@ -295,13 +295,13 @@ The discriminator strategy determines byte layout, parser guarantees, and cross-
 
 ## Discriminator and payload versioning
 
-| Change | Compatibility impact |
-| --- | --- |
-| Add a new enum variant | Usually backward-compatible if old clients ignore unknown variants |
-| Change an existing variant value | **Breaking** for every historical byte slice |
-| Reorder or remove struct fields | **Breaking** (offsets change) |
-| Append fields to a struct | Mostly non-breaking, but consumers must accept the larger size |
-| Switch primitive width (`u8` → `u16`, etc.) | **Breaking** for serialized payloads at that boundary |
+| Change                                      | Compatibility impact                                               |
+| ------------------------------------------- | ------------------------------------------------------------------ |
+| Add a new enum variant                      | Usually backward-compatible if old clients ignore unknown variants |
+| Change an existing variant value            | **Breaking** for every historical byte slice                       |
+| Reorder or remove struct fields             | **Breaking** (offsets change)                                      |
+| Append fields to a struct                   | Mostly non-breaking, but consumers must accept the larger size     |
+| Switch primitive width (`u8` → `u16`, etc.) | **Breaking** for serialized payloads at that boundary              |
 
 For on-chain accounts, treat layout as part of protocol ABI:
 

--- a/template.t.md
+++ b/template.t.md
@@ -359,3 +359,58 @@ pub struct MyState {
 ```
 
 <!-- {/pinaIdlCanonicalExamples} -->
+
+<!-- {@pinaDiscriminatorLayoutDecisionMatrix} -->
+
+## Discriminator layout decision matrix
+
+The discriminator strategy determines byte layout, parser guarantees, and cross-protocol compatibility.
+
+| Goal | Recommended layout |
+| --- | --- |
+| Keep layout **minimal and zero-copy** while staying explicit | **Current Pina model**: discriminator bytes are the first field inside `#[account]`, `#[instruction]`, and `#[event]` structs. |
+| Preserve compatibility with existing Anchor-account payloads (SHA-256 hash prefixes) | **Legacy adapter model**: custom raw wrapper types parse/write the existing 8-byte external prefix before converting to typed structs. |
+| Minimize account size growth when you have many types | **Use `u8`** (default) discriminator width. |
+| You need more than 256 route variants | **Use `u16` / `u32` / `u64`** by setting `#[discriminator(primitive = ...)]`. |
+| Avoid schema migrations across existing serialized data | Keep existing field order and discriminator values; only append fields. |
+
+### Raw discriminator width by use-case
+
+| Width | Max variants | Storage cost (bytes) | Recommended when |
+| --- | --- | --- | --- |
+| `u8` | 256 | 1 | Most programs and instructions |
+| `u16` | 65,536 | 2 | Medium-large routing tables and explicit version partitioning |
+| `u32` | 4,294,967,296 | 4 | Very large enums, rarely needed |
+| `u64` | 18,446,744,073,709,551,616 | 8 | Legacy interoperability shims or reserved growth |
+
+- Discriminator width only affects the first field bytes.
+- Widths above 8 are rejected at macro expansion time.
+- Wider discriminators improve variant space, but increase CPI payload and account rent by the exact number of bytes.
+
+<!-- {/pinaDiscriminatorLayoutDecisionMatrix} -->
+
+<!-- {@pinaDiscriminatorVersionCompatibility} -->
+
+## Discriminator and payload versioning
+
+| Change | Compatibility impact |
+| --- | --- |
+| Add a new enum variant | Usually backward-compatible if old clients ignore unknown variants |
+| Change an existing variant value | **Breaking** for every historical byte slice |
+| Reorder or remove struct fields | **Breaking** (offsets change) |
+| Append fields to a struct | Mostly non-breaking, but consumers must accept the larger size |
+| Switch primitive width (`u8` → `u16`, etc.) | **Breaking** for serialized payloads at that boundary |
+
+For on-chain accounts, treat layout as part of protocol ABI:
+
+- Keep field order stable.
+- Introduce optional `version` fields at the tail for in-place migration strategies.
+- Never change existing discriminator values in place.
+- When incompatible layout changes are required, perform explicit migration with a new account version and an operator upgrade flow.
+
+For instruction payloads:
+
+- Prefer additive migration: add a new variant and keep legacy handlers for a release cycle.
+- Reject stale payload shapes with explicit errors rather than silently reinterpreting bytes.
+
+<!-- {/pinaDiscriminatorVersionCompatibility} -->

--- a/template.t.md
+++ b/template.t.md
@@ -366,22 +366,22 @@ pub struct MyState {
 
 The discriminator strategy determines byte layout, parser guarantees, and cross-protocol compatibility.
 
-| Goal | Recommended layout |
-| --- | --- |
-| Keep layout **minimal and zero-copy** while staying explicit | **Current Pina model**: discriminator bytes are the first field inside `#[account]`, `#[instruction]`, and `#[event]` structs. |
+| Goal                                                                                 | Recommended layout                                                                                                                     |
+| ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Keep layout **minimal and zero-copy** while staying explicit                         | **Current Pina model**: discriminator bytes are the first field inside `#[account]`, `#[instruction]`, and `#[event]` structs.         |
 | Preserve compatibility with existing Anchor-account payloads (SHA-256 hash prefixes) | **Legacy adapter model**: custom raw wrapper types parse/write the existing 8-byte external prefix before converting to typed structs. |
-| Minimize account size growth when you have many types | **Use `u8`** (default) discriminator width. |
-| You need more than 256 route variants | **Use `u16` / `u32` / `u64`** by setting `#[discriminator(primitive = ...)]`. |
-| Avoid schema migrations across existing serialized data | Keep existing field order and discriminator values; only append fields. |
+| Minimize account size growth when you have many types                                | **Use `u8`** (default) discriminator width.                                                                                            |
+| You need more than 256 route variants                                                | **Use `u16` / `u32` / `u64`** by setting `#[discriminator(primitive = ...)]`.                                                          |
+| Avoid schema migrations across existing serialized data                              | Keep existing field order and discriminator values; only append fields.                                                                |
 
 ### Raw discriminator width by use-case
 
-| Width | Max variants | Storage cost (bytes) | Recommended when |
-| --- | --- | --- | --- |
-| `u8` | 256 | 1 | Most programs and instructions |
-| `u16` | 65,536 | 2 | Medium-large routing tables and explicit version partitioning |
-| `u32` | 4,294,967,296 | 4 | Very large enums, rarely needed |
-| `u64` | 18,446,744,073,709,551,616 | 8 | Legacy interoperability shims or reserved growth |
+| Width | Max variants               | Storage cost (bytes) | Recommended when                                              |
+| ----- | -------------------------- | -------------------- | ------------------------------------------------------------- |
+| `u8`  | 256                        | 1                    | Most programs and instructions                                |
+| `u16` | 65,536                     | 2                    | Medium-large routing tables and explicit version partitioning |
+| `u32` | 4,294,967,296              | 4                    | Very large enums, rarely needed                               |
+| `u64` | 18,446,744,073,709,551,616 | 8                    | Legacy interoperability shims or reserved growth              |
 
 - Discriminator width only affects the first field bytes.
 - Widths above 8 are rejected at macro expansion time.
@@ -393,13 +393,13 @@ The discriminator strategy determines byte layout, parser guarantees, and cross-
 
 ## Discriminator and payload versioning
 
-| Change | Compatibility impact |
-| --- | --- |
-| Add a new enum variant | Usually backward-compatible if old clients ignore unknown variants |
-| Change an existing variant value | **Breaking** for every historical byte slice |
-| Reorder or remove struct fields | **Breaking** (offsets change) |
-| Append fields to a struct | Mostly non-breaking, but consumers must accept the larger size |
-| Switch primitive width (`u8` → `u16`, etc.) | **Breaking** for serialized payloads at that boundary |
+| Change                                      | Compatibility impact                                               |
+| ------------------------------------------- | ------------------------------------------------------------------ |
+| Add a new enum variant                      | Usually backward-compatible if old clients ignore unknown variants |
+| Change an existing variant value            | **Breaking** for every historical byte slice                       |
+| Reorder or remove struct fields             | **Breaking** (offsets change)                                      |
+| Append fields to a struct                   | Mostly non-breaking, but consumers must accept the larger size     |
+| Switch primitive width (`u8` → `u16`, etc.) | **Breaking** for serialized payloads at that boundary              |
 
 For on-chain accounts, treat layout as part of protocol ABI:
 


### PR DESCRIPTION
## Summary

- Add compile-time discriminator width guard in `#[discriminator]` expansion so primitive width must be <= `MAX_DISCRIMINATOR_SPACE` (8).
- Add compile-time layout checks in `#[account]`, `#[instruction]`, and `#[event]` expansions:
  - Per-field alignment assertions (`align_of::<T>() == 1`)
  - Struct alignment assertion (`align_of::<S>() == 1`)
  - Struct size assertion (`size_of::<S>() == sum(size_of::<field>())`) to catch implicit padding.
- Introduce reusable `mdt` documentation blocks for discriminator layout tradeoffs and version compatibility.
- Document discriminator raw layout + migration/versioning guidance in:
  - `docs/src/core-concepts.md`
  - `docs/src/security-model.md`
  - `docs/src/tutorials/migrating-from-anchor.md`
  - `readme.md`
- Update affected macro snapshot tests to reflect newly emitted assertion constants.

## Checks

- `cargo test -p pina_macros`
- `cargo test -p pina`
- `mdt update --path .`
- `mdt check --path .`
- `mdbook build docs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added compile-time discriminator size validation with clearer, discriminator-specific error messaging.
  * Added struct-level size and alignment compile-time assertions for account, instruction, and event types.

* **Documentation**
  * Introduced a discriminator-first binary layout with explicit byte-offset diagram.
  * Specified allowed discriminator widths (u8/u16/u32/u64) and macro-time rejection above 8 bytes.
  * Added versioning/compatibility guidance and an Anchor → Pina migration tutorial.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->