### PR TITLE
test: add quasar svm codama client coverage

### DIFF
--- a/codama/tests/quasar-svm/package.json
+++ b/codama/tests/quasar-svm/package.json
@@ -1,0 +1,18 @@
+{
+	"name": "pina-quasar-svm-e2e",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"test": "vitest run --pool threads",
+		"test:types": "tsc --noEmit -p tsconfig.json"
+	},
+	"devDependencies": {
+		"@blueshift-gg/quasar-svm": "^0.1.12",
+		"@solana/kit": "^6.5.0",
+		"@solana/program-client-core": "^6.5.0",
+		"@solana-program/token": "^0.13.0",
+		"@types/node": "^25.5.0",
+		"typescript": "^5.9.3",
+		"vitest": "^4.1.1"
+	}
+}

--- a/codama/tests/quasar-svm/src/clientSmoke.test.ts
+++ b/codama/tests/quasar-svm/src/clientSmoke.test.ts
@@ -1,0 +1,33 @@
+import { readdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { describe, expect, test } from "vitest";
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const CLIENTS_DIR = resolve(TEST_DIR, "../../../clients/js");
+
+async function importModule(path: string) {
+	return await import(/* @vite-ignore */ pathToFileURL(path).href);
+}
+
+describe("generated Codama JS clients smoke", () => {
+	const clients = readdirSync(CLIENTS_DIR, { withFileTypes: true })
+		.filter((entry) => entry.isDirectory())
+		.filter((entry) => entry.name !== "node_modules")
+		.map((entry) => entry.name)
+		.sort();
+
+	test.each(clients)(
+		"%s generated entrypoints import cleanly",
+		async (client) => {
+			const generatedDir = resolve(CLIENTS_DIR, client, "src/generated");
+			const indexModule = await importModule(resolve(generatedDir, "index.ts"));
+			const programsModule = await importModule(
+				resolve(generatedDir, "programs/index.ts"),
+			);
+
+			expect(Object.keys(indexModule).length).toBeGreaterThan(0);
+			expect(Object.keys(programsModule).length).toBeGreaterThan(0);
+		},
+	);
+});

--- a/codama/tests/quasar-svm/src/counter.test.ts
+++ b/codama/tests/quasar-svm/src/counter.test.ts
@@ -1,0 +1,79 @@
+import { QuasarSvm } from "@blueshift-gg/quasar-svm/kit";
+import {
+	type Address,
+	generateKeyPairSigner,
+	getAddressEncoder,
+	getProgramDerivedAddress,
+	getUtf8Encoder,
+} from "@solana/kit";
+import { describe, expect, test } from "vitest";
+import { decodeCounterState } from "../../../clients/js/counter_program/src/generated/accounts";
+import {
+	getIncrementInstruction,
+	getInitializeInstruction,
+} from "../../../clients/js/counter_program/src/generated/instructions";
+import { COUNTER_PROGRAM_PROGRAM_ADDRESS } from "../../../clients/js/counter_program/src/generated/programs";
+import { createFundedSignerAccount, expectSome, loadProgram } from "./helpers";
+
+const PROGRAM_NAME = "counter_program";
+
+async function deriveCounterPda(authority: Address) {
+	return await getProgramDerivedAddress({
+		programAddress: COUNTER_PROGRAM_PROGRAM_ADDRESS,
+		seeds: [
+			getUtf8Encoder().encode("counter"),
+			getAddressEncoder().encode(authority),
+		],
+	});
+}
+
+describe("counter_program quasar e2e", () => {
+	test("initialize and increment a counter", async () => {
+		using svm = new QuasarSvm();
+		if (!loadProgram(svm, COUNTER_PROGRAM_PROGRAM_ADDRESS, PROGRAM_NAME)) {
+			console.log(
+				`[SKIP] ${PROGRAM_NAME}.so not found. Build SBF binaries first.`,
+			);
+			return;
+		}
+
+		const authority = await generateKeyPairSigner();
+		const authorityAccount = createFundedSignerAccount(authority);
+		const [counterPda, bump] = await deriveCounterPda(authority.address);
+
+		const initializeResult = svm.processInstruction(
+			getInitializeInstruction({ authority, counter: counterPda, bump }),
+			[authorityAccount],
+		);
+		initializeResult.assertSuccess();
+
+		const initializedCounter = decodeCounterState(
+			expectSome(
+				initializeResult.account(counterPda),
+				"counter PDA should exist after initialize",
+			),
+		);
+		expect(initializedCounter.data.bump).toBe(bump);
+		expect(initializedCounter.data.count).toBe(0n);
+
+		const incrementResult = svm.processInstruction(
+			getIncrementInstruction({ authority, counter: counterPda }),
+			[
+				authorityAccount,
+				expectSome(
+					initializeResult.account(counterPda),
+					"counter PDA should exist before increment",
+				),
+			],
+		);
+		incrementResult.assertSuccess();
+
+		const incrementedCounter = decodeCounterState(
+			expectSome(
+				incrementResult.account(counterPda),
+				"counter PDA should exist after increment",
+			),
+		);
+		expect(incrementedCounter.data.count).toBe(1n);
+	});
+});

--- a/codama/tests/quasar-svm/src/escrow.test.ts
+++ b/codama/tests/quasar-svm/src/escrow.test.ts
@@ -1,0 +1,178 @@
+import {
+	createKeyedMintAccount,
+	QuasarSvm,
+	SPL_TOKEN_PROGRAM_ID,
+} from "@blueshift-gg/quasar-svm/kit";
+import { getTokenDecoder } from "@solana-program/token";
+import {
+	type Address,
+	generateKeyPairSigner,
+	getAddressEncoder,
+	getProgramDerivedAddress,
+	getUtf8Encoder,
+} from "@solana/kit";
+import { describe, expect, test } from "vitest";
+import { decodeEscrowState } from "../../../clients/js/escrow_program/src/generated/accounts";
+import {
+	getMakeInstruction,
+	getTakeInstruction,
+} from "../../../clients/js/escrow_program/src/generated/instructions";
+import { ESCROW_PROGRAM_PROGRAM_ADDRESS } from "../../../clients/js/escrow_program/src/generated/programs";
+import {
+	createAta,
+	createFundedSignerAccount,
+	deriveAtaAddress,
+	expectSome,
+	getU64LeBytes,
+	loadProgram,
+} from "./helpers";
+
+const PROGRAM_NAME = "escrow_program";
+
+async function deriveEscrowPda(maker: Address, seed: bigint) {
+	return await getProgramDerivedAddress({
+		programAddress: ESCROW_PROGRAM_PROGRAM_ADDRESS,
+		seeds: [
+			getUtf8Encoder().encode("escrow"),
+			getAddressEncoder().encode(maker),
+			getU64LeBytes(seed),
+		],
+	});
+}
+
+describe("escrow_program quasar e2e", () => {
+	test("make and take complete the escrow lifecycle", async () => {
+		using svm = new QuasarSvm();
+		if (!loadProgram(svm, ESCROW_PROGRAM_PROGRAM_ADDRESS, PROGRAM_NAME)) {
+			console.log(
+				`[SKIP] ${PROGRAM_NAME}.so not found. Build SBF binaries first.`,
+			);
+			return;
+		}
+
+		const maker = await generateKeyPairSigner();
+		const taker = await generateKeyPairSigner();
+		const mintA = createKeyedMintAccount(
+			(await generateKeyPairSigner()).address,
+			{
+				decimals: 6,
+				supply: 1_000n,
+			},
+		);
+		const mintB = createKeyedMintAccount(
+			(await generateKeyPairSigner()).address,
+			{
+				decimals: 6,
+				supply: 1_000n,
+			},
+		);
+		const makerAccount = createFundedSignerAccount(maker);
+		const takerAccount = createFundedSignerAccount(taker);
+		const makerAtaA = await createAta(maker.address, mintA.address, 500n);
+		const takerAtaA = await createAta(taker.address, mintA.address, 0n);
+		const takerAtaB = await createAta(taker.address, mintB.address, 250n);
+		const makerAtaB = await createAta(maker.address, mintB.address, 0n);
+
+		const seed = 7n;
+		const amountA = 120n;
+		const amountB = 90n;
+		const [escrowPda, bump] = await deriveEscrowPda(maker.address, seed);
+		const vaultAta = await deriveAtaAddress(
+			escrowPda as Address,
+			mintA.address,
+			SPL_TOKEN_PROGRAM_ID as Address,
+		);
+
+		const makeResult = svm.processInstruction(
+			getMakeInstruction({
+				maker,
+				mintA: mintA.address,
+				mintB: mintB.address,
+				makerAtaA: makerAtaA.address,
+				escrow: escrowPda,
+				vault: vaultAta,
+				tokenProgram: SPL_TOKEN_PROGRAM_ID as Address,
+				seed,
+				amountA,
+				amountB,
+				bump,
+			}),
+			[makerAccount, mintA, mintB, makerAtaA],
+		);
+		makeResult.assertSuccess();
+
+		const escrowState = decodeEscrowState(
+			expectSome(
+				makeResult.account(escrowPda),
+				"escrow PDA should exist after make",
+			),
+		);
+		expect(escrowState.data.maker).toBe(maker.address);
+		expect(escrowState.data.amountA).toBe(amountA);
+		expect(escrowState.data.amountB).toBe(amountB);
+		expect(escrowState.data.seed).toBe(seed);
+
+		const vaultAfterMake = expectSome(
+			makeResult.account(vaultAta, getTokenDecoder()),
+			"vault ATA should exist after make",
+		);
+		expect(vaultAfterMake.amount).toBe(amountA);
+
+		const makerAtaAAfterMake = expectSome(
+			makeResult.account(makerAtaA.address, getTokenDecoder()),
+			"maker ATA A should exist after make",
+		);
+		expect(makerAtaAAfterMake.amount).toBe(380n);
+
+		const takeResult = svm.processInstruction(
+			getTakeInstruction({
+				taker,
+				mintA: mintA.address,
+				mintB: mintB.address,
+				takerAtaA: takerAtaA.address,
+				takerAtaB: takerAtaB.address,
+				maker: maker.address,
+				makerAtaB: makerAtaB.address,
+				escrow: escrowPda,
+				vault: vaultAta,
+				tokenProgram: SPL_TOKEN_PROGRAM_ID as Address,
+			}),
+			[
+				takerAccount,
+				mintA,
+				mintB,
+				takerAtaA,
+				takerAtaB,
+				makerAtaB,
+				expectSome(
+					makeResult.account(escrowPda),
+					"escrow PDA should exist before take",
+				),
+				expectSome(
+					makeResult.account(vaultAta),
+					"vault ATA should exist before take",
+				),
+			],
+		);
+		takeResult.assertSuccess();
+
+		expect(takeResult.account(escrowPda)).toBeNull();
+		expect(takeResult.account(vaultAta)).toBeNull();
+
+		const takerAtaAAfterTake = expectSome(
+			takeResult.account(takerAtaA.address, getTokenDecoder()),
+			"taker ATA A should exist after take",
+		);
+		const takerAtaBAfterTake = expectSome(
+			takeResult.account(takerAtaB.address, getTokenDecoder()),
+			"taker ATA B should exist after take",
+		);
+		const makerAtaBAfterTake = expectSome(
+			takeResult.account(makerAtaB.address, getTokenDecoder()),
+			"maker ATA B should exist after take",
+		);
+		expect(takerAtaAAfterTake.amount).toBe(amountA);
+		expect(takerAtaBAfterTake.amount).toBe(160n);
+		expect(makerAtaBAfterTake.amount).toBe(amountB);
+	});
+});

--- a/codama/tests/quasar-svm/src/helpers.ts
+++ b/codama/tests/quasar-svm/src/helpers.ts
@@ -1,0 +1,70 @@
+import {
+	createKeyedAssociatedTokenAccount,
+	createKeyedSystemAccount,
+	QuasarSvm,
+	SPL_ASSOCIATED_TOKEN_PROGRAM_ID,
+	SPL_TOKEN_PROGRAM_ID,
+} from "@blueshift-gg/quasar-svm/kit";
+import type { Address, TransactionSigner } from "@solana/kit";
+import { getAddressEncoder, getProgramDerivedAddress } from "@solana/kit";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+export const LAMPORTS_PER_SOL = 1_000_000_000n;
+
+export function findProgramBinary(programName: string): string | null {
+	const deployDir = process.env.SBF_OUT_DIR ??
+		resolve(process.cwd(), "../../target/deploy");
+	const soPath = resolve(deployDir, `${programName}.so`);
+	return existsSync(soPath) ? soPath : null;
+}
+
+export function loadProgram(
+	svm: QuasarSvm,
+	programAddress: Address,
+	programName: string,
+): boolean {
+	const soPath = findProgramBinary(programName);
+	if (!soPath) return false;
+
+	svm.addProgram(programAddress, readFileSync(soPath));
+	return true;
+}
+
+export function createFundedSignerAccount(
+	signer: TransactionSigner,
+	sol: bigint = 10n * LAMPORTS_PER_SOL,
+) {
+	return createKeyedSystemAccount(signer.address, sol);
+}
+
+export function expectSome<T>(value: T | null, message: string): T {
+	if (value === null) throw new Error(message);
+	return value;
+}
+
+export function getU64LeBytes(value: bigint): Uint8Array {
+	const bytes = new Uint8Array(8);
+	new DataView(bytes.buffer).setBigUint64(0, value, true);
+	return bytes;
+}
+
+export async function deriveAtaAddress(
+	wallet: Address,
+	mint: Address,
+	tokenProgram: Address = SPL_TOKEN_PROGRAM_ID as Address,
+): Promise<Address> {
+	const [ata] = await getProgramDerivedAddress({
+		programAddress: SPL_ASSOCIATED_TOKEN_PROGRAM_ID as Address,
+		seeds: [
+			getAddressEncoder().encode(wallet),
+			getAddressEncoder().encode(tokenProgram),
+			getAddressEncoder().encode(mint),
+		],
+	});
+	return ata as Address;
+}
+
+export async function createAta(owner: Address, mint: Address, amount: bigint) {
+	return await createKeyedAssociatedTokenAccount(owner, mint, amount);
+}

--- a/codama/tests/quasar-svm/src/roleRegistry.test.ts
+++ b/codama/tests/quasar-svm/src/roleRegistry.test.ts
@@ -1,0 +1,240 @@
+import { QuasarSvm } from "@blueshift-gg/quasar-svm/kit";
+import {
+	type Address,
+	generateKeyPairSigner,
+	getAddressEncoder,
+	getProgramDerivedAddress,
+	getUtf8Encoder,
+} from "@solana/kit";
+import { describe, expect, test } from "vitest";
+import {
+	decodeRegistryConfig,
+	decodeRoleEntry,
+} from "../../../clients/js/role_registry_program/src/generated/accounts";
+import {
+	getAddRoleInstruction,
+	getDeactivateRoleInstruction,
+	getInitializeInstruction,
+	getRotateAdminInstruction,
+	getUpdateRoleInstruction,
+} from "../../../clients/js/role_registry_program/src/generated/instructions";
+import {
+	ROLE_REGISTRY_PROGRAM_PROGRAM_ADDRESS,
+} from "../../../clients/js/role_registry_program/src/generated/programs";
+import { createFundedSignerAccount, loadProgram } from "./helpers";
+
+const PROGRAM_NAME = "role_registry_program";
+
+function expectSome<T>(value: T | null, message: string): T {
+	if (value === null) {
+		throw new Error(message);
+	}
+	return value;
+}
+
+async function deriveRegistryPda(admin: Address) {
+	return await getProgramDerivedAddress({
+		programAddress: ROLE_REGISTRY_PROGRAM_PROGRAM_ADDRESS,
+		seeds: [
+			getUtf8Encoder().encode("registry"),
+			getAddressEncoder().encode(admin),
+		],
+	});
+}
+
+async function deriveRoleEntryPda(registry: Address, roleId: bigint) {
+	const roleIdBytes = new Uint8Array(8);
+	new DataView(roleIdBytes.buffer).setBigUint64(0, roleId, true);
+	return await getProgramDerivedAddress({
+		programAddress: ROLE_REGISTRY_PROGRAM_PROGRAM_ADDRESS,
+		seeds: [
+			getUtf8Encoder().encode("role-entry"),
+			getAddressEncoder().encode(registry),
+			roleIdBytes,
+		],
+	});
+}
+
+describe("role_registry_program quasar e2e", () => {
+	test("full lifecycle: initialize -> add role -> update -> deactivate -> rotate admin", async () => {
+		using svm = new QuasarSvm();
+		if (
+			!loadProgram(svm, ROLE_REGISTRY_PROGRAM_PROGRAM_ADDRESS, PROGRAM_NAME)
+		) {
+			console.log(
+				`[SKIP] ${PROGRAM_NAME}.so not found. Build SBF binaries first.`,
+			);
+			return;
+		}
+
+		const admin = await generateKeyPairSigner();
+		const grantee = await generateKeyPairSigner();
+		const newAdmin = await generateKeyPairSigner();
+		const adminAccount = createFundedSignerAccount(admin);
+
+		const [registryPda, registryBump] = await deriveRegistryPda(admin.address);
+		const initIx = getInitializeInstruction({
+			admin,
+			registryConfig: registryPda,
+			bump: registryBump,
+		});
+		const initResult = svm.processInstruction(initIx, [adminAccount]);
+		initResult.assertSuccess();
+
+		const registryAccount = expectSome(
+			initResult.account(registryPda),
+			"RegistryConfig account should exist after initialize",
+		);
+		const registry = decodeRegistryConfig(registryAccount);
+		expect(registry.data.admin).toBe(admin.address);
+		expect(registry.data.roleCount).toBe(0n);
+		expect(registry.data.bump).toBe(registryBump);
+
+		const roleId = 1n;
+		const permissions = 255n;
+		const [roleEntryPda, roleEntryBump] = await deriveRoleEntryPda(
+			registryPda,
+			roleId,
+		);
+		const addRoleIx = getAddRoleInstruction({
+			admin,
+			grantee: grantee.address,
+			registryConfig: registryPda,
+			roleEntry: roleEntryPda,
+			roleId,
+			permissions,
+			bump: roleEntryBump,
+		});
+		const addRoleResult = svm.processInstruction(addRoleIx, [
+			adminAccount,
+			registryAccount,
+		]);
+		addRoleResult.assertSuccess();
+
+		const roleEntryAccount = expectSome(
+			addRoleResult.account(roleEntryPda),
+			"RoleEntry account should exist after add role",
+		);
+		const roleEntry = decodeRoleEntry(roleEntryAccount);
+		expect(roleEntry.data.registry).toBe(registryPda);
+		expect(roleEntry.data.roleId).toBe(roleId);
+		expect(roleEntry.data.grantee).toBe(grantee.address);
+		expect(roleEntry.data.permissions).toBe(permissions);
+		expect(roleEntry.data.active).toBe(true);
+		expect(roleEntry.data.bump).toBe(roleEntryBump);
+
+		const registryAfterAdd = expectSome(
+			addRoleResult.account(registryPda),
+			"RegistryConfig should still exist after add role",
+		);
+		expect(decodeRegistryConfig(registryAfterAdd).data.roleCount).toBe(1n);
+
+		const newPermissions = 42n;
+		const updateIx = getUpdateRoleInstruction({
+			admin,
+			registryConfig: registryPda,
+			roleEntry: roleEntryPda,
+			permissions: newPermissions,
+		});
+		const updateResult = svm.processInstruction(updateIx, [
+			adminAccount,
+			registryAfterAdd,
+			roleEntryAccount,
+		]);
+		updateResult.assertSuccess();
+
+		const roleAfterUpdate = expectSome(
+			updateResult.account(roleEntryPda),
+			"RoleEntry should exist after update",
+		);
+		expect(decodeRoleEntry(roleAfterUpdate).data.permissions).toBe(
+			newPermissions,
+		);
+		expect(decodeRoleEntry(roleAfterUpdate).data.active).toBe(true);
+
+		const deactivateIx = getDeactivateRoleInstruction({
+			admin,
+			registryConfig: registryPda,
+			roleEntry: roleEntryPda,
+		});
+		const deactivateResult = svm.processInstruction(deactivateIx, [
+			adminAccount,
+			registryAfterAdd,
+			roleAfterUpdate,
+		]);
+		deactivateResult.assertSuccess();
+
+		const roleAfterDeactivate = expectSome(
+			deactivateResult.account(roleEntryPda),
+			"RoleEntry should exist after deactivate",
+		);
+		expect(decodeRoleEntry(roleAfterDeactivate).data.active).toBe(false);
+
+		const rotateIx = getRotateAdminInstruction({
+			admin,
+			newAdmin: newAdmin.address,
+			registryConfig: registryPda,
+		});
+		const rotateResult = svm.processInstruction(rotateIx, [
+			adminAccount,
+			registryAfterAdd,
+		]);
+		rotateResult.assertSuccess();
+
+		const registryAfterRotate = expectSome(
+			rotateResult.account(registryPda),
+			"RegistryConfig should exist after rotate admin",
+		);
+		expect(decodeRegistryConfig(registryAfterRotate).data.admin).toBe(
+			newAdmin.address,
+		);
+	});
+
+	test("wrong signer cannot add role", async () => {
+		using svm = new QuasarSvm();
+		if (
+			!loadProgram(svm, ROLE_REGISTRY_PROGRAM_PROGRAM_ADDRESS, PROGRAM_NAME)
+		) {
+			console.log(`[SKIP] ${PROGRAM_NAME}.so not found.`);
+			return;
+		}
+
+		const admin = await generateKeyPairSigner();
+		const wrongAdmin = await generateKeyPairSigner();
+		const grantee = await generateKeyPairSigner();
+		const adminAccount = createFundedSignerAccount(admin);
+		const wrongAdminAccount = createFundedSignerAccount(wrongAdmin);
+
+		const [registryPda, registryBump] = await deriveRegistryPda(admin.address);
+		const initIx = getInitializeInstruction({
+			admin,
+			registryConfig: registryPda,
+			bump: registryBump,
+		});
+		const initResult = svm.processInstruction(initIx, [adminAccount]);
+		initResult.assertSuccess();
+		const registryAccount = expectSome(
+			initResult.account(registryPda),
+			"RegistryConfig account should exist after initialize",
+		);
+
+		const [roleEntryPda, roleEntryBump] = await deriveRoleEntryPda(
+			registryPda,
+			1n,
+		);
+		const addRoleIx = getAddRoleInstruction({
+			admin: wrongAdmin,
+			grantee: grantee.address,
+			registryConfig: registryPda,
+			roleEntry: roleEntryPda,
+			roleId: 1n,
+			permissions: 7n,
+			bump: roleEntryBump,
+		});
+		const result = svm.processInstruction(addRoleIx, [
+			wrongAdminAccount,
+			registryAccount,
+		]);
+		expect(result.isError()).toBe(true);
+	});
+});

--- a/codama/tests/quasar-svm/src/stakingRewards.test.ts
+++ b/codama/tests/quasar-svm/src/stakingRewards.test.ts
@@ -1,0 +1,234 @@
+import {
+	createKeyedMintAccount,
+	QuasarSvm,
+	SPL_TOKEN_PROGRAM_ID,
+} from "@blueshift-gg/quasar-svm/kit";
+import {
+	type Address,
+	generateKeyPairSigner,
+	getAddressEncoder,
+	getProgramDerivedAddress,
+	getUtf8Encoder,
+} from "@solana/kit";
+import { describe, expect, test } from "vitest";
+import {
+	decodePoolState,
+	decodePositionState,
+} from "../../../clients/js/staking_rewards_program/src/generated/accounts";
+import {
+	getClaimInstruction,
+	getDepositInstruction,
+	getInitializePoolInstruction,
+	getOpenPositionInstruction,
+} from "../../../clients/js/staking_rewards_program/src/generated/instructions";
+import { STAKING_REWARDS_PROGRAM_PROGRAM_ADDRESS } from "../../../clients/js/staking_rewards_program/src/generated/programs";
+import {
+	createAta,
+	createFundedSignerAccount,
+	deriveAtaAddress,
+	expectSome,
+	loadProgram,
+} from "./helpers";
+
+const PROGRAM_NAME = "staking_rewards_program";
+
+async function derivePoolPda(stakeMint: Address, rewardMint: Address) {
+	return await getProgramDerivedAddress({
+		programAddress: STAKING_REWARDS_PROGRAM_PROGRAM_ADDRESS,
+		seeds: [
+			getUtf8Encoder().encode("pool"),
+			getAddressEncoder().encode(stakeMint),
+			getAddressEncoder().encode(rewardMint),
+		],
+	});
+}
+
+async function derivePositionPda(pool: Address, owner: Address) {
+	return await getProgramDerivedAddress({
+		programAddress: STAKING_REWARDS_PROGRAM_PROGRAM_ADDRESS,
+		seeds: [
+			getUtf8Encoder().encode("position"),
+			getAddressEncoder().encode(pool),
+			getAddressEncoder().encode(owner),
+		],
+	});
+}
+
+describe("staking_rewards_program quasar e2e", () => {
+	test("initialize pool, open position, deposit, and claim", async () => {
+		using svm = new QuasarSvm();
+		if (
+			!loadProgram(svm, STAKING_REWARDS_PROGRAM_PROGRAM_ADDRESS, PROGRAM_NAME)
+		) {
+			console.log(
+				`[SKIP] ${PROGRAM_NAME}.so not found. Build SBF binaries first.`,
+			);
+			return;
+		}
+
+		const admin = await generateKeyPairSigner();
+		const user = await generateKeyPairSigner();
+		const adminAccount = createFundedSignerAccount(admin);
+		const userAccount = createFundedSignerAccount(user);
+		const stakeMint = createKeyedMintAccount(
+			(await generateKeyPairSigner()).address,
+			{
+				decimals: 6,
+				supply: 10_000n,
+			},
+		);
+		const rewardMint = createKeyedMintAccount(
+			(await generateKeyPairSigner()).address,
+			{
+				decimals: 6,
+				supply: 10_000n,
+			},
+		);
+		const userStakeAta = await createAta(user.address, stakeMint.address, 500n);
+		const userRewardAta = await createAta(user.address, rewardMint.address, 0n);
+
+		const [poolPda, poolBump] = await derivePoolPda(
+			stakeMint.address,
+			rewardMint.address,
+		);
+		const stakeVault = await deriveAtaAddress(
+			poolPda as Address,
+			stakeMint.address,
+			SPL_TOKEN_PROGRAM_ID as Address,
+		);
+		const rewardVault = await deriveAtaAddress(
+			poolPda as Address,
+			rewardMint.address,
+			SPL_TOKEN_PROGRAM_ID as Address,
+		);
+
+		const initializePoolResult = svm.processInstruction(
+			getInitializePoolInstruction({
+				admin,
+				stakeMint: stakeMint.address,
+				rewardMint: rewardMint.address,
+				poolState: poolPda,
+				stakeVault,
+				rewardVault,
+				tokenProgram: SPL_TOKEN_PROGRAM_ID as Address,
+				bump: poolBump,
+			}),
+			[adminAccount, stakeMint, rewardMint],
+		);
+		initializePoolResult.assertSuccess();
+
+		const poolState = decodePoolState(
+			expectSome(
+				initializePoolResult.account(poolPda),
+				"pool state should exist after initializePool",
+			),
+		);
+		expect(poolState.data.admin).toBe(admin.address);
+		expect(poolState.data.totalStaked).toBe(0n);
+		expect(poolState.data.bump).toBe(poolBump);
+
+		const [positionPda, positionBump] = await derivePositionPda(
+			poolPda,
+			user.address,
+		);
+		const openPositionResult = svm.processInstruction(
+			getOpenPositionInstruction({
+				user,
+				poolState: poolPda,
+				positionState: positionPda,
+				bump: positionBump,
+			}),
+			[
+				userAccount,
+				expectSome(
+					initializePoolResult.account(poolPda),
+					"pool state should exist before openPosition",
+				),
+			],
+		);
+		openPositionResult.assertSuccess();
+
+		const openPositionState = decodePositionState(
+			expectSome(
+				openPositionResult.account(positionPda),
+				"position state should exist after openPosition",
+			),
+		);
+		expect(openPositionState.data.owner).toBe(user.address);
+		expect(openPositionState.data.stakedAmount).toBe(0n);
+
+		const depositResult = svm.processInstruction(
+			getDepositInstruction({
+				user,
+				stakeMint: stakeMint.address,
+				poolState: poolPda,
+				positionState: positionPda,
+				userStakeAta: userStakeAta.address,
+				tokenProgram: SPL_TOKEN_PROGRAM_ID as Address,
+				amount: 200n,
+			}),
+			[
+				userAccount,
+				stakeMint,
+				expectSome(
+					openPositionResult.account(poolPda),
+					"pool state should exist before deposit",
+				),
+				expectSome(
+					openPositionResult.account(positionPda),
+					"position state should exist before deposit",
+				),
+				userStakeAta,
+			],
+		);
+		depositResult.assertSuccess();
+
+		const poolAfterDeposit = decodePoolState(
+			expectSome(
+				depositResult.account(poolPda),
+				"pool state should exist after deposit",
+			),
+		);
+		const positionAfterDeposit = decodePositionState(
+			expectSome(
+				depositResult.account(positionPda),
+				"position state should exist after deposit",
+			),
+		);
+		expect(poolAfterDeposit.data.totalStaked).toBe(200n);
+		expect(positionAfterDeposit.data.stakedAmount).toBe(200n);
+
+		const claimResult = svm.processInstruction(
+			getClaimInstruction({
+				user,
+				rewardMint: rewardMint.address,
+				poolState: poolPda,
+				positionState: positionPda,
+				userRewardAta: userRewardAta.address,
+				tokenProgram: SPL_TOKEN_PROGRAM_ID as Address,
+			}),
+			[
+				userAccount,
+				rewardMint,
+				expectSome(
+					depositResult.account(poolPda),
+					"pool state should exist before claim",
+				),
+				expectSome(
+					depositResult.account(positionPda),
+					"position state should exist before claim",
+				),
+				userRewardAta,
+			],
+		);
+		claimResult.assertSuccess();
+
+		const positionAfterClaim = decodePositionState(
+			expectSome(
+				claimResult.account(positionPda),
+				"position state should exist after claim",
+			),
+		);
+		expect(positionAfterClaim.data.pendingRewards).toBeGreaterThanOrEqual(0n);
+	});
+});

--- a/codama/tests/quasar-svm/src/vesting.test.ts
+++ b/codama/tests/quasar-svm/src/vesting.test.ts
@@ -1,0 +1,185 @@
+import {
+	createKeyedMintAccount,
+	QuasarSvm,
+	SPL_TOKEN_PROGRAM_ID,
+} from "@blueshift-gg/quasar-svm/kit";
+import { getTokenDecoder } from "@solana-program/token";
+import {
+	type Address,
+	generateKeyPairSigner,
+	getAddressEncoder,
+	getProgramDerivedAddress,
+	getUtf8Encoder,
+} from "@solana/kit";
+import { describe, expect, test } from "vitest";
+import { decodeVestingState } from "../../../clients/js/vesting_program/src/generated/accounts";
+import {
+	getCancelInstruction,
+	getClaimInstruction,
+	getInitializeInstruction,
+} from "../../../clients/js/vesting_program/src/generated/instructions";
+import { VESTING_PROGRAM_PROGRAM_ADDRESS } from "../../../clients/js/vesting_program/src/generated/programs";
+import {
+	createAta,
+	createFundedSignerAccount,
+	deriveAtaAddress,
+	expectSome,
+	loadProgram,
+} from "./helpers";
+
+const PROGRAM_NAME = "vesting_program";
+
+async function deriveVestingPda(
+	admin: Address,
+	beneficiary: Address,
+	mint: Address,
+) {
+	return await getProgramDerivedAddress({
+		programAddress: VESTING_PROGRAM_PROGRAM_ADDRESS,
+		seeds: [
+			getUtf8Encoder().encode("vesting"),
+			getAddressEncoder().encode(admin),
+			getAddressEncoder().encode(beneficiary),
+			getAddressEncoder().encode(mint),
+		],
+	});
+}
+
+describe("vesting_program quasar e2e", () => {
+	test("initialize, claim, and cancel a vesting schedule", async () => {
+		using svm = new QuasarSvm();
+		if (!loadProgram(svm, VESTING_PROGRAM_PROGRAM_ADDRESS, PROGRAM_NAME)) {
+			console.log(
+				`[SKIP] ${PROGRAM_NAME}.so not found. Build SBF binaries first.`,
+			);
+			return;
+		}
+
+		const admin = await generateKeyPairSigner();
+		const beneficiary = await generateKeyPairSigner();
+		const adminAccount = createFundedSignerAccount(admin);
+		const beneficiaryAccount = createFundedSignerAccount(beneficiary);
+		const mint = createKeyedMintAccount(
+			(await generateKeyPairSigner()).address,
+			{
+				decimals: 6,
+				supply: 10_000n,
+			},
+		);
+		const beneficiaryAta = await createAta(
+			beneficiary.address,
+			mint.address,
+			0n,
+		);
+		const [vestingPda, bump] = await deriveVestingPda(
+			admin.address,
+			beneficiary.address,
+			mint.address,
+		);
+		const vaultAta = await deriveAtaAddress(
+			vestingPda as Address,
+			mint.address,
+			SPL_TOKEN_PROGRAM_ID as Address,
+		);
+
+		const initializeResult = svm.processInstruction(
+			getInitializeInstruction({
+				admin,
+				beneficiary: beneficiary.address,
+				mint: mint.address,
+				vestingState: vestingPda,
+				vault: vaultAta,
+				tokenProgram: SPL_TOKEN_PROGRAM_ID as Address,
+				totalAmount: 1_000n,
+				startTs: 0n,
+				cliffTs: 0n,
+				endTs: 100n,
+				bump,
+			}),
+			[adminAccount, mint],
+		);
+		initializeResult.assertSuccess();
+
+		const initializedState = decodeVestingState(
+			expectSome(
+				initializeResult.account(vestingPda),
+				"vesting state should exist after initialize",
+			),
+		);
+		expect(initializedState.data.admin).toBe(admin.address);
+		expect(initializedState.data.beneficiary).toBe(beneficiary.address);
+		expect(initializedState.data.claimedAmount).toBe(0n);
+		expect(initializedState.data.cancelled).toBe(false);
+
+		const claimResult = svm.processInstruction(
+			getClaimInstruction({
+				beneficiary,
+				mint: mint.address,
+				vestingState: vestingPda,
+				beneficiaryAta: beneficiaryAta.address,
+				vault: vaultAta,
+				tokenProgram: SPL_TOKEN_PROGRAM_ID as Address,
+				amount: 250n,
+			}),
+			[
+				beneficiaryAccount,
+				mint,
+				expectSome(
+					initializeResult.account(vestingPda),
+					"vesting state should exist before claim",
+				),
+				expectSome(
+					initializeResult.account(vaultAta),
+					"vault ATA should exist before claim",
+				),
+				beneficiaryAta,
+			],
+		);
+		claimResult.assertSuccess();
+
+		const claimedState = decodeVestingState(
+			expectSome(
+				claimResult.account(vestingPda),
+				"vesting state should exist after claim",
+			),
+		);
+		expect(claimedState.data.claimedAmount).toBe(250n);
+
+		const beneficiaryAtaAfterClaim = expectSome(
+			claimResult.account(beneficiaryAta.address, getTokenDecoder()),
+			"beneficiary ATA should exist after claim",
+		);
+		expect(beneficiaryAtaAfterClaim.amount).toBe(250n);
+
+		const cancelResult = svm.processInstruction(
+			getCancelInstruction({
+				admin,
+				mint: mint.address,
+				vestingState: vestingPda,
+				vault: vaultAta,
+				tokenProgram: SPL_TOKEN_PROGRAM_ID as Address,
+			}),
+			[
+				adminAccount,
+				mint,
+				expectSome(
+					claimResult.account(vestingPda),
+					"vesting state should exist before cancel",
+				),
+				expectSome(
+					claimResult.account(vaultAta),
+					"vault ATA should exist before cancel",
+				),
+			],
+		);
+		cancelResult.assertSuccess();
+
+		const cancelledState = decodeVestingState(
+			expectSome(
+				cancelResult.account(vestingPda),
+				"vesting state should exist after cancel",
+			),
+		);
+		expect(cancelledState.data.cancelled).toBe(true);
+	});
+});

--- a/codama/tests/quasar-svm/tsconfig.json
+++ b/codama/tests/quasar-svm/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ES2022",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"noEmit": true,
+		"skipLibCheck": true,
+		"types": ["node"]
+	},
+	"include": [
+		"src/**/*.ts",
+		"../../clients/js/solana-kit-compat.d.ts"
+	]
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -488,6 +488,14 @@ in
         pnpm --dir "$DEVENV_ROOT/codama/tests/litesvm" install --frozen-lockfile
         SBF_OUT_DIR="$DEVENV_ROOT/target/deploy" \
           pnpm --dir "$DEVENV_ROOT/codama/tests/litesvm" test
