### PR TITLE
style: apply coding style guide across codebase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ Pina is a Rust workspace for building performant, `no_std` Solana programs on to
 ## Task-specific guidance
 
 - [Build and tooling](./docs/agents/build-and-tooling.md)
+- [Coding style guide](./docs/agents/coding-style.md) — visual organization, whitespace patterns, and code aesthetics
 - [Workspace architecture](./docs/agents/workspace-architecture.md)
 - [Testing and SBF builds](./docs/agents/testing-and-sbf.md)
 - [Release process and changesets](./docs/agents/release-and-changesets.md)

--- a/crates/pina/src/cpi.rs
+++ b/crates/pina/src/cpi.rs
@@ -282,6 +282,7 @@ pub fn allocate_account_with_bump<'a>(
 	let seeds_slice = &combined_seeds[..=seeds.len()];
 	let signer = Signer::from(seeds_slice);
 	let signers = &[signer];
+
 	// Allocate space for account
 	let rent = Rent::get()?;
 
@@ -296,36 +297,39 @@ pub fn allocate_account_with_bump<'a>(
 			owner,
 		}
 		.invoke_signed(signers)?;
-	} else {
-		// Otherwise, if balance is nonzero:
 
-		// 1) transfer sufficient lamports for rent exemption
-		let rent_exempt_balance = rent
-			.try_minimum_balance(space)?
-			.saturating_sub(target_account.lamports());
-		if rent_exempt_balance > 0 {
-			Transfer {
-				from: payer,
-				to: target_account,
-				lamports: rent_exempt_balance,
-			}
-			.invoke_signed(signers)?;
-		}
+		return Ok(());
+	}
 
-		// 2) allocate space for the account
-		Allocate {
-			account: target_account,
-			space: space as u64,
-		}
-		.invoke_signed(signers)?;
+	// Otherwise, if balance is nonzero:
 
-		// 3) assign our program as the owner
-		Assign {
-			account: target_account,
-			owner,
+	// 1) transfer sufficient lamports for rent exemption
+	let rent_exempt_balance = rent
+		.try_minimum_balance(space)?
+		.saturating_sub(target_account.lamports());
+
+	if rent_exempt_balance > 0 {
+		Transfer {
+			from: payer,
+			to: target_account,
+			lamports: rent_exempt_balance,
 		}
 		.invoke_signed(signers)?;
 	}
+
+	// 2) allocate space for the account
+	Allocate {
+		account: target_account,
+		space: space as u64,
+	}
+	.invoke_signed(signers)?;
+
+	// 3) assign our program as the owner
+	Assign {
+		account: target_account,
+		owner,
+	}
+	.invoke_signed(signers)?;
 
 	Ok(())
 }

