### PR TITLE
chore(github): add contribution templates and title rules

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,50 @@
+name: Bug report
+description: Report a defect or regression in Pina.
+title: "Sentence case summary of the bug"
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please write the issue title in **sentence case**.
+
+        Good: `Account loaders should preserve the borrow guard lifetime`
+        Avoid: `fix: account loaders preserve borrow guard lifetime`
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: Describe the bug and why it matters.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: How can we reproduce it?
+      description: Include code, commands, fixtures, or a minimal reproduction.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: impact
+    attributes:
+      label: Why is this important?
+      description: Explain the safety, correctness, DX, or performance impact.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Describe the observable behaviors that should be true when this is fixed.
+      placeholder: |
+        - [ ] Add regression coverage for the failing path
+        - [ ] Update docs/examples if the public API changes
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,51 @@
+name: Feature request
+description: Propose a new feature or workflow improvement for Pina.
+title: "Sentence case summary of the feature"
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please write the issue title in **sentence case**.
+
+        Good: `Add Miri coverage for account loader aliasing rules`
+        Avoid: `feat: add miri coverage for account loader aliasing rules`
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are we trying to solve?
+      description: Describe the gap in the current behavior or workflow.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the feature at a high level.
+    validations:
+      required: true
+  - type: textarea
+    id: implementation
+    attributes:
+      label: Implementation sketch
+      description: Outline the likely design, files, workflows, or components involved.
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why is this needed?
+      description: Explain the user, security, DX, or performance benefit.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      placeholder: |
+        - [ ] Add implementation
+        - [ ] Add tests or verification
+        - [ ] Update docs if behavior changes
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Summary
+
+<!-- Describe the change and why it is needed. -->
+
+## Linked issues
+
+<!-- Example: Closes #120 -->
+
+## Testing
+
+<!-- List the commands or checks you ran. -->
+
+- [ ] Tests added or updated where needed
+- [ ] Documentation updated where needed
+
+## Title and history conventions
+
+- [ ] PR title uses Conventional Commits syntax, for example `fix(loaders): preserve borrow guard lifetime`
+- [ ] Commits in this PR use Conventional Commits syntax
+- [ ] Referenced issue titles are written in sentence case

--- a/docs/agents/git-workflow.md
+++ b/docs/agents/git-workflow.md
@@ -1,9 +1,18 @@
 # Git Workflow
 
 - Create a dedicated branch for each change before committing.
-- Use branch names of the form:
+- Use branch names with conventional prefixes, for example:
   - `feat/<description>`
   - `fix/<description>`
+  - `docs/<description>`
+  - `test/<description>`
+  - `refactor/<description>`
+  - `ci/<description>`
+  - `build/<description>`
+  - `chore/<description>`
 - Do not use the `codex/` branch prefix.
-- Commit messages must follow Conventional Commits.
+- Commit messages must follow Conventional Commits, for example `fix(loaders): preserve borrow guard lifetime`.
+- Pull request titles must also follow Conventional Commits. Prefer using the eventual squash-merge commit title as the PR title.
+- GitHub issue titles must be written in sentence case. Do not use commit-style prefixes like `fix:` / `feat:` / `docs:` in issue titles.
 - Open a pull request for review before merging.
+- Link pull requests to the relevant issue(s).


### PR DESCRIPTION
## Summary

- document contribution workflow rules for branches, commits, PR titles, and issue titles
- add a pull request template that reinforces Conventional Commits and sentence-case issue titles
- add bug and feature issue forms that request fuller specifications and enforce sentence-case issue titles

## Linked issues

- Related to #119

## Testing

- `git diff --check`
- `cargo test -p pina_cli --test cli_snapshots -- --nocapture`

## Notes

- A full pre-push hook run hit a transient `-p pina_cli --test cli_snapshots` failure once, but the targeted rerun above passed.

## Title and history conventions

- [x] PR title uses Conventional Commits syntax
- [x] Commits in this PR use Conventional Commits syntax
- [x] Referenced issue titles are written in sentence case


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced git workflow documentation with standardized branch naming conventions, pull request title requirements following Conventional Commits, and sentence-case issue formatting guidelines

* **Chores**
  * Added GitHub issue templates for structured bug reports and feature requests with required fields and form validation
  * Introduced pull request template with submission guidelines and checklists

<!-- end of auto-generated comment: release notes by coderabbit.ai -->