+
+        # Run Quasar SVM tests alongside LiteSVM. These execute generated
+        # instructions directly against the compiled program ELF in-process,
+        # which is useful for fast instruction/account-cycle validation
+        # without a validator.
+        pnpm --dir "$DEVENV_ROOT/codama/tests/quasar-svm" install --frozen-lockfile
+        SBF_OUT_DIR="$DEVENV_ROOT/target/deploy" \
+          pnpm --dir "$DEVENV_ROOT/codama/tests/quasar-svm" test
       '';
       description = "Build SBF binaries and run end-to-end program tests including mollusk-svm integration.";
       binary = "bash";

--- a/docs/src/codama-workflow.md
+++ b/docs/src/codama-workflow.md
@@ -29,6 +29,9 @@ codama:test
 
 # Run IDL fixture drift + validation checks used by CI.
 test:idl
+
+# Run Quasar SVM generated-client e2e checks alongside LiteSVM.
+pnpm run test:quasar-svm
 ```
 
 <!-- {/codamaWorkflowCommands} -->

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 		"check:js": "tsc --noEmit -p codama/tsconfig.json",
 		"test:nodes-from-pina": "pnpm --filter codama-nodes-from-pina test",
 		"test:idls": "pnpm --filter pina-codama-idl-tests test",
+		"test:quasar-svm": "pnpm --filter pina-quasar-svm-e2e test",
 		"test": "pnpm run generate && pnpm run check:js"
 	},
 	"dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,30 @@ importers:
         specifier: ^4.1.1
         version: 4.1.1(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0))
 
+  codama/tests/quasar-svm:
+    devDependencies:
+      '@blueshift-gg/quasar-svm':
+        specifier: ^0.1.12
+        version: 0.1.12(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana-program/token':
+        specifier: ^0.13.0
+        version: 0.13.0(@solana/kit@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
+      '@solana/kit':
+        specifier: ^6.5.0
+        version: 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/program-client-core':
+        specifier: ^6.5.0
+        version: 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@types/node':
+        specifier: ^25.5.0
+        version: 25.5.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.1
+        version: 4.1.1(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0))
+
   packages/nodes-from-pina:
     dependencies:
       codama:
@@ -78,6 +102,40 @@ importers:
         version: 4.1.1(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0))
 
 packages:
+
+  '@blueshift-gg/quasar-svm-darwin-arm64@0.1.5':
+    resolution: {integrity: sha512-ty7RUgWRf2ive7BQOydPEq5+119oVP16vK4ugsbEI21bDVp0avgikoNh6I+j7zx8jTPcv90vx/FCMS5Ld5tl9w==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@blueshift-gg/quasar-svm-darwin-x64@0.1.5':
+    resolution: {integrity: sha512-IipaN9A6X1MbKRr6mPs5cn9ImcODCNLPb8VCiQP4CXwv5n3YtZDftOGvT/sSpvzhSByGBuxmbdHO8slyVLCJxA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@blueshift-gg/quasar-svm-linux-arm64-gnu@0.1.5':
+    resolution: {integrity: sha512-+hKg595AKMSMBySplyczxeKQpM3UkdwvvULM7wE63/UB0Js6/UVi6mc0v59pcReErQGx46yXTNip7wthlXhrBg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@blueshift-gg/quasar-svm-linux-x64-gnu@0.1.5':
+    resolution: {integrity: sha512-b7LhZU4jIFNp3o49qLgVBUjntyFnewWE93l6+OJnEApUzQm+nCaIu5aRueG101Nn5Xomw23rVKduRskWrUgFCg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@blueshift-gg/quasar-svm-win32-x64-msvc@0.1.5':
+    resolution: {integrity: sha512-+T8giW1+1/u4Mv0EgIohkWA2t5g8py1ZTHZxIu5U4TWI3mU70DBHG2GkdhudSBOl/OhVErE13+WZfvwM3QL2ew==}
+    cpu: [x64]
+    os: [win32]
+
+  '@blueshift-gg/quasar-svm@0.1.12':
+    resolution: {integrity: sha512-1Rv8pmDbeslxsFLvoTg28VDmpds+oRjr1LtruTrtEjMk5iZJChBUXImeB58PThUKBhBEj7kWhKuv3PLu+CLHXw==}
+    engines: {node: '>=22.13.0'}
+    peerDependencies:
+      '@solana/web3.js': git:blueshift-gg/solana-web3.js#v2
+    peerDependenciesMeta:
+      '@solana/web3.js':
+        optional: true
 
   '@codama/cli@1.5.0':
     resolution: {integrity: sha512-+q62IvEA6o7ji/mcnGgAvyPWyiFx3cojVGrFNG8NSm0zFXrBk1lT3n/qg+2Ag8C8aHwno9boXgDTxV+P5VCDYw==}
@@ -720,6 +778,11 @@ packages:
     peerDependencies:
       '@solana/kit': ^6.1.0
 
+  '@solana-program/token@0.13.0':
+    resolution: {integrity: sha512-/Apjrd5lwOJGrPB0J5Rv7EBeclvyEBQPAGA85Scm7wBH+GpkbdLDM9uK3TNg8jjFKyWQYai/JtPHbrx7VgFLSg==}
+    peerDependencies:
+      '@solana/kit': ^6.5.0
+
   '@solana/accounts@6.5.0':
     resolution: {integrity: sha512-h3zQFjwZjmy+YxgTGOEna6g74Tsn4hTBaBCslwPT4QjqWhywe2JrM2Ab0ANfJcj7g/xrHF5QJ/FnUIcyUTeVfQ==}
     engines: {node: '>=20.18.0'}
@@ -1330,6 +1393,9 @@ packages:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
 
+  koffi@2.15.5:
+    resolution: {integrity: sha512-4/35/oOpnH9tzrpWAC3ObjAERBSe0Q0Dh2NP1eBBPRGpohEj4vFw2+7tej9W9MTExvk0vtF0PjMqIGG4rf6feQ==}
+
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
     engines: {node: '>=14'}
@@ -1704,6 +1770,44 @@ packages:
         optional: true
 
 snapshots:
+
+  '@blueshift-gg/quasar-svm-darwin-arm64@0.1.5':
+    optional: true
+
+  '@blueshift-gg/quasar-svm-darwin-x64@0.1.5':
+    optional: true
+
+  '@blueshift-gg/quasar-svm-linux-arm64-gnu@0.1.5':
+    optional: true
+
+  '@blueshift-gg/quasar-svm-linux-x64-gnu@0.1.5':
+    optional: true
+
+  '@blueshift-gg/quasar-svm-win32-x64-msvc@0.1.5':
+    optional: true
+
+  '@blueshift-gg/quasar-svm@0.1.12(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana-program/system': 0.12.0(@solana/kit@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
+      '@solana-program/token': 0.12.0(@solana/kit@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
+      '@solana/accounts': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/addresses': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 6.5.0(typescript@5.9.3)
+      '@solana/instructions': 6.5.0(typescript@5.9.3)
+      '@solana/kit': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-types': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      koffi: 2.15.5
+    optionalDependencies:
+      '@blueshift-gg/quasar-svm-darwin-arm64': 0.1.5
+      '@blueshift-gg/quasar-svm-darwin-x64': 0.1.5
+      '@blueshift-gg/quasar-svm-linux-arm64-gnu': 0.1.5
+      '@blueshift-gg/quasar-svm-linux-x64-gnu': 0.1.5
+      '@blueshift-gg/quasar-svm-win32-x64-msvc': 0.1.5
+    transitivePeerDependencies:
+      - bufferutil
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
 
   '@codama/cli@1.5.0':
     dependencies:
@@ -2089,6 +2193,11 @@ snapshots:
       '@solana/kit': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
 
   '@solana-program/token@0.12.0(@solana/kit@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))':
+    dependencies:
+      '@solana-program/system': 0.12.0(@solana/kit@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
+      '@solana/kit': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+
+  '@solana-program/token@0.13.0(@solana/kit@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))':
     dependencies:
       '@solana-program/system': 0.12.0(@solana/kit@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
       '@solana/kit': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -2829,6 +2938,8 @@ snapshots:
   jsonify@0.0.1: {}
 
   kleur@3.0.3: {}
+
+  koffi@2.15.5: {}
 
   lilconfig@3.1.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - packages/*
   - codama/tests/js
   - codama/tests/litesvm
+  - codama/tests/quasar-svm
 
 onlyBuiltDependencies:
   - esbuild

--- a/template.t.md
+++ b/template.t.md
@@ -65,6 +65,9 @@ codama:test
 
 # Run IDL fixture drift + validation checks used by CI.
 test:idl
+
+# Run Quasar SVM generated-client e2e checks alongside LiteSVM.
+pnpm run test:quasar-svm
 ```
 
 <!-- {/codamaWorkflowCommands} -->


### PR DESCRIPTION
## Summary

- add a Quasar SVM workspace test package that runs alongside existing LiteSVM coverage
- add generated-client lifecycle tests for `counter_program`, `role_registry_program`, `escrow_program`, `staking_rewards_program`, and `vesting_program`
- add a generic smoke harness that imports every generated JS client entrypoint under `codama/clients/js`
- wire the new Quasar checks into the workspace scripts, `devenv`, and Codama workflow docs

## Testing

```bash
pnpm --filter pina-quasar-svm-e2e test:types
pnpm run test:quasar-svm
devenv shell -- verify:docs
```

## Notes

- Quasar lifecycle tests currently skip when the compiled `.so` artifacts are not present.
- The generated-client smoke tests run unconditionally and validate JS client importability across all generated clients.