--- a/crates/pina/src/impls.rs
+++ b/crates/pina/src/impls.rs
@@ -117,6 +117,7 @@ impl AccountInfoValidation for AccountView {
 		program_id: &Address,
 	) -> Result<&Self, ProgramError> {
 		self.assert_owner(program_id)?;
+
 		let data = self.try_borrow()?;
 
 		if !T::matches_discriminator(&data) {
@@ -172,6 +173,7 @@ impl AccountInfoValidation for AccountView {
 	fn assert_owners(&self, owners: &[Address]) -> Result<&Self, ProgramError> {
 		// SAFETY: see `assert_owner` above.
 		let account_owner = unsafe { self.owner() };
+
 		if owners.contains(account_owner) {
 			return Ok(self);
 		}
@@ -222,6 +224,7 @@ impl AccountInfoValidation for AccountView {
 				program_id.as_ref()
 			);
 			log_caller();
+
 			return Err(ProgramError::InvalidSeeds);
 		};
 
@@ -398,8 +401,10 @@ macro_rules! impl_account_validation {
 				if !condition(self) {
 					log!($label);
 					log_caller();
+
 					return Err(ProgramError::InvalidAccountData);
 				}
+
 				Ok(self)
 			}
 
@@ -408,10 +413,9 @@ macro_rules! impl_account_validation {
 			where
 				F: Fn(&Self) -> bool,
 			{
-				match crate::assert(condition(self), ProgramError::InvalidAccountData, log) {
-					Err(err) => Err(err),
-					Ok(()) => Ok(self),
-				}
+				crate::assert(condition(self), ProgramError::InvalidAccountData, log)?;
+
+				Ok(self)
 			}
 
 			#[track_caller]
@@ -422,8 +426,10 @@ macro_rules! impl_account_validation {
 				if !condition(self) {
 					log!($label);
 					log_caller();
+
 					return Err(ProgramError::InvalidAccountData);
 				}
+
 				Ok(self)
 			}
 
@@ -436,10 +442,9 @@ macro_rules! impl_account_validation {
 			where
 				F: Fn(&Self) -> bool,
 			{
-				match crate::assert(condition(self), ProgramError::InvalidAccountData, log) {
-					Err(err) => Err(err),
-					Ok(()) => Ok(self),
-				}
+				crate::assert(condition(self), ProgramError::InvalidAccountData, log)?;
+
+				Ok(self)
 			}
 		}
 	};
@@ -447,16 +452,19 @@ macro_rules! impl_account_validation {
 
 #[cfg(feature = "token")]
 impl_account_validation!(crate::token::state::Mint, "Mint account data is invalid");
+
 #[cfg(feature = "token")]
 impl_account_validation!(
 	crate::token_2022::state::Mint,
 	"Mint account data is invalid"
 );
+
 #[cfg(feature = "token")]
 impl_account_validation!(
 	crate::token::state::TokenAccount,
 	"Token account data is invalid"
 );
+
 #[cfg(feature = "token")]
 impl_account_validation!(
 	crate::token_2022::state::TokenAccount,
@@ -634,6 +642,7 @@ impl<'a> LamportTransfer<'a> for AccountView {
 		if self.address() == recipient.address() {
 			log!("Could not send lamports: sender and recipient must differ");
 			log_caller();
+
 			return Err(ProgramError::InvalidArgument);
 		}
 

--- a/crates/pina/src/introspection.rs
+++ b/crates/pina/src/introspection.rs
@@ -178,6 +178,7 @@ pub fn has_instruction_before(
 
 	for i in 0..current_index {
 		let ix = instructions.load_instruction_at(i)?;
+
 		if ix.get_program_id() == program_id {
 			return Ok(true);
 		}

--- a/crates/pina/tests/account_macro.rs
+++ b/crates/pina/tests/account_macro.rs
@@ -21,6 +21,7 @@ pub struct ConfigState {
 #[test]
 fn test_account_macro() {
 	let authority = address!("BHvLHF6mJpWxywWY5S2tsHdDtHirHyeRxoS6uF6T5FoY");
+
 	let config_state = ConfigState::builder()
 		.version(1)
 		.authority(authority)
@@ -40,6 +41,7 @@ fn test_account_macro() {
 #[test]
 fn test_account_assert_returns_ok_when_condition_true() {
 	let authority = address!("BHvLHF6mJpWxywWY5S2tsHdDtHirHyeRxoS6uF6T5FoY");
+
 	let config_state = ConfigState::builder()
 		.version(1)
 		.authority(authority)
@@ -47,12 +49,14 @@ fn test_account_assert_returns_ok_when_condition_true() {
 		.build();
 
 	let result = config_state.assert(|s| s.version == 1);
+
 	assert!(result.is_ok());
 }
 
 #[test]
 fn test_account_assert_returns_err_when_condition_false() {
 	let authority = address!("BHvLHF6mJpWxywWY5S2tsHdDtHirHyeRxoS6uF6T5FoY");
+
 	let config_state = ConfigState::builder()
 		.version(1)
 		.authority(authority)
@@ -60,6 +64,7 @@ fn test_account_assert_returns_err_when_condition_false() {
 		.build();
 
 	let result = config_state.assert(|s| s.version == 99);
+
 	assert!(result.is_err());
 	assert_eq!(result.unwrap_err(), ProgramError::InvalidAccountData);
 }
@@ -67,6 +72,7 @@ fn test_account_assert_returns_err_when_condition_false() {
 #[test]
 fn test_account_assert_mut_returns_ok_when_condition_true() {
 	let authority = address!("BHvLHF6mJpWxywWY5S2tsHdDtHirHyeRxoS6uF6T5FoY");
+
 	let mut config_state = ConfigState::builder()
 		.version(1)
 		.authority(authority)
@@ -74,12 +80,14 @@ fn test_account_assert_mut_returns_ok_when_condition_true() {
 		.build();
 
 	let result = config_state.assert_mut(|s| s.version == 1);
+
 	assert!(result.is_ok());
 }
 
 #[test]
 fn test_account_assert_mut_returns_err_when_condition_false() {
 	let authority = address!("BHvLHF6mJpWxywWY5S2tsHdDtHirHyeRxoS6uF6T5FoY");
+
 	let mut config_state = ConfigState::builder()
 		.version(1)
 		.authority(authority)
@@ -87,6 +95,7 @@ fn test_account_assert_mut_returns_err_when_condition_false() {
 		.build();
 
 	let result = config_state.assert_mut(|s| s.version == 99);
+
 	assert!(result.is_err());
 	assert_eq!(result.unwrap_err(), ProgramError::InvalidAccountData);
 }
@@ -94,6 +103,7 @@ fn test_account_assert_mut_returns_err_when_condition_false() {
 #[test]
 fn test_account_assert_msg_returns_ok_when_condition_true() {
 	let authority = address!("BHvLHF6mJpWxywWY5S2tsHdDtHirHyeRxoS6uF6T5FoY");
+
 	let config_state = ConfigState::builder()
 		.version(1)
 		.authority(authority)
@@ -101,12 +111,14 @@ fn test_account_assert_msg_returns_ok_when_condition_true() {
 		.build();
 
 	let result = config_state.assert_msg(|s| s.bump == 255, "bump must be 255");
+
 	assert!(result.is_ok());
 }
 
 #[test]
 fn test_account_assert_msg_returns_err_when_condition_false() {
 	let authority = address!("BHvLHF6mJpWxywWY5S2tsHdDtHirHyeRxoS6uF6T5FoY");
+
 	let config_state = ConfigState::builder()
 		.version(1)
 		.authority(authority)
@@ -114,6 +126,7 @@ fn test_account_assert_msg_returns_err_when_condition_false() {
 		.build();
 
 	let result = config_state.assert_msg(|s| s.bump == 0, "bump must be 0");
+
 	assert!(result.is_err());
 	assert_eq!(result.unwrap_err(), ProgramError::InvalidAccountData);
 }

--- a/crates/pina/tests/accounts_derive.rs
+++ b/crates/pina/tests/accounts_derive.rs
@@ -32,7 +32,6 @@ fn test_accounts_derive_exact() {
 	let ix_data = [3u8; 100];
 
 	// Input with 2 accounts.
-
 	let mut input = unsafe { create_input(2, &ix_data) };
 	let mut accounts = [UNINIT; 2];
 
@@ -50,7 +49,6 @@ fn test_accounts_derive_exact_not_enough() {
 	let ix_data = [3u8; 100];
 
 	// Input with 1 account
-
 	let mut input = unsafe { create_input(1, &ix_data) };
 	let mut accounts = [UNINIT; 1];
 
@@ -67,7 +65,6 @@ fn test_accounts_derive_exact_excess() {
 	let ix_data = [3u8; 100];
 
 	// Input with 4 accounts
-
 	let mut input = unsafe { create_input(4, &ix_data) };
 	let mut accounts = [UNINIT; 4];
 

--- a/crates/pina/tests/pda_functions.rs
+++ b/crates/pina/tests/pda_functions.rs
@@ -7,6 +7,7 @@ const SYSTEM_ID: pina::Address = pina::address!("1111111111111111111111111111111
 #[test]
 fn try_find_program_address_returns_some_for_valid_seeds() {
 	let result = try_find_program_address(&[b"test-seed"], &SYSTEM_ID);
+
 	assert!(result.is_some(), "expected to derive a PDA");
 }
 
@@ -74,11 +75,13 @@ fn create_program_address_wrong_bump_fails() {
 #[test]
 fn try_find_program_address_empty_seeds() {
 	let result = try_find_program_address(&[], &SYSTEM_ID);
+
 	assert!(result.is_some(), "empty seeds should still derive a PDA");
 }
 
 #[test]
 fn try_find_program_address_multiple_seeds() {
 	let result = try_find_program_address(&[b"prefix", b"middle", b"suffix"], &SYSTEM_ID);
+
 	assert!(result.is_some(), "multi-seed PDA should derive");
 }

--- a/crates/pina/tests/utils_functions.rs
+++ b/crates/pina/tests/utils_functions.rs
@@ -18,6 +18,7 @@ fn parse_instruction_valid_discriminator() {
 	let data = [0u8]; // Initialize = 0
 	let result: TestInstruction = parse_instruction(&PROGRAM_ID, &PROGRAM_ID, &data)
 		.unwrap_or_else(|e| panic!("expected valid parse: {e:?}"));
+
 	assert_eq!(result, TestInstruction::Initialize);
 }
 

--- a/crates/pina_cli/src/codama.rs
+++ b/crates/pina_cli/src/codama.rs
@@ -47,6 +47,7 @@ pub struct CodamaGenerateOptions {
 pub fn generate_codama(options: &CodamaGenerateOptions) -> Result<Vec<String>, CodamaError> {
 	let examples = collect_examples(options)?;
 
+	// Create output directories.
 	std::fs::create_dir_all(&options.idls_dir).map_err(|source| {
 		CodamaError::CreateDir {
 			path: options.idls_dir.clone(),
@@ -66,6 +67,7 @@ pub fn generate_codama(options: &CodamaGenerateOptions) -> Result<Vec<String>, C
 		}
 	})?;
 
+	// Generate IDL JSON files.
 	let mut idl_paths = Vec::with_capacity(examples.len());
 	for example in &examples {
 		let program_path = options.examples_dir.join(example);
@@ -93,6 +95,7 @@ pub fn generate_codama(options: &CodamaGenerateOptions) -> Result<Vec<String>, C
 		idl_paths.push(idl_path);
 	}
 
+	// Render Rust clients.
 	let render_config = RenderConfig::default();
 	for (example, idl_path) in examples.iter().zip(idl_paths.iter()) {
 		let crate_dir = options.rust_out.join(example);
@@ -104,6 +107,7 @@ pub fn generate_codama(options: &CodamaGenerateOptions) -> Result<Vec<String>, C
 		})?;
 	}
 
+	// Generate JavaScript clients.
 	run_js_generation(options, &idl_paths)?;
 
 	Ok(examples)
@@ -144,14 +148,15 @@ fn collect_examples(options: &CodamaGenerateOptions) -> Result<Vec<String>, Coda
 		}
 	}
 
-	let mut selected = options
+	let mut selected: Vec<_> = options
 		.examples
 		.iter()
 		.cloned()
 		.collect::<BTreeSet<_>>()
 		.into_iter()
-		.collect::<Vec<_>>();
+		.collect();
 	selected.sort();
+
 	Ok(selected)
 }
 
@@ -184,6 +189,7 @@ fn run_js_generation(
 
 	let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
 	let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+
 	let details = if !stderr.is_empty() {
 		format!(": {stderr}")
 	} else if !stdout.is_empty() {
@@ -192,12 +198,14 @@ fn run_js_generation(
 		String::new()
 	};
 
+	let cmd = if options.npx == "npx" {
+		"npx (or fallback pnpm dlx)".to_string()
+	} else {
+		options.npx.clone()
+	};
+
 	Err(CodamaError::CommandFailed {
-		cmd: if options.npx == "npx" {
-			"npx (or fallback pnpm dlx)".to_string()
-		} else {
-			options.npx.clone()
-		},
+		cmd,
 		status: output.status.code().unwrap_or(-1),
 		details,
 	})
@@ -208,6 +216,7 @@ fn run_js_generation_with_npx(
 	idl_paths: &[PathBuf],
 ) -> std::io::Result<Output> {
 	let mut command = Command::new(&options.npx);
+
 	command
 		.arg("-y")
 		.arg("-p")

--- a/crates/pina_cli/src/init.rs
+++ b/crates/pina_cli/src/init.rs
@@ -440,6 +440,7 @@ mod tests {
 		.unwrap_or_else(|err| panic!("expected seed file write to succeed: {err}"));
 
 		let result = init_project(&dir.path, "my_program", false);
+
 		match result {
 			Err(InitError::DestinationExists { path }) => {
 				assert!(path.ends_with("Cargo.toml"));

--- a/crates/pina_cli/src/main.rs
+++ b/crates/pina_cli/src/main.rs
@@ -156,9 +156,11 @@ fn run_idl(
 			eprintln!("Failed to write {}: {e}", output.display());
 			std::process::exit(1);
 		}
-	} else {
-		println!("{json}");
+
+		return;
 	}
+
+	println!("{json}");
 }
 
 fn run_init(name: &str, path: Option<&std::path::Path>, force: bool) {
@@ -203,16 +205,20 @@ fn run_profile(path: &std::path::Path, json: bool, output: Option<&std::path::Pa
 				std::process::exit(1);
 			}
 		};
+
 		if let Err(e) = pina_profile::output::write_profile(&profile, format, &mut file) {
 			eprintln!("Failed to write profile: {e}");
 			std::process::exit(1);
 		}
-	} else {
-		let mut stdout = std::io::stdout().lock();
-		if let Err(e) = pina_profile::output::write_profile(&profile, format, &mut stdout) {
-			eprintln!("Failed to write profile: {e}");
-			std::process::exit(1);
-		}
+
+		return;
+	}
+
+	let mut stdout = std::io::stdout().lock();
+
+	if let Err(e) = pina_profile::output::write_profile(&profile, format, &mut stdout) {
+		eprintln!("Failed to write profile: {e}");
+		std::process::exit(1);
 	}
 }
 

--- a/crates/pina_cli/src/parse/account_state.rs
+++ b/crates/pina_cli/src/parse/account_state.rs
@@ -48,11 +48,13 @@ fn get_account_discriminator_enum(attrs: &[syn::Attribute]) -> Option<String> {
 		if !attr.path().is_ident("account") {
 			continue;
 		}
+
 		let Ok(meta_list) = attr.parse_args_with(
 			syn::punctuated::Punctuated::<syn::Meta, syn::Token![,]>::parse_terminated,
 		) else {
 			continue;
 		};
+
 		for meta in &meta_list {
 			if let syn::Meta::NameValue(nv) = meta {
 				if nv.path.is_ident("discriminator") {
@@ -61,6 +63,7 @@ fn get_account_discriminator_enum(attrs: &[syn::Attribute]) -> Option<String> {
 			}
 		}
 	}
+
 	None
 }
 
@@ -93,6 +96,7 @@ fn extract_named_fields(fields: &syn::Fields) -> Vec<FieldIr> {
 				.map_or_else(|| "unknown".to_owned(), ToString::to_string);
 			let rust_type = type_to_string(&f.ty);
 			let docs = extract_docs(&f.attrs);
+
 			FieldIr {
 				name,
 				rust_type,

--- a/crates/pina_cli/src/parse/collision.rs
+++ b/crates/pina_cli/src/parse/collision.rs
@@ -103,13 +103,15 @@ pub fn find_duplicate_input_fields(ir: &ProgramIr) -> Vec<DuplicateInputField> {
 		}
 
 		for (name, sources) in &field_sources {
-			if sources.len() > 1 {
-				duplicates.push(DuplicateInputField {
-					instruction: instruction.name.clone(),
-					field_name: (*name).to_owned(),
-					sources: sources.clone(),
-				});
+			if sources.len() <= 1 {
+				continue;
 			}
+
+			duplicates.push(DuplicateInputField {
+				instruction: instruction.name.clone(),
+				field_name: (*name).to_owned(),
+				sources: sources.clone(),
+			});
 		}
 	}
 

--- a/crates/pina_cli/src/parse/entrypoint.rs
+++ b/crates/pina_cli/src/parse/entrypoint.rs
@@ -50,9 +50,11 @@ pub fn extract_dispatch_map(file: &File) -> Vec<DispatchEntry> {
 
 fn extract_from_fn_body(stmts: &[Stmt], entries: &mut Vec<DispatchEntry>) {
 	for stmt in stmts {
-		if let Stmt::Expr(expr, _) = stmt {
-			extract_from_expr(expr, entries);
-		}
+		let Stmt::Expr(expr, _) = stmt else {
+			continue;
+		};
+
+		extract_from_expr(expr, entries);
 	}
 }
 
@@ -60,18 +62,24 @@ fn extract_from_expr(expr: &Expr, entries: &mut Vec<DispatchEntry>) {
 	match expr {
 		Expr::Match(m) => {
 			for arm in &m.arms {
-				if let Some(entry) = parse_match_arm(arm) {
-					entries.push(entry);
-				}
+				let Some(entry) = parse_match_arm(arm) else {
+					continue;
+				};
+
+				entries.push(entry);
 			}
 		}
+
 		Expr::Block(b) => {
 			for stmt in &b.block.stmts {
-				if let Stmt::Expr(expr, _) = stmt {
-					extract_from_expr(expr, entries);
-				}
+				let Stmt::Expr(expr, _) = stmt else {
+					continue;
+				};
+
+				extract_from_expr(expr, entries);
 			}
 		}
+
 		_ => {}
 	}
 }

--- a/crates/pina_cli/src/parse/mod.rs
+++ b/crates/pina_cli/src/parse/mod.rs
@@ -91,6 +91,7 @@ pub fn assemble_program_ir_multi(
 
 		let file_seed_constants = seeds::extract_seed_constants(file);
 		let file_pdas = seeds::extract_pda_from_seed_macros(file, &file_seed_constants);
+
 		all_seed_constants.extend(file_seed_constants);
 		pdas_ir.extend(file_pdas);
 	}
@@ -239,8 +240,10 @@ fn assemble_from_extracted(
 /// first set of violations found.
 pub fn validate_program_ir(ir: &ProgramIr) -> Result<(), IdlError> {
 	let collisions = collision::find_discriminator_collisions(ir);
+
 	if !collisions.is_empty() {
 		let messages = collision::format_collision_errors(&collisions);
+
 		return Err(IdlError::Other(format!(
 			"Discriminator collisions detected:\n  {}",
 			messages.join("\n  "),
@@ -248,8 +251,10 @@ pub fn validate_program_ir(ir: &ProgramIr) -> Result<(), IdlError> {
 	}
 
 	let duplicates = collision::find_duplicate_input_fields(ir);
+
 	if !duplicates.is_empty() {
 		let messages = collision::format_duplicate_field_errors(&duplicates);
+
 		return Err(IdlError::Other(format!(
 			"Duplicate instruction input field names detected:\n  {}",
 			messages.join("\n  "),

--- a/crates/pina_cli/src/parse/module_resolver.rs
+++ b/crates/pina_cli/src/parse/module_resolver.rs
@@ -45,49 +45,52 @@ fn resolve_modules(
 	files: &mut Vec<ResolvedFile>,
 ) -> Result<(), IdlError> {
 	for item in &file.items {
-		if let syn::Item::Mod(item_mod) = item {
-			// Skip inline modules (they're already in the parent file's AST).
-			if item_mod.content.is_some() {
-				continue;
-			}
+		let syn::Item::Mod(item_mod) = item else {
+			continue;
+		};
 
-			let mod_name = item_mod.ident.to_string();
-
-			// Try mod_name.rs first, then mod_name/mod.rs.
-			let candidates = [
-				base_dir.join(format!("{mod_name}.rs")),
-				base_dir.join(&mod_name).join("mod.rs"),
-			];
-
-			let mod_path = candidates.iter().find(|p| p.is_file());
-
-			let Some(mod_path) = mod_path else {
-				// Module file not found — skip silently (could be a cfg-gated
-				// or external module).
-				continue;
-			};
-
-			let source =
-				std::fs::read_to_string(mod_path).map_err(|e| IdlError::io(mod_path, e))?;
-			let mod_file = syn::parse_file(&source).map_err(|e| IdlError::parse(mod_path, &e))?;
-
-			files.push(ResolvedFile {
-				path: mod_path.clone(),
-				file: mod_file.clone(),
-			});
-
-			// Recurse into the resolved module's directory for nested modules.
-			let child_dir = if mod_path.file_name().is_some_and(|n| n == "mod.rs") {
-				mod_path.parent().unwrap_or(base_dir).to_path_buf()
-			} else {
-				// For foo.rs, child modules would be in foo/ directory.
-				base_dir.join(&mod_name)
-			};
-
-			if child_dir.is_dir() {
-				resolve_modules(&child_dir, &mod_file, files)?;
-			}
+		// Skip inline modules (they're already in the parent file's AST).
+		if item_mod.content.is_some() {
+			continue;
 		}
+
+		let mod_name = item_mod.ident.to_string();
+
+		// Try mod_name.rs first, then mod_name/mod.rs.
+		let candidates = [
+			base_dir.join(format!("{mod_name}.rs")),
+			base_dir.join(&mod_name).join("mod.rs"),
+		];
+
+		let mod_path = candidates.iter().find(|p| p.is_file());
+
+		let Some(mod_path) = mod_path else {
+			// Module file not found — skip silently (could be a cfg-gated
+			// or external module).
+			continue;
+		};
+
+		let source = std::fs::read_to_string(mod_path).map_err(|e| IdlError::io(mod_path, e))?;
+		let mod_file = syn::parse_file(&source).map_err(|e| IdlError::parse(mod_path, &e))?;
+
+		files.push(ResolvedFile {
+			path: mod_path.clone(),
+			file: mod_file.clone(),
+		});
+
+		// Recurse into the resolved module's directory for nested modules.
+		let child_dir = if mod_path.file_name().is_some_and(|n| n == "mod.rs") {
+			mod_path.parent().unwrap_or(base_dir).to_path_buf()
+		} else {
+			// For foo.rs, child modules would be in foo/ directory.
+			base_dir.join(&mod_name)
+		};
+
+		if !child_dir.is_dir() {
+			continue;
+		}
+
+		resolve_modules(&child_dir, &mod_file, files)?;
 	}
 
 	Ok(())

--- a/crates/pina_cli/src/parse/seeds.rs
+++ b/crates/pina_cli/src/parse/seeds.rs
@@ -100,21 +100,25 @@ fn parse_seed_macro_tokens(tokens: &str, seed_constants: &[SeedConstant]) -> Vec
 	let Some(start) = start else {
 		return Vec::new();
 	};
+
 	// Skip past `& [` or `&[`.
 	let skip = if tokens[start..].starts_with("& [") {
 		3
 	} else {
 		2
 	};
+
 	let rest = &tokens[start + skip..];
 	let Some(end) = find_matching_bracket(rest) else {
 		return Vec::new();
 	};
-	let body = &rest[..end];
 
+	let body = &rest[..end];
 	let mut seeds = Vec::new();
+
 	for element in body.split(',') {
 		let element = element.trim();
+
 		if element.is_empty() {
 			continue;
 		}
@@ -133,8 +137,11 @@ fn parse_seed_macro_tokens(tokens: &str, seed_constants: &[SeedConstant]) -> Vec
 			seeds.push(PdaSeedIr::Constant {
 				value: constant.value.clone(),
 			});
-		} else if element.starts_with('$') || element.starts_with("$ ") {
-			// It's a macro variable — extract the name.
+			continue;
+		}
+
+		// It's a macro variable — extract the name.
+		if element.starts_with('$') || element.starts_with("$ ") {
 			// Tokenized form may be `$ authority` (with space).
 			let var_name = element
 				.trim_start_matches('$')
@@ -144,6 +151,7 @@ fn parse_seed_macro_tokens(tokens: &str, seed_constants: &[SeedConstant]) -> Vec
 				.unwrap_or("unknown")
 				.trim()
 				.to_owned();
+
 			// Default to Address/PublicKey type for variable seeds.
 			seeds.push(PdaSeedIr::Variable {
 				name: var_name,

--- a/crates/pina_cli/src/parse/validation.rs
+++ b/crates/pina_cli/src/parse/validation.rs
@@ -48,6 +48,7 @@ pub fn extract_validation_properties(
 		let Some(trait_path) = item_impl.trait_.as_ref().map(|(_, path, _)| path) else {
 			continue;
 		};
+
 		if !path_ends_with(trait_path, "ProcessAccountInfos") {
 			continue;
 		}
@@ -83,24 +84,30 @@ fn collect_assertions_from_stmt(stmt: &Stmt, props: &mut HashMap<String, Account
 		Stmt::Expr(expr, _) => {
 			collect_assertions_from_expr(expr, props);
 		}
+
 		Stmt::Local(syn::Local {
 			init: Some(init), ..
 		}) => {
 			collect_assertions_from_expr(&init.expr, props);
+
 			if let Some((_, diverge)) = &init.diverge {
 				collect_assertions_from_expr(diverge, props);
 			}
 		}
+
 		Stmt::Item(Item::Impl(item_impl)) => {
 			// Nested impl blocks (unlikely but handle gracefully).
 			for ii in &item_impl.items {
-				if let ImplItem::Fn(f) = ii {
-					for s in &f.block.stmts {
-						collect_assertions_from_stmt(s, props);
-					}
+				let ImplItem::Fn(f) = ii else {
+					continue;
+				};
+
+				for s in &f.block.stmts {
+					collect_assertions_from_stmt(s, props);
 				}
 			}
 		}
+
 		_ => {}
 	}
 }
@@ -109,49 +116,63 @@ fn collect_assertions_from_expr(expr: &Expr, props: &mut HashMap<String, Account
 	match expr {
 		Expr::MethodCall(mc) => {
 			let method = mc.method.to_string();
+
 			if let Some(field_name) = resolve_self_field(&mc.receiver) {
 				let entry = props.entry(field_name).or_default();
 				apply_assertion(&method, &mc.args, entry);
 			}
+
 			// Also recurse into the receiver (for chained calls).
 			collect_assertions_from_expr(&mc.receiver, props);
+
 			// And recurse into arguments.
 			for arg in &mc.args {
 				collect_assertions_from_expr(arg, props);
 			}
 		}
+
 		Expr::Try(t) => {
 			collect_assertions_from_expr(&t.expr, props);
 		}
+
 		Expr::Block(b) => {
 			for stmt in &b.block.stmts {
 				collect_assertions_from_stmt(stmt, props);
 			}
 		}
+
 		Expr::If(if_expr) => {
 			collect_assertions_from_expr(&if_expr.cond, props);
+
 			for stmt in &if_expr.then_branch.stmts {
 				collect_assertions_from_stmt(stmt, props);
 			}
+
 			if let Some((_, else_expr)) = &if_expr.else_branch {
 				collect_assertions_from_expr(else_expr, props);
 			}
 		}
+
 		Expr::Let(let_expr) => {
 			collect_assertions_from_expr(&let_expr.expr, props);
 		}
+
 		Expr::Call(call) => {
 			collect_assertions_from_expr(&call.func, props);
+
 			for arg in &call.args {
 				collect_assertions_from_expr(arg, props);
 			}
 		}
+
 		Expr::Paren(p) => {
 			collect_assertions_from_expr(&p.expr, props);
 		}
+
 		Expr::Reference(r) => {
 			collect_assertions_from_expr(&r.expr, props);
 		}
+
 		_ => {}
 	}
 }

--- a/crates/pina_codama_renderer/src/lib.rs
+++ b/crates/pina_codama_renderer/src/lib.rs
@@ -49,6 +49,7 @@ pub fn render_idl_file(path: &Path, crate_dir: &Path, config: &RenderConfig) -> 
 
 pub fn render_root_node(root: &RootNode, crate_dir: &Path, config: &RenderConfig) -> Result<()> {
 	ensure_crate_scaffold(crate_dir, root.program.name.as_ref())?;
+
 	let generated_dir = crate_dir.join(&config.generated_folder);
 
 	if config.delete_folder_before_rendering && generated_dir.exists() {
@@ -61,6 +62,7 @@ pub fn render_root_node(root: &RootNode, crate_dir: &Path, config: &RenderConfig
 	}
 
 	let files = render_program_to_files(root)?;
+
 	write_files(&generated_dir, files)
 }
 
@@ -77,6 +79,7 @@ fn render_program_to_files(root: &RootNode) -> Result<BTreeMap<PathBuf, String>>
 	let program = &root.program;
 	let mut files = BTreeMap::new();
 
+	// Build program metadata
 	let program_constants = std::iter::once(&root.program)
 		.chain(root.additional_programs.iter())
 		.collect::<Vec<_>>();
@@ -88,12 +91,14 @@ fn render_program_to_files(root: &RootNode) -> Result<BTreeMap<PathBuf, String>>
 		.map(|pda| (pda.name.as_ref().to_string(), pda))
 		.collect::<BTreeMap<_, _>>();
 
+	// Core module files
 	files.insert(PathBuf::from("mod.rs"), page(&render_root_mod(program)));
 	files.insert(
 		PathBuf::from("programs.rs"),
 		page(&render_programs_mod(&program_constants)),
 	);
 
+	// Account files
 	if !program.accounts.is_empty() {
 		files.insert(
 			PathBuf::from("accounts/mod.rs"),
@@ -102,42 +107,47 @@ fn render_program_to_files(root: &RootNode) -> Result<BTreeMap<PathBuf, String>>
 
 		for account in &program.accounts {
 			let filename = format!("accounts/{}.rs", snake(account.name.as_ref()));
-			let account_content = render_account_page(
-				account,
-				&primary_program_const,
-				pdas_by_name
-					.get(account.pda.as_ref().map_or("", |p| p.name.as_ref()))
-					.copied(),
-			)?;
+			let pda = pdas_by_name
+				.get(account.pda.as_ref().map_or("", |p| p.name.as_ref()))
+				.copied();
+			let account_content = render_account_page(account, &primary_program_const, pda)?;
+
 			files.insert(PathBuf::from(filename), page(&account_content));
 		}
 	}
 
+	// Instruction files
 	if !program.instructions.is_empty() {
 		files.insert(
 			PathBuf::from("instructions/mod.rs"),
 			page(&render_instructions_mod(&program.instructions)),
 		);
+
 		for instruction in &program.instructions {
 			let filename = format!("instructions/{}.rs", snake(instruction.name.as_ref()));
 			let instruction_content =
 				render_instruction_page(instruction, program, &primary_program_const)?;
+
 			files.insert(PathBuf::from(filename), page(&instruction_content));
 		}
 	}
 
+	// Type definitions
 	if !program.defined_types.is_empty() {
 		files.insert(
 			PathBuf::from("types/mod.rs"),
 			page(&render_defined_types_mod(&program.defined_types)),
 		);
+
 		for defined_type in &program.defined_types {
 			let filename = format!("types/{}.rs", snake(defined_type.name.as_ref()));
 			let defined_type_content = render_defined_type_page(defined_type)?;
+
 			files.insert(PathBuf::from(filename), page(&defined_type_content));
 		}
 	}
 
+	// Error definitions
 	if !program.errors.is_empty() {
 		files.insert(
 			PathBuf::from("errors/mod.rs"),

--- a/crates/pina_codama_renderer/src/main.rs
+++ b/crates/pina_codama_renderer/src/main.rs
@@ -41,6 +41,7 @@ fn run() -> Result<(), RenderError> {
 	for idl_path in &idl_paths {
 		let root = read_root_node(idl_path)?;
 		let output_crate_dir = args.output.join(file_stem(idl_path)?);
+
 		render_root_node(&root, &output_crate_dir, &config)?;
 	}
 

--- a/crates/pina_codama_renderer/src/render/accounts.rs
+++ b/crates/pina_codama_renderer/src/render/accounts.rs
@@ -14,19 +14,23 @@ use crate::error::Result;
 
 pub(crate) fn render_accounts_mod(accounts: &[AccountNode]) -> String {
 	let mut lines = Vec::new();
+
 	for account in accounts {
 		lines.push(format!(
 			"pub(crate) mod r#{};",
 			snake(account.name.as_ref())
 		));
 	}
+
 	lines.push(String::new());
+
 	for account in accounts {
 		lines.push(format!(
 			"pub use self::r#{}::*;",
 			snake(account.name.as_ref())
 		));
 	}
+
 	lines.join("\n")
 }
 
@@ -91,9 +95,11 @@ pub(crate) fn render_account_page(
 	if ctor_args.is_empty() {
 		lines.push("\tpub const fn new() -> Self {".to_string());
 		lines.push("\t\tSelf {".to_string());
+
 		if let Some(discriminator) = &discriminator {
 			lines.push(format!("\t\t\tdiscriminator: {},", discriminator.name));
 		}
+
 		lines.push("\t\t}".to_string());
 		lines.push("\t}".to_string());
 	} else {
@@ -102,9 +108,11 @@ pub(crate) fn render_account_page(
 			ctor_args.join(", ")
 		));
 		lines.push("\t\tSelf {".to_string());
+
 		if let Some(discriminator) = &discriminator {
 			lines.push(format!("\t\t\tdiscriminator: {},", discriminator.name));
 		}
+
 		lines.extend(ctor_inits);
 		lines.push("\t\t}".to_string());
 		lines.push("\t}".to_string());
@@ -198,6 +206,7 @@ fn render_account_pda_helpers(
 				let context = format!("PDA `{}` variable seed `{seed_name}`", pda.name.as_ref());
 				let (param_type, seed_expr) =
 					render_variable_seed_parameter(&seed_name, &variable.r#type, &context)?;
+
 				params.push(format!("{seed_name}: {param_type}"));
 				seed_exprs.push(seed_expr);
 			}
@@ -221,9 +230,11 @@ fn render_account_pda_helpers(
 	));
 	lines.push("\t\tsolana_pubkey::Pubkey::find_program_address(".to_string());
 	lines.push("\t\t\t&[".to_string());
+
 	for seed_expr in &seed_exprs {
 		lines.push(format!("\t\t\t\t{seed_expr},"));
 	}
+
 	lines.push("\t\t\t],".to_string());
 	lines.push(format!("\t\t\t&crate::{primary_program_const},"));
 	lines.push("\t\t)".to_string());
@@ -238,9 +249,11 @@ fn render_account_pda_helpers(
 	));
 	lines.push("\t\tsolana_pubkey::Pubkey::create_program_address(".to_string());
 	lines.push("\t\t\t&[".to_string());
+
 	for seed_expr in &seed_exprs {
 		lines.push(format!("\t\t\t\t{seed_expr},"));
 	}
+
 	lines.push("\t\t\t\t&[bump],".to_string());
 	lines.push("\t\t\t],".to_string());
 	lines.push(format!("\t\t\t&crate::{primary_program_const},"));

--- a/crates/pina_codama_renderer/src/render/discriminator.rs
+++ b/crates/pina_codama_renderer/src/render/discriminator.rs
@@ -36,6 +36,7 @@ pub(crate) fn render_constant_discriminator(
 	};
 
 	let (ty, value) = render_constant_discriminator_value(constant_discriminator, context)?;
+
 	Ok(Some(DiscriminatorInfo {
 		name: format!("{}_DISCRIMINATOR", shouty(prefix)),
 		ty,

--- a/crates/pina_codama_renderer/src/render/instructions.rs
+++ b/crates/pina_codama_renderer/src/render/instructions.rs
@@ -17,19 +17,23 @@ use crate::error::Result;
 
 pub(crate) fn render_instructions_mod(instructions: &[InstructionNode]) -> String {
 	let mut lines = Vec::new();
+
 	for instruction in instructions {
 		lines.push(format!(
 			"pub(crate) mod r#{};",
 			snake(instruction.name.as_ref())
 		));
 	}
+
 	lines.push(String::new());
+
 	for instruction in instructions {
 		lines.push(format!(
 			"pub use self::r#{}::*;",
 			snake(instruction.name.as_ref())
 		));
 	}
+
 	lines.join("\n")
 }
 
@@ -52,9 +56,11 @@ pub(crate) fn render_instruction_page(
 	})?;
 
 	let mut lines = Vec::new();
+
 	for doc_line in render_docs(&instruction.docs, 0) {
 		lines.push(doc_line);
 	}
+
 	lines.push(format!(
 		"pub const {}: {} = {};",
 		discriminator.name, discriminator.ty, discriminator.value
@@ -63,22 +69,27 @@ pub(crate) fn render_instruction_page(
 	lines.push("/// Accounts.".to_string());
 	lines.push("#[derive(Clone, Debug)]".to_string());
 	lines.push(format!("pub struct {instruction_name} {{"));
+
 	for account in &instruction.accounts {
 		let (field_type, _) = render_instruction_account_field_type(account);
+
 		for doc_line in render_docs(&account.docs, 1) {
 			lines.push(doc_line);
 		}
+
 		lines.push(format!(
 			"\tpub {}: {},",
 			snake(account.name.as_ref()),
 			field_type
 		));
 	}
+
 	lines.push("}".to_string());
 	lines.push(String::new());
 
 	let mut new_params = Vec::new();
 	let mut new_inits = Vec::new();
+
 	for account in &instruction.accounts {
 		let field_name = snake(account.name.as_ref());
 		let (field_type, base_type) = render_instruction_account_field_type(account);
@@ -88,6 +99,7 @@ pub(crate) fn render_instruction_page(
 			primary_program_const,
 			program,
 		)?;
+
 		if let Some(default_expr) = default_value {
 			new_inits.push(format!("\t\t\t{field_name}: {default_expr},"));
 		} else {
@@ -95,6 +107,7 @@ pub(crate) fn render_instruction_page(
 			new_inits.push(format!("\t\t\t{field_name},"));
 		}
 	}
+
 	lines.push(format!("impl {instruction_name} {{"));
 	lines.push(format!(
 		"\tpub fn new({}) -> Self {{",
@@ -140,6 +153,7 @@ pub(crate) fn render_instruction_page(
 
 	let mut data_fields = Vec::new();
 	data_fields.push(format!("\tpub discriminator: {},", discriminator.ty));
+
 	let mut data_new_args = Vec::new();
 	let mut data_inits = Vec::new();
 	data_inits.push(format!("\t\t\tdiscriminator: {},", discriminator.name));
@@ -148,9 +162,11 @@ pub(crate) fn render_instruction_page(
 		let argument_name = snake(argument.name.as_ref());
 		let field_context = format!("{instruction_name}.{argument_name}");
 		let argument_type = render_type_for_pod(&argument.r#type, &field_context)?;
+
 		for doc_line in render_docs(&argument.docs, 1) {
 			data_fields.push(doc_line);
 		}
+
 		data_fields.push(format!("\tpub {argument_name}: {argument_type},"));
 		data_new_args.push(format!("{argument_name}: {argument_type}"));
 		data_inits.push(format!("\t\t\t{argument_name},"));
@@ -184,6 +200,7 @@ fn render_instruction_account_metas(
 	primary_program_const: &str,
 ) -> Vec<String> {
 	let mut lines = Vec::new();
+
 	for account in &instruction.accounts {
 		let field_name = snake(account.name.as_ref());
 		let meta_ctor = if account.is_writable {
@@ -233,6 +250,7 @@ fn render_instruction_account_metas(
 				));
 				lines.push("\t\t}".to_string());
 			}
+
 			continue;
 		}
 
@@ -240,6 +258,7 @@ fn render_instruction_account_metas(
 			"\t\taccounts.push({meta_ctor}({key_expr}, {signer_expr}));"
 		));
 	}
+
 	lines
 }
 
@@ -257,7 +276,7 @@ fn render_instruction_account_field_type(account: &InstructionAccountNode) -> (S
 
 fn render_instruction_account_default_value(
 	account: &InstructionAccountNode,
-	base_type: &str,
+	_base_type: &str,
 	primary_program_const: &str,
 	program: &ProgramNode,
 ) -> Result<Option<String>> {
@@ -273,7 +292,9 @@ fn render_instruction_account_default_value(
 		InstructionInputValueNode::PublicKey(public_key) => {
 			format!("solana_pubkey::pubkey!(\"{}\")", public_key.public_key)
 		}
-		InstructionInputValueNode::ProgramId(_) => format!("crate::{primary_program_const}"),
+		InstructionInputValueNode::ProgramId(_) => {
+			format!("crate::{primary_program_const}")
+		}
 		InstructionInputValueNode::ProgramLink(program_link) => {
 			format!(
 				"crate::{}",
@@ -294,9 +315,8 @@ fn render_instruction_account_default_value(
 	};
 
 	if matches!(account.is_signer, IsAccountSigner::Either) {
-		Ok(Some(format!("({value}, false)")))
-	} else {
-		let _ = base_type;
-		Ok(Some(value))
+		return Ok(Some(format!("({value}, false)")));
 	}
+
+	Ok(Some(value))
 }

--- a/crates/pina_macros/src/lib.rs
+++ b/crates/pina_macros/src/lib.rs
@@ -379,31 +379,29 @@ fn discriminator_impl(
 		let existing_derives_result =
 			derive_attr.parse_args_with(Punctuated::<syn::Path, Token![,]>::parse_terminated);
 
-		let Ok(mut existing_derives) = existing_derives_result else {
-			// No derive attribute exists, so create one
-			let new_derive_attr: Attribute = syn::parse_quote!(#[derive(#(#derives_to_add),*)]);
-			item_enum.attrs.push(new_derive_attr);
+		if let Ok(mut existing_derives) = existing_derives_result {
+			let existing_derive_names: std::collections::HashSet<String> = existing_derives
+				.iter()
+				.map(|p| p.segments.last().unwrap().ident.to_string())
+				.collect();
 
-			return quote! { #item_enum };
-		};
-
-		let existing_derive_names: std::collections::HashSet<String> = existing_derives
-			.iter()
-			.map(|p| p.segments.last().unwrap().ident.to_string())
-			.collect();
-
-		for derive_to_add in &derives_to_add {
-			let to_add_name = derive_to_add.segments.last().unwrap().ident.to_string();
-			if !existing_derive_names.contains(&to_add_name) {
-				existing_derives.push(derive_to_add.clone());
+			for derive_to_add in &derives_to_add {
+				let to_add_name = derive_to_add.segments.last().unwrap().ident.to_string();
+				if !existing_derive_names.contains(&to_add_name) {
+					existing_derives.push(derive_to_add.clone());
+				}
 			}
+
+			let new_derive_attr: Attribute = syn::parse_quote! {
+				#[derive(#existing_derives)]
+			};
+
+			*derive_attr = new_derive_attr;
+		} else {
+			// Derive attribute exists but failed to parse; replace with defaults
+			let new_derive_attr: Attribute = syn::parse_quote!(#[derive(#(#derives_to_add),*)]);
+			*derive_attr = new_derive_attr;
 		}
-
-		let new_derive_attr: Attribute = syn::parse_quote! {
-			#[derive(#existing_derives)]
-		};
-
-		*derive_attr = new_derive_attr;
 	} else {
 		// No derive attribute exists, so create one
 		let new_derive_attr: Attribute = syn::parse_quote!(#[derive(#(#derives_to_add),*)]);
@@ -748,31 +746,29 @@ fn account_impl(
 		let existing_derives_result =
 			derive_attr.parse_args_with(Punctuated::<syn::Path, Token![,]>::parse_terminated);
 
-		let Ok(mut existing_derives) = existing_derives_result else {
-			// Failed to parse derives, create new one
-			let new_derive_attr: Attribute = syn::parse_quote!(#[derive(#(#derives_to_add),*)]);
-			item_struct.attrs.push(new_derive_attr);
+		if let Ok(mut existing_derives) = existing_derives_result {
+			let existing_derive_names: std::collections::HashSet<String> = existing_derives
+				.iter()
+				.map(|p| p.segments.last().unwrap().ident.to_string())
+				.collect();
 
-			return quote! { #item_struct };
-		};
-
-		let existing_derive_names: std::collections::HashSet<String> = existing_derives
-			.iter()
-			.map(|p| p.segments.last().unwrap().ident.to_string())
-			.collect();
-
-		for derive_to_add in &derives_to_add {
-			let to_add_name = derive_to_add.segments.last().unwrap().ident.to_string();
-			if !existing_derive_names.contains(&to_add_name) {
-				existing_derives.push(derive_to_add.clone());
+			for derive_to_add in &derives_to_add {
+				let to_add_name = derive_to_add.segments.last().unwrap().ident.to_string();
+				if !existing_derive_names.contains(&to_add_name) {
+					existing_derives.push(derive_to_add.clone());
+				}
 			}
+
+			let new_derive_attr: Attribute = syn::parse_quote! {
+				#[derive(#existing_derives)]
+			};
+
+			*derive_attr = new_derive_attr;
+		} else {
+			// Derive attribute exists but failed to parse; replace with defaults
+			let new_derive_attr: Attribute = syn::parse_quote!(#[derive(#(#derives_to_add),*)]);
+			*derive_attr = new_derive_attr;
 		}
-
-		let new_derive_attr: Attribute = syn::parse_quote! {
-			#[derive(#existing_derives)]
-		};
-
-		*derive_attr = new_derive_attr;
 	} else {
 		// No derive attribute exists, so create one
 		let new_derive_attr: Attribute = syn::parse_quote!(#[derive(#(#derives_to_add),*)]);
@@ -1140,31 +1136,29 @@ fn instruction_impl(
 		let existing_derives_result =
 			derive_attr.parse_args_with(Punctuated::<syn::Path, Token![,]>::parse_terminated);
 
-		let Ok(mut existing_derives) = existing_derives_result else {
-			// Failed to parse derives, create new one
-			let new_derive_attr: Attribute = syn::parse_quote!(#[derive(#(#derives_to_add),*)]);
-			item_struct.attrs.push(new_derive_attr);
+		if let Ok(mut existing_derives) = existing_derives_result {
+			let existing_derive_names: std::collections::HashSet<String> = existing_derives
+				.iter()
+				.map(|p| p.segments.last().unwrap().ident.to_string())
+				.collect();
 
-			return quote! { #item_struct };
-		};
-
-		let existing_derive_names: std::collections::HashSet<String> = existing_derives
-			.iter()
-			.map(|p| p.segments.last().unwrap().ident.to_string())
-			.collect();
-
-		for derive_to_add in &derives_to_add {
-			let to_add_name = derive_to_add.segments.last().unwrap().ident.to_string();
-			if !existing_derive_names.contains(&to_add_name) {
-				existing_derives.push(derive_to_add.clone());
+			for derive_to_add in &derives_to_add {
+				let to_add_name = derive_to_add.segments.last().unwrap().ident.to_string();
+				if !existing_derive_names.contains(&to_add_name) {
+					existing_derives.push(derive_to_add.clone());
+				}
 			}
+
+			let new_derive_attr: Attribute = syn::parse_quote! {
+				#[derive(#existing_derives)]
+			};
+
+			*derive_attr = new_derive_attr;
+		} else {
+			// Derive attribute exists but failed to parse; replace with defaults
+			let new_derive_attr: Attribute = syn::parse_quote!(#[derive(#(#derives_to_add),*)]);
+			*derive_attr = new_derive_attr;
 		}
-
-		let new_derive_attr: Attribute = syn::parse_quote! {
-			#[derive(#existing_derives)]
-		};
-
-		*derive_attr = new_derive_attr;
 	} else {
 		// No derive attribute exists, so create one
 		let new_derive_attr: Attribute = syn::parse_quote!(#[derive(#(#derives_to_add),*)]);
@@ -1445,31 +1439,29 @@ fn event_impl(
 		let existing_derives_result =
 			derive_attr.parse_args_with(Punctuated::<syn::Path, Token![,]>::parse_terminated);
 
-		let Ok(mut existing_derives) = existing_derives_result else {
-			// Failed to parse derives, create new one
-			let new_derive_attr: Attribute = syn::parse_quote!(#[derive(#(#derives_to_add),*)]);
-			item_struct.attrs.push(new_derive_attr);
+		if let Ok(mut existing_derives) = existing_derives_result {
+			let existing_derive_names: std::collections::HashSet<String> = existing_derives
+				.iter()
+				.map(|p| p.segments.last().unwrap().ident.to_string())
+				.collect();
 
-			return quote! { #item_struct };
-		};
-
-		let existing_derive_names: std::collections::HashSet<String> = existing_derives
-			.iter()
-			.map(|p| p.segments.last().unwrap().ident.to_string())
-			.collect();
-
-		for derive_to_add in &derives_to_add {
-			let to_add_name = derive_to_add.segments.last().unwrap().ident.to_string();
-			if !existing_derive_names.contains(&to_add_name) {
-				existing_derives.push(derive_to_add.clone());
+			for derive_to_add in &derives_to_add {
+				let to_add_name = derive_to_add.segments.last().unwrap().ident.to_string();
+				if !existing_derive_names.contains(&to_add_name) {
+					existing_derives.push(derive_to_add.clone());
+				}
 			}
+
+			let new_derive_attr: Attribute = syn::parse_quote! {
+				#[derive(#existing_derives)]
+			};
+
+			*derive_attr = new_derive_attr;
+		} else {
+			// Derive attribute exists but failed to parse; replace with defaults
+			let new_derive_attr: Attribute = syn::parse_quote!(#[derive(#(#derives_to_add),*)]);
+			*derive_attr = new_derive_attr;
 		}
-
-		let new_derive_attr: Attribute = syn::parse_quote! {
-			#[derive(#existing_derives)]
-		};
-
-		*derive_attr = new_derive_attr;
 	} else {
 		// No derive attribute exists, so create one
 		let new_derive_attr: Attribute = syn::parse_quote!(#[derive(#(#derives_to_add),*)]);

--- a/crates/pina_macros/src/lib.rs
+++ b/crates/pina_macros/src/lib.rs
@@ -35,6 +35,7 @@ pub fn accounts_derive(input: TokenStream) -> TokenStream {
 }
 
 fn accounts_derive_impl(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
+	// Parse input
 	let input: DeriveInput = match syn::parse2(input) {
 		Ok(v) => v,
 		Err(e) => return e.to_compile_error(),
@@ -42,18 +43,16 @@ fn accounts_derive_impl(input: proc_macro2::TokenStream) -> proc_macro2::TokenSt
 
 	let args = match AccountsInput::from_derive_input(&input) {
 		Ok(v) => v,
-		Err(e) => {
-			return e.write_errors();
-		}
+		Err(e) => return e.write_errors(),
 	};
 
+	// Extract configuration
 	let struct_name = &args.ident;
 	let (impl_generics, ty_generics, where_clause) = args.generics.split_for_impl();
 	let crate_path = &args.crate_path;
 	let fields = args.data.take_struct().unwrap();
-	let mut field_idents = Vec::new();
-	let mut remaining_field = None;
 
+	// Get lifetime parameter
 	let lifetime = match args.generics.lifetimes().next() {
 		Some(lt) => &lt.lifetime,
 		None => {
@@ -64,6 +63,10 @@ fn accounts_derive_impl(input: proc_macro2::TokenStream) -> proc_macro2::TokenSt
 			.to_compile_error();
 		}
 	};
+
+	// Process fields
+	let mut field_idents = Vec::new();
+	let mut remaining_field = None;
 
 	for field in fields.iter() {
 		if !field.remaining.is_present() {
@@ -191,16 +194,12 @@ fn error_impl(
 ) -> proc_macro2::TokenStream {
 	let nested_metas = match NestedMeta::parse_meta_list(args) {
 		Ok(value) => value,
-		Err(e) => {
-			return e.into_compile_error();
-		}
+		Err(e) => return e.into_compile_error(),
 	};
 
 	let args = match ErrorArgs::from_list(&nested_metas) {
 		Ok(v) => v,
-		Err(e) => {
-			return e.write_errors();
-		}
+		Err(e) => return e.write_errors(),
 	};
 
 	let mut item_enum: ItemEnum = match syn::parse2(input) {
@@ -332,22 +331,19 @@ fn discriminator_impl(
 ) -> proc_macro2::TokenStream {
 	let nested_metas = match NestedMeta::parse_meta_list(args) {
 		Ok(value) => value,
-		Err(e) => {
-			return e.into_compile_error();
-		}
+		Err(e) => return e.into_compile_error(),
 	};
 
 	let args = match DiscriminatorArgs::from_list(&nested_metas) {
 		Ok(v) => v,
-		Err(e) => {
-			return e.write_errors();
-		}
+		Err(e) => return e.write_errors(),
 	};
 
 	let mut item_enum: ItemEnum = match syn::parse2(input) {
 		Ok(v) => v,
 		Err(e) => return e.to_compile_error(),
 	};
+
 	let enum_name = &item_enum.ident;
 
 	let DiscriminatorArgs {
@@ -374,33 +370,40 @@ fn discriminator_impl(
 		syn::parse_quote!(::core::cmp::Eq),
 	];
 
-	if let Some(derive_attr) = item_enum
+	let derive_attr = item_enum
 		.attrs
 		.iter_mut()
-		.find(|attr| attr.path().is_ident("derive"))
-	{
+		.find(|attr| attr.path().is_ident("derive"));
+
+	if let Some(derive_attr) = derive_attr {
 		let existing_derives_result =
 			derive_attr.parse_args_with(Punctuated::<syn::Path, Token![,]>::parse_terminated);
 
-		if let Ok(mut existing_derives) = existing_derives_result {
-			let existing_derive_names: std::collections::HashSet<String> = existing_derives
-				.iter()
-				.map(|p| p.segments.last().unwrap().ident.to_string())
-				.collect();
+		let Ok(mut existing_derives) = existing_derives_result else {
+			// No derive attribute exists, so create one
+			let new_derive_attr: Attribute = syn::parse_quote!(#[derive(#(#derives_to_add),*)]);
+			item_enum.attrs.push(new_derive_attr);
 
-			for derive_to_add in &derives_to_add {
-				let to_add_name = derive_to_add.segments.last().unwrap().ident.to_string();
-				if !existing_derive_names.contains(&to_add_name) {
-					existing_derives.push(derive_to_add.clone());
-				}
+			return quote! { #item_enum };
+		};
+
+		let existing_derive_names: std::collections::HashSet<String> = existing_derives
+			.iter()
+			.map(|p| p.segments.last().unwrap().ident.to_string())
+			.collect();
+
+		for derive_to_add in &derives_to_add {
+			let to_add_name = derive_to_add.segments.last().unwrap().ident.to_string();
+			if !existing_derive_names.contains(&to_add_name) {
+				existing_derives.push(derive_to_add.clone());
 			}
-
-			let new_derive_attr: Attribute = syn::parse_quote! {
-				#[derive(#existing_derives)]
-			};
-
-			*derive_attr = new_derive_attr;
 		}
+
+		let new_derive_attr: Attribute = syn::parse_quote! {
+			#[derive(#existing_derives)]
+		};
+
+		*derive_attr = new_derive_attr;
 	} else {
 		// No derive attribute exists, so create one
 		let new_derive_attr: Attribute = syn::parse_quote!(#[derive(#(#derives_to_add),*)]);
@@ -693,24 +696,24 @@ fn account_impl(
 	args: proc_macro2::TokenStream,
 	input: proc_macro2::TokenStream,
 ) -> proc_macro2::TokenStream {
+	// Parse macro arguments
 	let nested_metas = match NestedMeta::parse_meta_list(args) {
 		Ok(value) => value,
-		Err(e) => {
-			return e.into_compile_error();
-		}
+		Err(e) => return e.into_compile_error(),
 	};
 
 	let args = match AccountArgs::from_list(&nested_metas) {
 		Ok(v) => v,
-		Err(e) => {
-			return e.write_errors();
-		}
+		Err(e) => return e.write_errors(),
 	};
 
+	// Parse input struct
 	let mut item_struct: ItemStruct = match syn::parse2(input) {
 		Ok(v) => v,
 		Err(e) => return e.to_compile_error(),
 	};
+
+	// Extract configuration
 	let struct_name = &item_struct.ident;
 	let builder_name = format_ident!("{}Builder", struct_name);
 
@@ -719,7 +722,6 @@ fn account_impl(
 		discriminator,
 		variant,
 	} = args;
-
 	let variant = variant.unwrap_or(struct_name.clone());
 
 	// Add #[repr(C)]
@@ -737,33 +739,40 @@ fn account_impl(
 		syn::parse_quote!(::core::cmp::Eq),
 	];
 
-	if let Some(derive_attr) = item_struct
+	let derive_attr = item_struct
 		.attrs
 		.iter_mut()
-		.find(|attr| attr.path().is_ident("derive"))
-	{
+		.find(|attr| attr.path().is_ident("derive"));
+
+	if let Some(derive_attr) = derive_attr {
 		let existing_derives_result =
 			derive_attr.parse_args_with(Punctuated::<syn::Path, Token![,]>::parse_terminated);
 
-		if let Ok(mut existing_derives) = existing_derives_result {
-			let existing_derive_names: std::collections::HashSet<String> = existing_derives
-				.iter()
-				.map(|p| p.segments.last().unwrap().ident.to_string())
-				.collect();
+		let Ok(mut existing_derives) = existing_derives_result else {
+			// Failed to parse derives, create new one
+			let new_derive_attr: Attribute = syn::parse_quote!(#[derive(#(#derives_to_add),*)]);
+			item_struct.attrs.push(new_derive_attr);
 
-			for derive_to_add in &derives_to_add {
-				let to_add_name = derive_to_add.segments.last().unwrap().ident.to_string();
-				if !existing_derive_names.contains(&to_add_name) {
-					existing_derives.push(derive_to_add.clone());
-				}
+			return quote! { #item_struct };
+		};
+
+		let existing_derive_names: std::collections::HashSet<String> = existing_derives
+			.iter()
+			.map(|p| p.segments.last().unwrap().ident.to_string())
+			.collect();
+
+		for derive_to_add in &derives_to_add {
+			let to_add_name = derive_to_add.segments.last().unwrap().ident.to_string();
+			if !existing_derive_names.contains(&to_add_name) {
+				existing_derives.push(derive_to_add.clone());
 			}
-
-			let new_derive_attr: Attribute = syn::parse_quote! {
-				#[derive(#existing_derives)]
-			};
-
-			*derive_attr = new_derive_attr;
 		}
+
+		let new_derive_attr: Attribute = syn::parse_quote! {
+			#[derive(#existing_derives)]
+		};
+
+		*derive_attr = new_derive_attr;
 	} else {
 		// No derive attribute exists, so create one
 		let new_derive_attr: Attribute = syn::parse_quote!(#[derive(#(#derives_to_add),*)]);
@@ -783,16 +792,17 @@ fn account_impl(
 	item_struct.attrs.push(bytemuck_attr);
 
 	// Add discriminator field
-	if let Fields::Named(named_fields) = &mut item_struct.fields {
-		let discriminator_field = syn::parse_quote! {
-			discriminator: [u8; #discriminator::BYTES]
-		};
-		named_fields.named.insert(0, discriminator_field);
-	} else {
+	let Fields::Named(named_fields) = &mut item_struct.fields else {
 		return syn::Error::new_spanned(item_struct, "Account structs must have named fields")
 			.to_compile_error();
-	}
+	};
 
+	let discriminator_field = syn::parse_quote! {
+		discriminator: [u8; #discriminator::BYTES]
+	};
+	named_fields.named.insert(0, discriminator_field);
+
+	// Generate assertions
 	let assertions = if let Fields::Named(named_fields) = &item_struct.fields {
 		let field_assertions = named_fields.named.iter().map(|field| {
 			let field_name = field.ident.as_ref().unwrap();
@@ -822,6 +832,7 @@ fn account_impl(
 			"__{}_ALIGNMENT_ASSERTIONS__",
 			struct_name.to_string().to_uppercase()
 		);
+
 		quote! {
 			const #assertion_const_name: () = {
 				#(#field_assertions)*
@@ -1076,24 +1087,24 @@ fn instruction_impl(
 	args: proc_macro2::TokenStream,
 	input: proc_macro2::TokenStream,
 ) -> proc_macro2::TokenStream {
+	// Parse macro arguments
 	let nested_metas = match NestedMeta::parse_meta_list(args) {
 		Ok(value) => value,
-		Err(e) => {
-			return e.into_compile_error();
-		}
+		Err(e) => return e.into_compile_error(),
 	};
 
 	let args = match InstructionArgs::from_list(&nested_metas) {
 		Ok(v) => v,
-		Err(e) => {
-			return e.write_errors();
-		}
+		Err(e) => return e.write_errors(),
 	};
 
+	// Parse input struct
 	let mut item_struct: ItemStruct = match syn::parse2(input) {
 		Ok(v) => v,
 		Err(e) => return e.to_compile_error(),
 	};
+
+	// Extract configuration
 	let struct_name = &item_struct.ident;
 	let builder_name = format_ident!("{}Builder", struct_name);
 
@@ -1102,7 +1113,6 @@ fn instruction_impl(
 		discriminator,
 		variant,
 	} = args;
-
 	let variant = variant.unwrap_or(struct_name.clone());
 
 	// Add #[repr(C)]
@@ -1121,33 +1131,40 @@ fn instruction_impl(
 		syn::parse_quote!(::core::fmt::Debug),
 	];
 
-	if let Some(derive_attr) = item_struct
+	let derive_attr = item_struct
 		.attrs
 		.iter_mut()
-		.find(|attr| attr.path().is_ident("derive"))
-	{
+		.find(|attr| attr.path().is_ident("derive"));
+
+	if let Some(derive_attr) = derive_attr {
 		let existing_derives_result =
 			derive_attr.parse_args_with(Punctuated::<syn::Path, Token![,]>::parse_terminated);
 
-		if let Ok(mut existing_derives) = existing_derives_result {
-			let existing_derive_names: std::collections::HashSet<String> = existing_derives
-				.iter()
-				.map(|p| p.segments.last().unwrap().ident.to_string())
-				.collect();
+		let Ok(mut existing_derives) = existing_derives_result else {
+			// Failed to parse derives, create new one
+			let new_derive_attr: Attribute = syn::parse_quote!(#[derive(#(#derives_to_add),*)]);
+			item_struct.attrs.push(new_derive_attr);
 
-			for derive_to_add in &derives_to_add {
-				let to_add_name = derive_to_add.segments.last().unwrap().ident.to_string();
-				if !existing_derive_names.contains(&to_add_name) {
-					existing_derives.push(derive_to_add.clone());
-				}
+			return quote! { #item_struct };
+		};
+
+		let existing_derive_names: std::collections::HashSet<String> = existing_derives
+			.iter()
+			.map(|p| p.segments.last().unwrap().ident.to_string())
+			.collect();
+
+		for derive_to_add in &derives_to_add {
+			let to_add_name = derive_to_add.segments.last().unwrap().ident.to_string();
+			if !existing_derive_names.contains(&to_add_name) {
+				existing_derives.push(derive_to_add.clone());
 			}
-
-			let new_derive_attr: Attribute = syn::parse_quote! {
-				#[derive(#existing_derives)]
-			};
-
-			*derive_attr = new_derive_attr;
 		}
+
+		let new_derive_attr: Attribute = syn::parse_quote! {
+			#[derive(#existing_derives)]
+		};
+
+		*derive_attr = new_derive_attr;
 	} else {
 		// No derive attribute exists, so create one
 		let new_derive_attr: Attribute = syn::parse_quote!(#[derive(#(#derives_to_add),*)]);
@@ -1158,6 +1175,7 @@ fn instruction_impl(
 	let builder_attr: Attribute =
 		syn::parse_quote!(#[builder(builder_method(vis = "", name = __builder))]);
 	item_struct.attrs.push(builder_attr);
+
 	let bytemuck_crate_str = format!(
 		"{}::bytemuck",
 		quote!(#crate_path).to_string().replace(' ', "")
@@ -1166,16 +1184,17 @@ fn instruction_impl(
 	item_struct.attrs.push(bytemuck_attr);
 
 	// Add discriminator field
-	if let Fields::Named(named_fields) = &mut item_struct.fields {
-		let discriminator_field = syn::parse_quote! {
-			discriminator: [u8; #discriminator::BYTES]
-		};
-		named_fields.named.insert(0, discriminator_field);
-	} else {
+	let Fields::Named(named_fields) = &mut item_struct.fields else {
 		return syn::Error::new_spanned(item_struct, "Instruction structs must have named fields")
 			.to_compile_error();
-	}
+	};
 
+	let discriminator_field = syn::parse_quote! {
+		discriminator: [u8; #discriminator::BYTES]
+	};
+	named_fields.named.insert(0, discriminator_field);
+
+	// Generate assertions
 	let assertions = if let Fields::Named(named_fields) = &item_struct.fields {
 		let field_assertions = named_fields.named.iter().map(|field| {
 			let field_name = field.ident.as_ref().unwrap();
@@ -1205,6 +1224,7 @@ fn instruction_impl(
 			"__{}_ALIGNMENT_ASSERTIONS__",
 			struct_name.to_string().to_uppercase()
 		);
+
 		quote! {
 			const #assertion_const_name: () = {
 				#(#field_assertions)*
@@ -1246,7 +1266,6 @@ fn instruction_impl(
 		#assertions
 
 		impl #struct_name {
-
 			pub fn to_bytes(&self) -> &[u8] {
 				#crate_path::bytemuck::bytes_of(self)
 			}
@@ -1368,24 +1387,24 @@ fn event_impl(
 	args: proc_macro2::TokenStream,
 	input: proc_macro2::TokenStream,
 ) -> proc_macro2::TokenStream {
+	// Parse macro arguments
 	let nested_metas = match NestedMeta::parse_meta_list(args) {
 		Ok(value) => value,
-		Err(e) => {
-			return e.into_compile_error();
-		}
+		Err(e) => return e.into_compile_error(),
 	};
 
 	let args = match EventArgs::from_list(&nested_metas) {
 		Ok(v) => v,
-		Err(e) => {
-			return e.write_errors();
-		}
+		Err(e) => return e.write_errors(),
 	};
 
+	// Parse input struct
 	let mut item_struct: ItemStruct = match syn::parse2(input) {
 		Ok(v) => v,
 		Err(e) => return e.to_compile_error(),
 	};
+
+	// Extract configuration
 	let struct_name = &item_struct.ident;
 	let builder_name = format_ident!("{}Builder", struct_name);
 
@@ -1394,7 +1413,6 @@ fn event_impl(
 		discriminator,
 		variant,
 	} = args;
-
 	let variant = variant.unwrap_or(struct_name.clone());
 
 	// Add #[repr(C)]
@@ -1418,33 +1436,40 @@ fn event_impl(
 		syn::parse_quote!(::core::fmt::Debug),
 	];
 
-	if let Some(derive_attr) = item_struct
+	let derive_attr = item_struct
 		.attrs
 		.iter_mut()
-		.find(|attr| attr.path().is_ident("derive"))
-	{
+		.find(|attr| attr.path().is_ident("derive"));
+
+	if let Some(derive_attr) = derive_attr {
 		let existing_derives_result =
 			derive_attr.parse_args_with(Punctuated::<syn::Path, Token![,]>::parse_terminated);
 
-		if let Ok(mut existing_derives) = existing_derives_result {
-			let existing_derive_names: std::collections::HashSet<String> = existing_derives
-				.iter()
-				.map(|p| p.segments.last().unwrap().ident.to_string())
-				.collect();
+		let Ok(mut existing_derives) = existing_derives_result else {
+			// Failed to parse derives, create new one
+			let new_derive_attr: Attribute = syn::parse_quote!(#[derive(#(#derives_to_add),*)]);
+			item_struct.attrs.push(new_derive_attr);
 
-			for derive_to_add in &derives_to_add {
-				let to_add_name = derive_to_add.segments.last().unwrap().ident.to_string();
-				if !existing_derive_names.contains(&to_add_name) {
-					existing_derives.push(derive_to_add.clone());
-				}
+			return quote! { #item_struct };
+		};
+
+		let existing_derive_names: std::collections::HashSet<String> = existing_derives
+			.iter()
+			.map(|p| p.segments.last().unwrap().ident.to_string())
+			.collect();
+
+		for derive_to_add in &derives_to_add {
+			let to_add_name = derive_to_add.segments.last().unwrap().ident.to_string();
+			if !existing_derive_names.contains(&to_add_name) {
+				existing_derives.push(derive_to_add.clone());
 			}
-
-			let new_derive_attr: Attribute = syn::parse_quote! {
-				#[derive(#existing_derives)]
-			};
-
-			*derive_attr = new_derive_attr;
 		}
+
+		let new_derive_attr: Attribute = syn::parse_quote! {
+			#[derive(#existing_derives)]
+		};
+
+		*derive_attr = new_derive_attr;
 	} else {
 		// No derive attribute exists, so create one
 		let new_derive_attr: Attribute = syn::parse_quote!(#[derive(#(#derives_to_add),*)]);
@@ -1459,16 +1484,17 @@ fn event_impl(
 	item_struct.attrs.push(bytemuck_attr);
 
 	// Add discriminator field
-	if let Fields::Named(named_fields) = &mut item_struct.fields {
-		let discriminator_field = syn::parse_quote! {
-			discriminator: [u8; #discriminator::BYTES]
-		};
-		named_fields.named.insert(0, discriminator_field);
-	} else {
+	let Fields::Named(named_fields) = &mut item_struct.fields else {
 		return syn::Error::new_spanned(item_struct, "Event structs must have named fields")
 			.to_compile_error();
-	}
+	};
 
+	let discriminator_field = syn::parse_quote! {
+		discriminator: [u8; #discriminator::BYTES]
+	};
+	named_fields.named.insert(0, discriminator_field);
+
+	// Generate assertions
 	let assertions = if let Fields::Named(named_fields) = &item_struct.fields {
 		let field_assertions = named_fields.named.iter().map(|field| {
 			let field_name = field.ident.as_ref().unwrap();

--- a/crates/pina_profile/src/cost.rs
+++ b/crates/pina_profile/src/cost.rs
@@ -62,10 +62,10 @@ pub fn estimate_instruction_cu(instruction_bytes: &[u8; 8]) -> u64 {
 	let src_reg = instruction_bytes[1] >> 4;
 
 	if opcode == BPF_CALL_IMM && src_reg == 0 {
-		CU_PER_SYSCALL
-	} else {
-		CU_PER_INSTRUCTION
+		return CU_PER_SYSCALL;
 	}
+
+	CU_PER_INSTRUCTION
 }
 
 /// Per-function CU profile.

--- a/crates/pina_profile/src/elf.rs
+++ b/crates/pina_profile/src/elf.rs
@@ -42,6 +42,7 @@ pub struct ElfInfo {
 
 /// Parse an ELF binary and extract profiling-relevant information.
 pub fn parse_elf(data: &[u8], path: &Path) -> Result<ElfInfo, ProfileError> {
+	// Parse the ELF file
 	let obj = object::File::parse(data).map_err(|e| {
 		ProfileError::Elf {
 			path: path.to_path_buf(),
@@ -74,6 +75,7 @@ pub fn parse_elf(data: &[u8], path: &Path) -> Result<ElfInfo, ProfileError> {
 		}
 	})?;
 
+	// Extract section metadata
 	let text_vaddr = text_section.address();
 	let text_bytes = text_section.data().map_err(|e| {
 		ProfileError::Elf {
@@ -109,6 +111,7 @@ pub fn parse_elf(data: &[u8], path: &Path) -> Result<ElfInfo, ProfileError> {
 
 	symbols.sort_by_key(|s| s.address);
 
+	// Extract program name from path
 	let program_name = path
 		.file_stem()
 		.and_then(|s| s.to_str())

--- a/crates/pina_profile/src/lib.rs
+++ b/crates/pina_profile/src/lib.rs
@@ -24,6 +24,7 @@ pub use output::OutputFormat;
 /// Returns a [`ProfileError`] if the file cannot be read, is not a valid ELF,
 /// or contains no SBF text sections.
 pub fn profile_program(path: &Path) -> Result<ProgramProfile, ProfileError> {
+	// Read the binary file
 	let data = std::fs::read(path).map_err(|e| {
 		ProfileError::Io {
 			path: path.to_path_buf(),
@@ -31,8 +32,11 @@ pub fn profile_program(path: &Path) -> Result<ProgramProfile, ProfileError> {
 		}
 	})?;
 
+	// Parse ELF and analyze functions
 	let elf_info = elf::parse_elf(&data, path)?;
 	let functions = sbf::analyze_functions(&elf_info);
+
+	// Calculate totals
 	let total_instructions = functions.iter().map(|f| f.instruction_count).sum();
 	let total_syscalls = functions.iter().map(|f| f.syscall_count).sum();
 	let total_cu = functions.iter().map(|f| f.estimated_cu).sum();

--- a/crates/pina_profile/src/output.rs
+++ b/crates/pina_profile/src/output.rs
@@ -75,13 +75,15 @@ fn write_json(profile: &ProgramProfile, w: &mut dyn Write) -> Result<(), OutputE
 /// Truncate a function name to fit in a column, adding `..` if needed.
 fn truncate_name(name: &str, max_len: usize) -> String {
 	if name.len() <= max_len {
-		name.to_owned()
-	} else if max_len <= 2 {
-		name.chars().take(max_len).collect()
-	} else {
-		let truncated: String = name.chars().take(max_len - 2).collect();
-		format!("{truncated}..")
+		return name.to_owned();
 	}
+
+	if max_len <= 2 {
+		return name.chars().take(max_len).collect();
+	}
+
+	let truncated: String = name.chars().take(max_len - 2).collect();
+	format!("{truncated}..")
 }
 
 /// Errors during output formatting.

--- a/crates/pina_profile/src/sbf.rs
+++ b/crates/pina_profile/src/sbf.rs
@@ -55,10 +55,12 @@ fn estimate_range(text_bytes: &[u8], start: u64, size: u64) -> (u64, u64, u64) {
 pub fn analyze_functions(elf: &ElfInfo) -> Vec<FunctionProfile> {
 	let text_len = elf.text_bytes.len() as u64;
 
+	// Handle empty text section
 	if text_len == 0 {
 		return vec![];
 	}
 
+	// No symbols: report entire text as a single function
 	if elf.symbols.is_empty() {
 		let (instruction_count, syscall_count, estimated_cu) =
 			estimate_range(&elf.text_bytes, 0, text_len);
@@ -75,6 +77,7 @@ pub fn analyze_functions(elf: &ElfInfo) -> Vec<FunctionProfile> {
 	let mut functions = Vec::new();
 	let mut covered_up_to: u64 = 0;
 
+	// Process each symbol in address order
 	for (i, sym) in elf.symbols.iter().enumerate() {
 		let sym_offset = sym.address.saturating_sub(elf.text_vaddr);
 
@@ -143,6 +146,7 @@ pub fn analyze_functions(elf: &ElfInfo) -> Vec<FunctionProfile> {
 		}
 	}
 
+	// Sort by estimated CU (highest first)
 	functions.sort_by_key(|f| Reverse(f.estimated_cu));
 
 	functions

--- a/crates/pina_sdk_ids/src/lib.rs
+++ b/crates/pina_sdk_ids/src/lib.rs
@@ -3,8 +3,6 @@
 //! Each sub-module declares a single `ID` constant via
 //! [`solana_address::declare_id!`]. Import the module and use `module::ID` to
 //! reference the address.
-//! Each module below declares a canonical Solana `ID` constant using
-//! `solana_address::declare_id!`.
 
 #![no_std]
 

--- a/docs/agents/coding-style.md
+++ b/docs/agents/coding-style.md
@@ -1,0 +1,449 @@
+# Pina Coding Style Guide
+
+This guide defines the visual organization and aesthetic patterns for the Pina codebase. It complements the automated formatters (`dprint`, `rustfmt`) and focuses on readability, maintainability, and consistency.
+
+## Philosophy
+
+**Simple code is better than complex code.**
+
+Code is read far more often than it is written. Optimize for the reader.
+
+- Choose solutions with fewer lines and less nesting
+- Use early returns to avoid deep indentation
+- Group related operations and separate them with blank lines
+- Explain _why_, not _what_ (the code itself should be clear)
+
+## Language Standards
+
+### Rust
+
+- **Edition**: 2024
+- **Formatter**: `rustfmt` with `rustfmt.toml` configuration
+- **Style Edition**: 2024
+- **Tabs**: Hard tabs (indent width: 2 for dprint, configured in rustfmt)
+- **Max Width**: 100 characters
+
+### TypeScript/JavaScript
+
+- **Formatter**: dprint with TypeScript plugin
+- **Tabs**: Hard tabs
+- **Quote Style**: Double quotes
+- **Semicolons**: Always
+
+## Core Principles
+
+### 1. Whitespace Is Semantics
+
+Blank lines separate concepts and give the reader time to breathe.
+
+**Rules:**
+
+- Add blank lines before control flow statements (`if`, `match`, `for`, `while`)
+- Group related operations, separate groups with blank lines
+- Add blank lines after complex declarations
+- Add blank lines before return statements (unless it's the immediate next line)
+
+```rust
+// Good: Logical grouping with breathing room
+fn process_instruction(accounts: &[AccountView], data: &[u8]) -> ProgramResult {
+	// Group 1: Parse and validate instruction discriminator
+	let disc = parse_instruction(&ID, program_id, data)?;
+
+	// Group 2: Route to appropriate handler
+	match disc {
+		Instruction::Initialize => initialize(accounts, data),
+		Instruction::Update => update(accounts, data),
+	}
+}
+```
+
+### 2. Early Returns Over Deep Nesting
+
+Indentation is a code smell. Prefer guard clauses and early returns.
+
+**Maximum nesting depth**: 2-3 levels. If you exceed this, refactor.
+
+```rust
+// Avoid: Deep nesting
+fn validate(account: &AccountView) -> Result<&AccountView, ProgramError> {
+	if account.is_signer() {
+		if account.is_writable() {
+			if account.data_len() > 0 {
+				Ok(account)
+			} else {
+				Err(ProgramError::InvalidAccountData)
+			}
+		} else {
+			Err(ProgramError::InvalidAccountData)
+		}
+	} else {
+		Err(ProgramError::MissingRequiredSignature)
+	}
+}
+
+// Prefer: Early returns with guard clauses
+fn validate(account: &AccountView) -> Result<&AccountView, ProgramError> {
+	if !account.is_signer() {
+		return Err(ProgramError::MissingRequiredSignature);
+	}
+
+	if !account.is_writable() {
+		return Err(ProgramError::InvalidAccountData);
+	}
+
+	if account.data_len() == 0 {
+		return Err(ProgramError::InvalidAccountData);
+	}
+
+	Ok(account)
+}
+```
+
+### 3. Variables at the Top
+
+Declare variables and constants at the start of functions when possible.
+
+```rust
+fn configure_server(config: &Config) -> Server {
+	// Configuration extraction
+	let port = config.port;
+	let timeout = config.timeout_secs;
+	let max_connections = config.max_connections;
+
+	// Security settings
+	let require_tls = config.environment == Environment::Production;
+
+	// Build and return
+	Server::builder()
+		.port(port)
+		.timeout(timeout)
+		.max_connections(max_connections)
+		.tls(require_tls)
+		.build()
+}
+```
+
+**Exception**: When a variable's value depends on prior computation, declare it near where it's computed.
+
+### 4. Extraction Over Nesting
+
+When logic becomes complex, extract it into smaller, focused functions.
+
+```rust
+// Avoid: Complex nested logic
+fn process_data(data: Data) -> Result {
+	if let Some(items) = data.items {
+		for item in items {
+			if item.is_active {
+				// 20 lines of complex processing...
+			}
+		}
+	}
+}
+
+// Prefer: Extract into focused functions
+fn process_data(data: Data) -> Result {
+	let active_items = data.active_items()?;
+
+	for item in active_items {
+		process_active_item(item)?;
+	}
+
+	Ok(())
+}
+
+fn process_active_item(item: &Item) -> Result {
+	// 20 lines of focused processing...
+}
+```
+
+### 5. Comments Explain Why, Not What
+
+Comments should explain **why** code exists, not **what** it does.
+
+```rust
+// Avoid: Commenting the obvious
+// Add 1 to the counter
+let counter = counter + 1;
+
+// Prefer: Explain why
+// Increment counter to track unique visitors (resets daily)
+let counter = counter + 1;
+```
+
+**Exception**: When security or performance requires non-obvious code, explain both:
+
+```rust
+// Security: Constant-time comparison to prevent timing attacks
+// We compare every byte regardless of mismatches to ensure
+// the operation takes the same time regardless of where the
+// first difference occurs
+if !constant_time_eq(provided_hash, stored_hash) {
+	return Err(Error::InvalidCredentials);
+}
+```
+
+### 6. Safety Comments for Unsafe Code
+
+All `unsafe` blocks require a `// SAFETY:` comment explaining why the operation is safe.
+
+```rust
+// SAFETY: `try_borrow` yields a guard-backed slice of the account data.
+// We rebuild a raw-parts slice from the same pointer with exactly
+// `size_of::<T>()` bytes, which is guaranteed by `assert_data_len` above.
+unsafe {
+	T::try_from_bytes(from_raw_parts(self.try_borrow()?.as_ptr(), size_of::<T>()))
+}
+```
+
+## Rust-Specific Patterns
+
+### Import Organization
+
+Imports are grouped and sorted by `rustfmt`:
+
+```rust
+// 1. Standard library imports
+use std::collections::HashMap;
+use std::path::Path;
+
+// 2. External crate imports
+use bytemuck::Pod;
+use pinocchio::ProgramResult;
+
+// 3. Internal crate imports
+use crate::AccountView;
+use crate::Address;
+use crate::ProgramError;
+```
+
+### Error Handling
+
+Always use `?` for propagation. Avoid `unwrap()` and `expect()` in production code.
+
+```rust
+// Good
+let data = account.try_borrow()?;
+let parsed = parse_data(&data)?;
+
+// Avoid
+let data = account.try_borrow().unwrap();
+```
+
+### Type Conversions
+
+Use explicit conversion functions and avoid implicit casts.
+
+```rust
+// Good
+let value = PodU64::from_primitive(100u64);
+let native: u64 = value.into();
+
+// Avoid
+let value = PodU64::from(100); // Ambiguous
+```
+
+### Trait Implementations
+
+Group trait implementations together. Use blank lines between different trait implementations.
+
+```rust
+impl AccountInfoValidation for AccountView {
+	// methods...
+}
+
+impl AsAccount for AccountView {
+	// methods...
+}
+```
+
+### Constants and Statics
+
+Use `SCREAMING_SNAKE_CASE` for constants. Define them near their usage when module-scoped, or at the top of the file when crate-scoped.
+
+```rust
+/// Maximum number of bytes for a discriminator.
+pub const MAX_DISCRIMINATOR_SPACE: usize = 8;
+
+/// Known program addresses for default value resolution.
+const KNOWN_ADDRESSES: &[(&str, &str)] = &[
+	("system::ID", "11111111111111111111111111111111"),
+	("token::ID", "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"),
+];
+```
+
+### Macro Definitions
+
+Document macros with usage examples. Keep macro logic as simple as possible.
+
+````rust
+/// Sets up a `no_std` Solana program entrypoint.
+///
+/// # Usage
+///
+/// ```ignore
+/// nostd_entrypoint!(process_instruction);
+/// ```
+#[macro_export]
+macro_rules! nostd_entrypoint {
+	($process_instruction:expr) => {
+		// ...
+	};
+}
+````
+
+## Documentation Standards
+
+### Module Documentation
+
+Every module should start with a module-level doc comment explaining its purpose.
+
+```rust
+//! CPI and account-allocation helpers used by on-chain instruction handlers.
+//!
+//! These utilities wrap common system-program patterns with consistent
+//! `ProgramError` behavior and PDA signing. All APIs are designed for
+//! on-chain determinism.
+```
+
+### Function Documentation
+
+Use doc comments (`///`) for all public APIs:
+
+````rust
+/// Creates a new PDA-backed program account and returns `(address, bump)`.
+///
+/// This helper derives the canonical PDA for `seeds` + `owner`, allocates
+/// account storage for `T`, and assigns account ownership to `owner`.
+///
+/// # Errors
+///
+/// Returns `InvalidSeeds` when no valid PDA can be derived, plus any errors
+/// from allocation/assignment steps.
+///
+/// # Examples
+///
+/// ```ignore
+/// let seeds: &[&[u8]] = &[b"escrow", authority.address().as_ref()];
+/// let (address, bump) =
+///     create_program_account::<EscrowState>(escrow_account, payer, &program_id, seeds)?;
+/// ```
+pub fn create_program_account<'a, T: HasDiscriminator + Pod>(// ...)
+ -> Result<(Address, u8), ProgramError> {
+	// ...
+}
+````
+
+### Documentation Sections
+
+Use standardized documentation patterns for common sections:
+
+- `# Errors` - Document possible error conditions
+- `# Examples` - Include usage examples (use `ignore` for code that won't compile in docs)
+- `# Safety` - Required for unsafe functions
+- `# Panics` - Document when the function might panic
+
+## Testing Patterns
+
+### Test Organization
+
+Place tests in a `#[cfg(test)]` module at the end of the file.
+
+```rust
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn parses_valid_instruction() {
+		// ...
+	}
+
+	#[test]
+	fn rejects_invalid_discriminator() {
+		// ...
+	}
+}
+```
+
+### Test Naming
+
+Use descriptive snake_case names that explain what is being tested.
+
+```rust
+// Good
+#[test]
+fn account_deserialize_rejects_wrong_discriminator() {}
+
+// Avoid
+#[test]
+fn test_account() {}
+```
+
+## Formatter Integration
+
+This style guide complements automated formatters. Always run the formatter after editing:
+
+```bash
+# Format all files
+dprint fmt
+
+# Or for specific files
+dprint fmt <file-path>
+```
+
+### Pre-commit Checklist
+
+1. **Format**: Run `dprint fmt` on all modified files
+2. **Lint**: Run `cargo clippy --fix` and address remaining warnings
+3. **Test**: Run `cargo test` to ensure changes don't break tests
+
+## Language-Specific Formatting
+
+### Rust Formatting
+
+The project uses `rustfmt.toml` with these key settings:
+
+- `hard_tabs = true` - Use tabs for indentation
+- `max_width = 100` - Wrap lines at 100 characters
+- `imports_granularity = "Item"` - One import per line
+- `group_imports = "StdExternalCrate"` - Group imports by category
+- `format_code_in_doc_comments = true` - Format code in docs
+- `wrap_comments = false` - Don't wrap comments
+
+### TypeScript/JavaScript Formatting
+
+The project uses dprint with these settings:
+
+- `useTabs: true` - Use tabs for indentation
+- `quoteStyle: "alwaysDouble"` - Use double quotes
+- `semiColons: "always"` - Always use semicolons
+
+## No-Std Considerations
+
+All on-chain code must be `no_std` compatible:
+
+```rust
+#![no_std]
+
+// Use core instead of std
+use core::mem::size_of;
+
+// Use alloc for collections when needed
+extern crate alloc;
+use alloc::vec::Vec;
+```
+
+## Summary
+
+| Principle      | Rule                                            | Exception                                 |
+| -------------- | ----------------------------------------------- | ----------------------------------------- |
+| **Simplicity** | Choose simpler solutions                        | Security/performance requires complexity  |
+| **Whitespace** | Blank lines before control flow, between groups | Short, tightly-coupled operations         |
+| **Nesting**    | Max 2-3 levels deep                             | Language idioms require it                |
+| **Comments**   | Explain why, not what                           | Security/performance requires explanation |
+| **Extraction** | Break complex logic into functions              | Hurts performance                         |
+| **Formatting** | Run `dprint fmt` after every edit               | N/A - Always run it                       |
+| **Linting**    | Run `cargo clippy`, fix all warnings            | Only skip if very slow                    |
+
+**Remember**: Code is read far more often than it is written. Optimize for the reader.

--- a/docs/agents/coding-style.md
+++ b/docs/agents/coding-style.md
@@ -1,6 +1,6 @@
 # Pina Coding Style Guide
 
-This guide defines the visual organization and aesthetic patterns for the Pina codebase. It complements the automated formatters (`dprint`, `rustfmt`) and focuses on readability, maintainability, and consistency.
+This guide defines the visual organization and aesthetic patterns for the Pina codebase. It complements the automated formatting workflow (`fix:format`, `dprint fmt`) and focuses on readability, maintainability, and consistency.
 
 ## Philosophy
 
@@ -18,7 +18,7 @@ Code is read far more often than it is written. Optimize for the reader.
 ### Rust
 
 - **Edition**: 2024
-- **Formatter**: `rustfmt` with `rustfmt.toml` configuration
+- **Formatter**: `fix:format` or `dprint fmt` (do not run `rustfmt` directly)
 - **Style Edition**: 2024
 - **Tabs**: Hard tabs (indent width: 2 for dprint, configured in rustfmt)
 - **Max Width**: 100 characters
@@ -402,7 +402,7 @@ dprint fmt <file-path>
 
 ### Rust Formatting
 
-The project uses `rustfmt.toml` with these key settings:
+The project uses `rustfmt.toml` settings through the repository formatting workflow:
 
 - `hard_tabs = true` - Use tabs for indentation
 - `max_width = 100` - Wrap lines at 100 characters

--- a/examples/anchor_declare_program/src/lib.rs
+++ b/examples/anchor_declare_program/src/lib.rs
@@ -53,6 +53,7 @@ impl<'a> ProcessAccountInfos<'a> for ValidateExternalProgramAccounts<'a> {
 
 		self.authority.assert_signer()?;
 		assert_external_program_id(self.external_program.address())?;
+
 		self.external_program
 			.assert_address(&external::ID)?
 			.assert_executable()?;

--- a/examples/anchor_duplicate_mutable_accounts/src/lib.rs
+++ b/examples/anchor_duplicate_mutable_accounts/src/lib.rs
@@ -62,8 +62,10 @@ fn ensure_distinct(account1: &Address, account2: &Address) -> ProgramResult {
 impl<'a> ProcessAccountInfos<'a> for DuplicateMutableAccounts<'a> {
 	fn process(&self, data: &[u8]) -> ProgramResult {
 		let _ = FailsDuplicateMutableInstruction::try_from_bytes(data)?;
+
 		self.account1.assert_writable()?;
 		self.account2.assert_writable()?;
+
 		ensure_distinct(self.account1.address(), self.account2.address())
 	}
 }
@@ -93,10 +95,12 @@ pub mod entrypoint {
 			DuplicateMutableInstruction::FailsDuplicateMutable => {
 				DuplicateMutableAccounts::try_from(accounts)?.process(data)
 			}
+
 			DuplicateMutableInstruction::AllowsDuplicateMutable => {
 				let _ = AllowsDuplicateMutableInstruction::try_from_bytes(data)?;
 				Ok(())
 			}
+
 			DuplicateMutableInstruction::AllowsDuplicateReadonly => {
 				DuplicateReadonlyAccounts::try_from(accounts)?.process(data)
 			}

--- a/examples/anchor_errors/src/lib.rs
+++ b/examples/anchor_errors/src/lib.rs
@@ -67,6 +67,7 @@ fn require_eq(left: u64, right: u64, error: MyError) -> ProgramResult {
 	if left != right {
 		return Err(error.into());
 	}
+
 	Ok(())
 }
 
@@ -75,6 +76,7 @@ fn require_neq(left: u64, right: u64, error: MyError) -> ProgramResult {
 	if left == right {
 		return Err(error.into());
 	}
+
 	Ok(())
 }
 
@@ -83,6 +85,7 @@ fn require_gt(left: u64, right: u64, error: MyError) -> ProgramResult {
 	if left <= right {
 		return Err(error.into());
 	}
+
 	Ok(())
 }
 
@@ -91,6 +94,7 @@ fn require_gte(left: u64, right: u64, error: MyError) -> ProgramResult {
 	if left < right {
 		return Err(error.into());
 	}
+
 	Ok(())
 }
 

--- a/examples/anchor_events/src/lib.rs
+++ b/examples/anchor_events/src/lib.rs
@@ -78,6 +78,7 @@ fn build_event(instruction: EventsInstruction) -> EmittedEvent {
 					.build(),
 			)
 		}
+
 		EventsInstruction::TestEvent => {
 			EmittedEvent::MyOtherEvent(
 				MyOtherEvent::builder()
@@ -86,6 +87,7 @@ fn build_event(instruction: EventsInstruction) -> EmittedEvent {
 					.build(),
 			)
 		}
+
 		EventsInstruction::TestEventCpi => {
 			EmittedEvent::MyOtherEvent(
 				MyOtherEvent::builder()

--- a/examples/anchor_floats/src/lib.rs
+++ b/examples/anchor_floats/src/lib.rs
@@ -83,6 +83,7 @@ fn apply_update(
 
 	account.data_f32 = PodU32::from_primitive(data_f32.to_bits());
 	account.data_f64 = PodU64::from_primitive(data_f64.to_bits());
+
 	Ok(())
 }
 

--- a/examples/anchor_realloc/src/lib.rs
+++ b/examples/anchor_realloc/src/lib.rs
@@ -60,6 +60,7 @@ pub struct Realloc2Accounts<'a> {
 fn validate_realloc_delta(current_len: usize, new_len: usize) -> ProgramResult {
 	if new_len > current_len {
 		let delta = new_len - current_len;
+
 		if delta > MAX_PERMITTED_DATA_INCREASE {
 			return Err(ReallocError::AccountReallocExceedsLimit.into());
 		}
@@ -86,6 +87,7 @@ impl<'a> ProcessAccountInfos<'a> for ReallocAccounts<'a> {
 		self.system_program.assert_address(&system::ID)?;
 
 		validate_realloc_delta(self.sample.data_len(), target_len)?;
+
 		self.sample.resize(target_len)
 	}
 }
@@ -108,6 +110,7 @@ impl<'a> ProcessAccountInfos<'a> for Realloc2Accounts<'a> {
 		validate_realloc_delta(self.sample2.data_len(), second_target_len)?;
 
 		self.sample1.resize(base_len)?;
+
 		self.sample2.resize(second_target_len)
 	}
 }
@@ -125,6 +128,7 @@ pub mod entrypoint {
 		data: &[u8],
 	) -> ProgramResult {
 		let instruction: ReallocInstruction = parse_instruction(program_id, &ID, data)?;
+
 		match instruction {
 			ReallocInstruction::Realloc => ReallocAccounts::try_from(accounts)?.process(data),
 			ReallocInstruction::Realloc2 => Realloc2Accounts::try_from(accounts)?.process(data),

--- a/examples/anchor_system_accounts/src/lib.rs
+++ b/examples/anchor_system_accounts/src/lib.rs
@@ -53,6 +53,7 @@ pub mod entrypoint {
 		data: &[u8],
 	) -> ProgramResult {
 		let instruction: SystemAccountsInstruction = parse_instruction(program_id, &ID, data)?;
+
 		match instruction {
 			SystemAccountsInstruction::Initialize => {
 				InitializeAccounts::try_from(accounts)?.process(data)
@@ -85,6 +86,7 @@ mod tests {
 		let wrong_program_id: Address = [9u8; 32].into();
 		let data = [SystemAccountsInstruction::Initialize as u8];
 		let result = parse_instruction::<SystemAccountsInstruction>(&wrong_program_id, &ID, &data);
+
 		assert!(matches!(result, Err(ProgramError::IncorrectProgramId)));
 	}
 

--- a/examples/counter_program/src/lib.rs
+++ b/examples/counter_program/src/lib.rs
@@ -172,33 +172,21 @@ pub struct IncrementAccounts<'a> {
 
 impl<'a> ProcessAccountInfos<'a> for InitializeAccounts<'a> {
 	fn process(&self, data: &[u8]) -> ProgramResult {
+		// Parse instruction and prepare PDA seeds
 		let args = InitializeInstruction::try_from_bytes(data)?;
 		let authority_key = self.authority.address();
-
-		// Build the PDA seeds with the bump from instruction data.
 		let seeds = counter_seeds!(authority_key.as_ref());
 		let seeds_with_bump = counter_seeds!(authority_key.as_ref(), args.bump);
 
-		// --- Validate accounts ---
-
-		// The authority must sign the transaction and is the rent payer.
+		// Validate accounts
 		self.authority.assert_signer()?;
-
-		// The counter account must be empty (not yet allocated) and writable.
-		// We also verify the PDA derivation matches the expected seeds + bump.
 		self.counter
 			.assert_empty()?
 			.assert_writable()?
 			.assert_seeds_with_bump(seeds_with_bump, &ID)?;
-
-		// Verify the system program address.
 		self.system_program.assert_address(&system::ID)?;
 
-		// --- Create the PDA account ---
-
-		// `create_program_account_with_bump` issues a `CreateAccount` CPI
-		// to the system program, allocating `size_of::<CounterState>()` bytes
-		// and assigning ownership to this program.
+		// Create the PDA account
 		create_program_account_with_bump::<CounterState>(
 			self.counter,
 			self.authority,
@@ -207,10 +195,7 @@ impl<'a> ProcessAccountInfos<'a> for InitializeAccounts<'a> {
 			args.bump,
 		)?;
 
-		// --- Initialize account data ---
-
-		// `as_account_mut` deserializes the raw account bytes into a mutable
-		// reference to `CounterState`, verifying the owner and discriminator.
+		// Initialize account data
 		let counter = self.counter.as_account_mut::<CounterState>(&ID)?;
 		*counter = CounterState::builder()
 			.bump(args.bump)
@@ -225,36 +210,30 @@ impl<'a> ProcessAccountInfos<'a> for InitializeAccounts<'a> {
 
 impl<'a> ProcessAccountInfos<'a> for IncrementAccounts<'a> {
 	fn process(&self, data: &[u8]) -> ProgramResult {
-		// Validate the instruction discriminator.
+		// Validate instruction discriminator
 		let _ = IncrementInstruction::try_from_bytes(data)?;
 
-		// --- Validate accounts ---
-
-		// The authority must sign to prove they own this counter.
+		// Validate accounts
 		self.authority.assert_signer()?;
 
-		// The counter must exist, be writable, be the correct type, and
-		// derive from the expected PDA seeds.
 		let authority_key = self.authority.address();
 		self.counter
 			.assert_not_empty()?
 			.assert_writable()?
 			.assert_type::<CounterState>(&ID)?;
 
-		// Read the current state to get the bump for seed verification.
 		let counter = self.counter.as_account::<CounterState>(&ID)?;
 		let seeds_with_bump = counter_seeds!(authority_key.as_ref(), counter.bump);
 		self.counter.assert_seeds_with_bump(seeds_with_bump, &ID)?;
 
-		// --- Mutate state ---
-
+		// Mutate state
 		let counter = self.counter.as_account_mut::<CounterState>(&ID)?;
 		let current: u64 = counter.count.into();
-		counter.count = PodU64::from_primitive(
-			current
-				.checked_add(1)
-				.ok_or(ProgramError::ArithmeticOverflow)?,
-		);
+		let next = current
+			.checked_add(1)
+			.ok_or(ProgramError::ArithmeticOverflow)?;
+
+		counter.count = PodU64::from_primitive(next);
 
 		log!("Counter incremented");
 

--- a/examples/escrow_program/src/lib.rs
+++ b/examples/escrow_program/src/lib.rs
@@ -128,12 +128,13 @@ macro_rules! seeds_escrow {
 
 impl<'a> ProcessAccountInfos<'a> for MakeAccounts<'a> {
 	fn process(&self, data: &[u8]) -> ProgramResult {
+		// Parse instruction and prepare PDA seeds
 		let args = MakeInstruction::try_from_bytes(data)?;
 		let escrow_seeds = seeds_escrow!(self.maker.address().as_ref(), &args.seed.0);
 		let escrow_seeds_with_bump =
 			seeds_escrow!(self.maker.address().as_ref(), &args.seed.0, args.bump);
 
-		// assertions
+		// Validate accounts
 		self.token_program.assert_addresses(&SPL_PROGRAM_IDS)?;
 		self.system_program.assert_address(&system::ID)?;
 		self.maker.assert_signer()?;
@@ -157,7 +158,7 @@ impl<'a> ProcessAccountInfos<'a> for MakeAccounts<'a> {
 				self.token_program.address(),
 			)?;
 
-		// create the program account
+		// Create the escrow account
 		create_program_account_with_bump::<EscrowState>(
 			self.escrow,
 			self.maker,
@@ -166,6 +167,7 @@ impl<'a> ProcessAccountInfos<'a> for MakeAccounts<'a> {
 			args.bump,
 		)?;
 
+		// Initialize escrow state
 		let escrow = self.escrow.as_account_mut::<EscrowState>(&ID)?;
 		*escrow = EscrowState::builder()
 			.maker(*self.maker.address())
@@ -177,6 +179,7 @@ impl<'a> ProcessAccountInfos<'a> for MakeAccounts<'a> {
 			.bump(args.bump)
 			.build();
 
+		// Create the vault token account
 		associated_token_account::instructions::Create {
 			account: self.vault,
 			funding_account: self.maker,
@@ -187,6 +190,7 @@ impl<'a> ProcessAccountInfos<'a> for MakeAccounts<'a> {
 		}
 		.invoke()?;
 
+		// Transfer tokens to vault
 		let decimals = self.mint_a.as_token_mint()?.decimals();
 		token_2022::instructions::TransferChecked {
 			from: self.maker_ata_a,
@@ -220,12 +224,14 @@ pub struct TakeAccounts<'a> {
 
 impl<'a> ProcessAccountInfos<'a> for TakeAccounts<'a> {
 	fn process(&self, data: &[u8]) -> ProgramResult {
-		// Validate the discriminator; TakeInstruction has no payload fields.
+		// Parse instruction data
 		let _ = TakeInstruction::try_from_bytes(data)?;
 
-		// -- assertions --
+		// Validate program accounts
 		self.token_program.assert_addresses(&SPL_PROGRAM_IDS)?;
 		self.system_program.assert_address(&system::ID)?;
+
+		// Validate taker accounts
 		self.taker.assert_signer()?.assert_writable()?;
 		self.taker_ata_a
 			.assert_owners(&SPL_PROGRAM_IDS)?
@@ -243,6 +249,8 @@ impl<'a> ProcessAccountInfos<'a> for TakeAccounts<'a> {
 				self.mint_b.address(),
 				self.token_program.address(),
 			)?;
+
+		// Validate escrow state
 		self.escrow
 			.assert_not_empty()?
 			.assert_writable()?
@@ -257,10 +265,12 @@ impl<'a> ProcessAccountInfos<'a> for TakeAccounts<'a> {
 			bump,
 			..
 		} = self.escrow.as_account::<EscrowState>(&ID)?;
-		let escrow_seeds_with_bump = seeds_escrow!(self.maker.address().as_ref(), &seed.0, *bump);
 
+		let escrow_seeds_with_bump = seeds_escrow!(self.maker.address().as_ref(), &seed.0, *bump);
 		self.escrow
 			.assert_seeds_with_bump(escrow_seeds_with_bump, &ID)?;
+
+		// Validate maker and mint accounts
 		self.maker.assert_address(maker)?;
 		self.mint_a
 			.assert_owners(&SPL_PROGRAM_IDS)?
@@ -269,6 +279,7 @@ impl<'a> ProcessAccountInfos<'a> for TakeAccounts<'a> {
 			.assert_owners(&SPL_PROGRAM_IDS)?
 			.assert_address(mint_b)?;
 
+		// Validate vault and maker ATA
 		self.vault
 			.assert_not_empty()?
 			.assert_writable()?
@@ -286,7 +297,7 @@ impl<'a> ProcessAccountInfos<'a> for TakeAccounts<'a> {
 				self.token_program.address(),
 			)?;
 
-		// create token account if none exists
+		// Create maker's token B account if needed
 		associated_token_account::instructions::CreateIdempotent {
 			funding_account: self.taker,
 			account: self.maker_ata_b,
@@ -297,6 +308,7 @@ impl<'a> ProcessAccountInfos<'a> for TakeAccounts<'a> {
 		}
 		.invoke()?;
 
+		// Transfer token B from taker to maker
 		token_2022::instructions::TransferChecked {
 			from: self.taker_ata_b,
 			mint: self.mint_b,
@@ -308,12 +320,14 @@ impl<'a> ProcessAccountInfos<'a> for TakeAccounts<'a> {
 		}
 		.invoke()?;
 
+		// Prepare escrow signer for vault operations
 		let bump_as_seeds = [*bump];
 		let escrow_seeds =
 			seeds_escrow!(true, self.maker.address().as_ref(), &seed.0, &bump_as_seeds);
 		let escrow_signer = Signer::from(&escrow_seeds);
 		let signers = [escrow_signer];
 
+		// Transfer token A from vault to taker
 		token_2022::instructions::TransferChecked {
 			from: self.vault,
 			mint: self.mint_a,
@@ -324,6 +338,8 @@ impl<'a> ProcessAccountInfos<'a> for TakeAccounts<'a> {
 			token_program: self.token_program.address(),
 		}
 		.invoke_signed(&signers)?;
+
+		// Close vault account
 		token_2022::instructions::CloseAccount {
 			account: self.vault,
 			destination: self.maker,
@@ -332,9 +348,8 @@ impl<'a> ProcessAccountInfos<'a> for TakeAccounts<'a> {
 		}
 		.invoke_signed(&signers)?;
 
-		{
-			self.escrow.as_account_mut::<EscrowState>(&ID)?.zeroed();
-		}
+		// Zero out escrow state and close
+		self.escrow.as_account_mut::<EscrowState>(&ID)?.zeroed();
 
 		self.escrow.close_with_recipient(self.maker)
 	}

--- a/examples/pina_bpf/src/lib.rs
+++ b/examples/pina_bpf/src/lib.rs
@@ -46,6 +46,7 @@ pub mod entrypoint {
 		instruction_data: &[u8],
 	) -> ProgramResult {
 		let instruction: PinaBpfInstruction = parse_instruction(program_id, &ID, instruction_data)?;
+
 		match instruction {
 			PinaBpfInstruction::Hello => process_hello(instruction_data),
 		}

--- a/examples/role_registry_program/src/lib.rs
+++ b/examples/role_registry_program/src/lib.rs
@@ -40,13 +40,17 @@ pub mod entrypoint {
 			RegistryInstruction::Initialize => {
 				InitializeAccounts::try_from(accounts)?.process(data)
 			}
+
 			RegistryInstruction::AddRole => AddRoleAccounts::try_from(accounts)?.process(data),
+
 			RegistryInstruction::UpdateRole => {
 				UpdateRoleAccounts::try_from(accounts)?.process(data)
 			}
+
 			RegistryInstruction::DeactivateRole => {
 				DeactivateRoleAccounts::try_from(accounts)?.process(data)
 			}
+
 			RegistryInstruction::RotateAdmin => {
 				RotateAdminAccounts::try_from(accounts)?.process(data)
 			}
@@ -234,6 +238,7 @@ impl<'a> ProcessAccountInfos<'a> for AddRoleAccounts<'a> {
 
 		let registry_config = self.registry_config.as_account::<RegistryConfig>(&ID)?;
 		self.admin.assert_address(&registry_config.admin)?;
+
 		create_program_account_with_bump::<RoleEntry>(
 			self.role_entry,
 			self.admin,
@@ -245,6 +250,7 @@ impl<'a> ProcessAccountInfos<'a> for AddRoleAccounts<'a> {
 		let role_count = u64::from(registry_config.role_count)
 			.checked_add(1)
 			.ok_or(ProgramError::ArithmeticOverflow)?;
+
 		let role_entry = self.role_entry.as_account_mut::<RoleEntry>(&ID)?;
 		*role_entry = RoleEntry::builder()
 			.registry(*self.registry_config.address())
@@ -265,6 +271,7 @@ impl<'a> ProcessAccountInfos<'a> for AddRoleAccounts<'a> {
 impl<'a> ProcessAccountInfos<'a> for UpdateRoleAccounts<'a> {
 	fn process(&self, data: &[u8]) -> ProgramResult {
 		let args = UpdateRoleInstruction::try_from_bytes(data)?;
+
 		self.admin.assert_signer()?;
 		self.registry_config
 			.assert_not_empty()?
@@ -277,16 +284,20 @@ impl<'a> ProcessAccountInfos<'a> for UpdateRoleAccounts<'a> {
 
 		let registry_config = self.registry_config.as_account::<RegistryConfig>(&ID)?;
 		let role_entry = self.role_entry.as_account::<RoleEntry>(&ID)?;
+
 		self.admin.assert_address(&registry_config.admin)?;
+
 		if !bool::from(role_entry.active) {
 			return Err(RegistryError::RoleInactive.into());
 		}
+
 		if role_entry.registry != *self.registry_config.address() {
 			return Err(RegistryError::InvalidPermissions.into());
 		}
 
 		let role_entry = self.role_entry.as_account_mut::<RoleEntry>(&ID)?;
 		role_entry.permissions = args.permissions;
+
 		Ok(())
 	}
 }
@@ -305,16 +316,20 @@ impl<'a> ProcessAccountInfos<'a> for DeactivateRoleAccounts<'a> {
 
 		let registry_config = self.registry_config.as_account::<RegistryConfig>(&ID)?;
 		let role_entry = self.role_entry.as_account::<RoleEntry>(&ID)?;
+
 		self.admin.assert_address(&registry_config.admin)?;
+
 		if role_entry.registry != *self.registry_config.address() {
 			return Err(RegistryError::InvalidPermissions.into());
 		}
+
 		if !bool::from(role_entry.active) {
 			return Err(RegistryError::RoleInactive.into());
 		}
 
 		let role_entry = self.role_entry.as_account_mut::<RoleEntry>(&ID)?;
 		role_entry.active = PodBool::from_bool(false);
+
 		Ok(())
 	}
 }
@@ -328,9 +343,12 @@ impl<'a> ProcessAccountInfos<'a> for RotateAdminAccounts<'a> {
 			.assert_type::<RegistryConfig>(&ID)?;
 
 		let registry_config = self.registry_config.as_account::<RegistryConfig>(&ID)?;
+
 		self.admin.assert_address(&registry_config.admin)?;
+
 		let registry_config = self.registry_config.as_account_mut::<RegistryConfig>(&ID)?;
 		registry_config.admin = *self.new_admin.address();
+
 		Ok(())
 	}
 }

--- a/examples/staking_rewards_program/src/lib.rs
+++ b/examples/staking_rewards_program/src/lib.rs
@@ -200,6 +200,7 @@ macro_rules! position_seeds {
 
 impl<'a> ProcessAccountInfos<'a> for InitializePoolAccounts<'a> {
 	fn process(&self, data: &[u8]) -> ProgramResult {
+		// Parse instruction and prepare PDA seeds
 		let args = InitializePoolInstruction::try_from_bytes(data)?;
 		let pool_seeds = pool_seeds!(
 			self.stake_mint.address().as_ref(),
@@ -211,6 +212,7 @@ impl<'a> ProcessAccountInfos<'a> for InitializePoolAccounts<'a> {
 			args.bump
 		);
 
+		// Validate accounts
 		self.admin.assert_signer()?;
 		self.stake_mint.assert_owners(&SPL_PROGRAM_IDS)?;
 		self.reward_mint.assert_owners(&SPL_PROGRAM_IDS)?;
@@ -237,6 +239,7 @@ impl<'a> ProcessAccountInfos<'a> for InitializePoolAccounts<'a> {
 				self.token_program.address(),
 			)?;
 
+		// Create the pool state account
 		create_program_account_with_bump::<PoolState>(
 			self.pool_state,
 			self.admin,
@@ -245,6 +248,7 @@ impl<'a> ProcessAccountInfos<'a> for InitializePoolAccounts<'a> {
 			args.bump,
 		)?;
 
+		// Initialize pool state
 		let pool_state = self.pool_state.as_account_mut::<PoolState>(&ID)?;
 		*pool_state = PoolState::builder()
 			.admin(*self.admin.address())
@@ -256,6 +260,7 @@ impl<'a> ProcessAccountInfos<'a> for InitializePoolAccounts<'a> {
 			.bump(args.bump)
 			.build();
 
+		// Create stake vault
 		associated_token_account::instructions::Create {
 			account: self.stake_vault,
 			funding_account: self.admin,
@@ -266,6 +271,7 @@ impl<'a> ProcessAccountInfos<'a> for InitializePoolAccounts<'a> {
 		}
 		.invoke()?;
 
+		// Create reward vault
 		associated_token_account::instructions::Create {
 			account: self.reward_vault,
 			funding_account: self.admin,
@@ -282,6 +288,7 @@ impl<'a> ProcessAccountInfos<'a> for InitializePoolAccounts<'a> {
 
 impl<'a> ProcessAccountInfos<'a> for OpenPositionAccounts<'a> {
 	fn process(&self, data: &[u8]) -> ProgramResult {
+		// Parse instruction and prepare PDA seeds
 		let args = OpenPositionInstruction::try_from_bytes(data)?;
 		let position_seeds = position_seeds!(
 			self.pool_state.address().as_ref(),
@@ -293,6 +300,7 @@ impl<'a> ProcessAccountInfos<'a> for OpenPositionAccounts<'a> {
 			args.bump
 		);
 
+		// Validate accounts
 		self.user.assert_signer()?;
 		self.system_program.assert_address(&system::ID)?;
 		self.pool_state
@@ -304,11 +312,13 @@ impl<'a> ProcessAccountInfos<'a> for OpenPositionAccounts<'a> {
 			.assert_writable()?
 			.assert_seeds_with_bump(position_seeds_with_bump, &ID)?;
 
+		// Check pool is not paused
 		let pool_state = self.pool_state.as_account::<PoolState>(&ID)?;
 		if bool::from(pool_state.paused) {
 			return Err(StakingError::PoolPaused.into());
 		}
 
+		// Create the position account
 		create_program_account_with_bump::<PositionState>(
 			self.position_state,
 			self.user,
@@ -317,6 +327,7 @@ impl<'a> ProcessAccountInfos<'a> for OpenPositionAccounts<'a> {
 			args.bump,
 		)?;
 
+		// Initialize position state
 		let position_state = self.position_state.as_account_mut::<PositionState>(&ID)?;
 		*position_state = PositionState::builder()
 			.pool(*self.pool_state.address())
@@ -333,9 +344,11 @@ impl<'a> ProcessAccountInfos<'a> for OpenPositionAccounts<'a> {
 
 impl<'a> ProcessAccountInfos<'a> for DepositAccounts<'a> {
 	fn process(&self, data: &[u8]) -> ProgramResult {
+		// Parse instruction data
 		let args = DepositInstruction::try_from_bytes(data)?;
 		let amount: u64 = args.amount.into();
 
+		// Validate accounts
 		self.user.assert_signer()?;
 		self.stake_mint.assert_owners(&SPL_PROGRAM_IDS)?;
 		self.system_program.assert_address(&system::ID)?;
@@ -356,8 +369,10 @@ impl<'a> ProcessAccountInfos<'a> for DepositAccounts<'a> {
 				self.token_program.address(),
 			)?;
 
+		// Validate pool and position state
 		let pool_state = self.pool_state.as_account::<PoolState>(&ID)?;
 		let position_state = self.position_state.as_account::<PositionState>(&ID)?;
+
 		if bool::from(pool_state.paused) {
 			return Err(StakingError::PoolPaused.into());
 		}
@@ -368,6 +383,7 @@ impl<'a> ProcessAccountInfos<'a> for DepositAccounts<'a> {
 			return Err(StakingError::InvalidAmount.into());
 		}
 
+		// Calculate updated amounts
 		let staked_amount = u64::from(position_state.staked_amount);
 		let next_staked = staked_amount
 			.checked_add(amount)
@@ -376,6 +392,7 @@ impl<'a> ProcessAccountInfos<'a> for DepositAccounts<'a> {
 			.checked_add(amount)
 			.ok_or(ProgramError::ArithmeticOverflow)?;
 
+		// Update position state
 		let position_state = self.position_state.as_account_mut::<PositionState>(&ID)?;
 		position_state.staked_amount = PodU64::from_primitive(next_staked);
 		position_state.reward_debt = PodU64::from_primitive(
@@ -384,9 +401,11 @@ impl<'a> ProcessAccountInfos<'a> for DepositAccounts<'a> {
 				.ok_or(ProgramError::ArithmeticOverflow)?,
 		);
 
+		// Update pool state
 		let pool_state = self.pool_state.as_account_mut::<PoolState>(&ID)?;
 		pool_state.total_staked = PodU64::from_primitive(total_staked);
 
+		// Ensure user's stake ATA exists
 		associated_token_account::instructions::CreateIdempotent {
 			funding_account: self.user,
 			account: self.user_stake_ata,
@@ -403,9 +422,11 @@ impl<'a> ProcessAccountInfos<'a> for DepositAccounts<'a> {
 
 impl<'a> ProcessAccountInfos<'a> for WithdrawAccounts<'a> {
 	fn process(&self, data: &[u8]) -> ProgramResult {
+		// Parse instruction data
 		let args = WithdrawInstruction::try_from_bytes(data)?;
 		let amount: u64 = args.amount.into();
 
+		// Validate accounts
 		self.user.assert_signer()?;
 		self.stake_mint.assert_owners(&SPL_PROGRAM_IDS)?;
 		self.system_program.assert_address(&system::ID)?;
@@ -426,19 +447,24 @@ impl<'a> ProcessAccountInfos<'a> for WithdrawAccounts<'a> {
 				self.token_program.address(),
 			)?;
 
+		// Validate pool and position state
 		let pool_state = self.pool_state.as_account::<PoolState>(&ID)?;
 		let position_state = self.position_state.as_account::<PositionState>(&ID)?;
+
 		if bool::from(pool_state.paused) {
 			return Err(StakingError::PoolPaused.into());
 		}
+
 		let staked_amount = u64::from(position_state.staked_amount);
 		if amount > staked_amount {
 			return Err(StakingError::InsufficientBalance.into());
 		}
 
+		// Update position state
 		let position_state = self.position_state.as_account_mut::<PositionState>(&ID)?;
 		position_state.staked_amount = PodU64::from_primitive(staked_amount - amount);
 
+		// Update pool state
 		let pool_state = self.pool_state.as_account_mut::<PoolState>(&ID)?;
 		pool_state.total_staked =
 			PodU64::from_primitive(u64::from(pool_state.total_staked) - amount);
@@ -449,6 +475,7 @@ impl<'a> ProcessAccountInfos<'a> for WithdrawAccounts<'a> {
 
 impl<'a> ProcessAccountInfos<'a> for ClaimAccounts<'a> {
 	fn process(&self, _data: &[u8]) -> ProgramResult {
+		// Validate accounts
 		self.user.assert_signer()?;
 		self.reward_mint.assert_owners(&SPL_PROGRAM_IDS)?;
 		self.system_program.assert_address(&system::ID)?;
@@ -469,8 +496,10 @@ impl<'a> ProcessAccountInfos<'a> for ClaimAccounts<'a> {
 				self.token_program.address(),
 			)?;
 
+		// Validate pool and position state
 		let pool_state = self.pool_state.as_account::<PoolState>(&ID)?;
 		let position_state = self.position_state.as_account::<PositionState>(&ID)?;
+
 		if bool::from(pool_state.paused) {
 			return Err(StakingError::PoolPaused.into());
 		}
@@ -478,12 +507,15 @@ impl<'a> ProcessAccountInfos<'a> for ClaimAccounts<'a> {
 			return Err(StakingError::InvalidAmount.into());
 		}
 
+		// Calculate and update pending rewards
 		let next_pending = u64::from(position_state.pending_rewards)
 			.checked_add(u64::from(pool_state.reward_index))
 			.ok_or(ProgramError::ArithmeticOverflow)?;
+
 		let position_state = self.position_state.as_account_mut::<PositionState>(&ID)?;
 		position_state.pending_rewards = PodU64::from_primitive(next_pending);
 
+		// Ensure user's reward ATA exists
 		associated_token_account::instructions::CreateIdempotent {
 			funding_account: self.user,
 			account: self.user_reward_ata,

--- a/examples/todo_program/src/lib.rs
+++ b/examples/todo_program/src/lib.rs
@@ -81,11 +81,13 @@ pub struct UpdateAccounts<'a> {
 
 impl<'a> ProcessAccountInfos<'a> for InitializeAccounts<'a> {
 	fn process(&self, data: &[u8]) -> ProgramResult {
+		// Parse instruction and prepare PDA seeds
 		let args = InitializeInstruction::try_from_bytes(data)?;
 		let owner = self.owner.address();
 		let seeds = todo_seeds!(owner.as_ref());
 		let seeds_with_bump = todo_seeds!(owner.as_ref(), args.bump);
 
+		// Validate accounts
 		self.owner.assert_signer()?;
 		self.todo
 			.assert_empty()?
@@ -93,10 +95,12 @@ impl<'a> ProcessAccountInfos<'a> for InitializeAccounts<'a> {
 			.assert_seeds_with_bump(seeds_with_bump, &ID)?;
 		self.system_program.assert_address(&system::ID)?;
 
+		// Create the PDA account
 		create_program_account_with_bump::<TodoState>(
 			self.todo, self.owner, &ID, seeds, args.bump,
 		)?;
 
+		// Initialize account data
 		let todo = self.todo.as_account_mut::<TodoState>(&ID)?;
 		*todo = TodoState::builder()
 			.owner(*owner)
@@ -111,8 +115,16 @@ impl<'a> ProcessAccountInfos<'a> for InitializeAccounts<'a> {
 
 impl<'a> ProcessAccountInfos<'a> for UpdateAccounts<'a> {
 	fn process(&self, data: &[u8]) -> ProgramResult {
+		// Parse instruction data
 		let owner = self.owner.address();
+		let instruction = parse_instruction::<TodoInstruction>(&ID, &ID, data)?;
 
+		// Reject invalid instruction for this context
+		if instruction == TodoInstruction::Initialize {
+			return Err(ProgramError::InvalidInstructionData);
+		}
+
+		// Validate accounts
 		self.owner.assert_signer()?;
 		self.todo
 			.assert_not_empty()?
@@ -121,22 +133,29 @@ impl<'a> ProcessAccountInfos<'a> for UpdateAccounts<'a> {
 
 		let todo = self.todo.as_account::<TodoState>(&ID)?;
 		self.owner.assert_address(&todo.owner)?;
+
 		let seeds_with_bump = todo_seeds!(owner.as_ref(), todo.bump);
 		self.todo.assert_seeds_with_bump(seeds_with_bump, &ID)?;
 
-		match parse_instruction::<TodoInstruction>(&ID, &ID, data)? {
+		// Execute instruction
+		match instruction {
 			TodoInstruction::ToggleCompleted => {
 				let _ = ToggleCompletedInstruction::try_from_bytes(data)?;
 				let todo = self.todo.as_account_mut::<TodoState>(&ID)?;
 				let completed = bool::from(todo.completed);
+
 				todo.completed = PodBool::from_bool(!completed);
 			}
 			TodoInstruction::UpdateDigest => {
 				let args = UpdateDigestInstruction::try_from_bytes(data)?;
 				let todo = self.todo.as_account_mut::<TodoState>(&ID)?;
+
 				todo.digest = args.digest;
 			}
-			TodoInstruction::Initialize => return Err(ProgramError::InvalidInstructionData),
+			TodoInstruction::Initialize => {
+				// Already handled above; unreachable
+				return Err(ProgramError::InvalidInstructionData);
+			}
 		}
 
 		Ok(())

--- a/examples/transfer_sol/src/lib.rs
+++ b/examples/transfer_sol/src/lib.rs
@@ -234,6 +234,7 @@ pub mod entrypoint {
 			TransferInstruction::CpiTransfer => {
 				CpiTransferAccounts::try_from(accounts)?.process(data)
 			}
+
 			TransferInstruction::DirectTransfer => {
 				DirectTransferAccounts::try_from(accounts)?.process(data)
 			}

--- a/examples/vesting_program/src/lib.rs
+++ b/examples/vesting_program/src/lib.rs
@@ -159,6 +159,7 @@ impl<'a> ProcessAccountInfos<'a> for InitializeAccounts<'a> {
 		let start_ts = u64::from(args.start_ts);
 		let cliff_ts = u64::from(args.cliff_ts);
 		let end_ts = u64::from(args.end_ts);
+
 		validate_schedule(start_ts, cliff_ts, end_ts)?;
 
 		let vesting_seeds = vesting_seeds!(
@@ -320,8 +321,10 @@ impl<'a> ProcessAccountInfos<'a> for CancelAccounts<'a> {
 			)?;
 
 		let vesting_state = self.vesting_state.as_account::<VestingState>(&ID)?;
+
 		self.admin.assert_address(&vesting_state.admin)?;
 		self.mint.assert_address(&vesting_state.mint)?;
+
 		self.vesting_state.assert_seeds_with_bump(
 			vesting_seeds!(
 				vesting_state.admin.as_ref(),
@@ -338,6 +341,7 @@ impl<'a> ProcessAccountInfos<'a> for CancelAccounts<'a> {
 
 		let vesting_state = self.vesting_state.as_account_mut::<VestingState>(&ID)?;
 		vesting_state.cancelled = PodBool::from_bool(true);
+
 		Ok(())
 	}
 }

--- a/security/00-signer-authorization/insecure/src/lib.rs
+++ b/security/00-signer-authorization/insecure/src/lib.rs
@@ -57,6 +57,7 @@ impl<'a> ProcessAccountInfos<'a> for WithdrawAccounts<'a> {
 		let vault = self.vault.as_account_mut::<VaultState>(&ID)?;
 		let current: u64 = vault.balance.into();
 		let amount: u64 = args.amount.into();
+
 		vault.balance = PodU64::from_primitive(current.saturating_sub(amount));
 
 		Ok(())

--- a/security/00-signer-authorization/secure/src/lib.rs
+++ b/security/00-signer-authorization/secure/src/lib.rs
@@ -57,12 +57,14 @@ impl<'a> ProcessAccountInfos<'a> for WithdrawAccounts<'a> {
 			.assert_type::<VaultState>(&ID)?;
 
 		let vault = self.vault.as_account::<VaultState>(&ID)?;
+
 		// Also verify the authority matches the vault's stored authority.
 		self.authority.assert_address(&vault.authority)?;
 
 		let vault = self.vault.as_account_mut::<VaultState>(&ID)?;
 		let current: u64 = vault.balance.into();
 		let amount: u64 = args.amount.into();
+
 		vault.balance = PodU64::from_primitive(checked_withdraw_balance(current, amount)?);
 
 		Ok(())

--- a/security/02-owner-checks/insecure/src/lib.rs
+++ b/security/02-owner-checks/insecure/src/lib.rs
@@ -45,6 +45,7 @@ impl<'a> ProcessAccountInfos<'a> for DepositAccounts<'a> {
 		let balance = token.amount();
 
 		let amount: u64 = args.amount.into();
+
 		if balance < amount {
 			return Err(ProgramError::InsufficientFunds);
 		}

--- a/security/02-owner-checks/secure/src/lib.rs
+++ b/security/02-owner-checks/secure/src/lib.rs
@@ -42,6 +42,7 @@ impl<'a> ProcessAccountInfos<'a> for DepositAccounts<'a> {
 		let balance = token.amount();
 
 		let amount: u64 = args.amount.into();
+
 		if balance < amount {
 			return Err(ProgramError::InsufficientFunds);
 		}

--- a/security/03-type-cosplay/secure/src/lib.rs
+++ b/security/03-type-cosplay/secure/src/lib.rs
@@ -58,6 +58,7 @@ impl<'a> ProcessAccountInfos<'a> for AdminActionAccounts<'a> {
 		self.config.assert_type::<AdminConfig>(&ID)?;
 
 		let config = self.config.as_account::<AdminConfig>(&ID)?;
+
 		self.authority.assert_address(&config.authority)?;
 
 		let config_mut = self.config.as_account_mut::<AdminConfig>(&ID)?;

--- a/security/04-initialization/secure/src/lib.rs
+++ b/security/04-initialization/secure/src/lib.rs
@@ -65,6 +65,7 @@ impl<'a> ProcessAccountInfos<'a> for InitializeAccounts<'a> {
 		)?;
 
 		let config = self.config.as_account_mut::<Config>(&ID)?;
+
 		*config = Config::builder()
 			.authority(*self.authority.address())
 			.value(args.value)

--- a/security/06-duplicate-mutable-accounts/secure/src/lib.rs
+++ b/security/06-duplicate-mutable-accounts/secure/src/lib.rs
@@ -54,6 +54,7 @@ fn checked_transfer_balances(
 	let new_source = source_amount
 		.checked_sub(amount)
 		.ok_or(ProgramError::InsufficientFunds)?;
+
 	let new_dest = dest_amount
 		.checked_add(amount)
 		.ok_or(ProgramError::ArithmeticOverflow)?;
@@ -81,6 +82,7 @@ impl<'a> ProcessAccountInfos<'a> for TransferAccounts<'a> {
 
 		let dest = self.dest.as_account_mut::<Balance>(&ID)?;
 		let dest_amount: u64 = dest.amount.into();
+
 		let (new_source, new_dest) = checked_transfer_balances(source_amount, dest_amount, amount)?;
 		source.amount = PodU64::from_primitive(new_source);
 		dest.amount = PodU64::from_primitive(new_dest);

--- a/security/07-bump-seed-canonicalization/secure/src/lib.rs
+++ b/security/07-bump-seed-canonicalization/secure/src/lib.rs
@@ -61,6 +61,7 @@ impl<'a> ProcessAccountInfos<'a> for CreateAccounts<'a> {
 			create_program_account::<Data>(self.data, self.authority, &ID, seeds)?;
 
 		let data_account = self.data.as_account_mut::<Data>(&ID)?;
+
 		*data_account = Data::builder()
 			.authority(*self.authority.address())
 			.value(args.value)

--- a/security/08-pda-sharing/secure/src/lib.rs
+++ b/security/08-pda-sharing/secure/src/lib.rs
@@ -74,6 +74,7 @@ impl<'a> ProcessAccountInfos<'a> for CreateConfigAccounts<'a> {
 			create_program_account::<UserConfig>(self.config, self.authority, &ID, seeds)?;
 
 		let config = self.config.as_account_mut::<UserConfig>(&ID)?;
+
 		*config = UserConfig::builder()
 			.authority(*self.authority.address())
 			.setting(args.setting)

--- a/security/09-closing-accounts/secure/src/lib.rs
+++ b/security/09-closing-accounts/secure/src/lib.rs
@@ -48,6 +48,7 @@ impl<'a> ProcessAccountInfos<'a> for ClaimAndCloseAccounts<'a> {
 			.assert_type::<RewardState>(&ID)?;
 
 		let reward = self.reward.as_account::<RewardState>(&ID)?;
+
 		self.authority.assert_address(&reward.authority)?;
 
 		// SECURE: Zero the account data first, then close properly.
@@ -56,6 +57,7 @@ impl<'a> ProcessAccountInfos<'a> for ClaimAndCloseAccounts<'a> {
 		{
 			self.reward.as_account_mut::<RewardState>(&ID)?.zeroed();
 		}
+
 		self.reward.close_with_recipient(self.recipient)
 	}
 }


### PR DESCRIPTION
This PR introduces a new coding style guide and applies style improvements across the codebase.

## Changes

### Documentation
- Added comprehensive coding style guide at `docs/agents/coding-style.md`
- Updated `AGENTS.md` to reference the new style guide

### Code Style Improvements
Applied the following patterns across core crates and examples:
- **Early returns**: Converted nested if/else blocks to guard clauses
- **Whitespace**: Added blank lines before control flow and between logical groups
- **Grouping**: Separated related operations with visual breathing room
- **Simplification**: Reduced nesting depth and extracted complex logic

### Files Modified
- `crates/pina/src/cpi.rs` - Early returns in allocation functions
- `crates/pina/src/impls.rs` - Whitespace in trait implementations
- `crates/pina_cli/src/parse/` - Validation and seed extraction improvements
- `crates/pina_codama_renderer/src/` - Code organization
- `examples/*/src/lib.rs` - Process method improvements with better grouping

## Verification
- ✅ All tests pass (`cargo test`)
- ✅ Clippy clean (`cargo clippy --all-features`)
- ✅ Formatting verified (`dprint fmt`)

## Style Guide Highlights
Key principles documented:
1. Whitespace is semantics - blank lines separate concepts
2. Early returns over deep nesting (max 2-3 levels)
3. Variables at the top when possible
4. Extraction over nesting for complex logic
5. Comments explain why, not what
6. Safety comments required for unsafe code

See `docs/agents/coding-style.md` for full details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive coding-style guide covering formatting, idioms, docs, and test conventions for Rust and TypeScript.

* **Refactor**
  * Simplified and clarified control flow across libraries and tools (more early-return/guard patterns) without changing behavior or public APIs.

* **Style**
  * Widespread whitespace, formatting, and generated-output spacing cleanup across code, examples, tests, and tooling; no functional changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->