### PR TITLE
fix(loaders): make as_account guard-backed

### DIFF
--- a/crates/pina/src/impls.rs
+++ b/crates/pina/src/impls.rs
@@ -1,9 +1,10 @@
 #![allow(unsafe_code)]
 
-use core::slice::from_raw_parts;
-use core::slice::from_raw_parts_mut;
+use core::mem::size_of;
 
 use pinocchio::ProgramResult;
+use pinocchio::account::Ref as AccountRef;
+use pinocchio::account::RefMut as AccountRefMut;
 use pinocchio_system::instructions::Transfer;
 
 use crate::AccountDeserialize;
@@ -18,6 +19,8 @@ use crate::AsTokenAccount;
 use crate::CloseAccountWithRecipient;
 use crate::HasDiscriminator;
 use crate::LamportTransfer;
+use crate::LoadedAccount;
+use crate::LoadedAccountMut;
 use crate::Pod;
 use crate::ProgramError;
 use crate::log;
@@ -342,47 +345,36 @@ impl AccountInfoValidation for AccountView {
 
 impl AsAccount for AccountView {
 	#[track_caller]
-	fn as_account<T>(&self, program_id: &Address) -> Result<&T, ProgramError>
+	fn as_account<T>(&self, program_id: &Address) -> Result<LoadedAccount<'_, T>, ProgramError>
 	where
 		T: AccountDeserialize + HasDiscriminator + Pod,
 	{
 		self.assert_owner(program_id)?;
 		self.assert_data_len(size_of::<T>())?;
 
-		// SAFETY: `try_borrow` yields a guard-backed slice of the account data.
-		// We rebuild a raw-parts slice from the same pointer with exactly
-		// `size_of::<T>()` bytes, which is guaranteed by `assert_data_len` above.
-		// `T::try_from_bytes` then validates the discriminator and performs the
-		// bytemuck cast.
-		//
-		// The returned `&T` intentionally outlives the temporary borrow guard, so
-		// callers must not create overlapping mutable borrows of the same account
-		// while the reference is still in use.
-		unsafe { T::try_from_bytes(from_raw_parts(self.try_borrow()?.as_ptr(), size_of::<T>())) }
+		let bytes = self.try_borrow()?;
+		let account = AccountRef::try_map(bytes, |data| T::try_from_bytes(data))
+			.map_err(|(_, error)| error)?;
+
+		Ok(LoadedAccount::new(account))
 	}
 
 	#[track_caller]
-	fn as_account_mut<T>(&self, program_id: &Address) -> Result<&mut T, ProgramError>
+	fn as_account_mut<T>(
+		&self,
+		program_id: &Address,
+	) -> Result<LoadedAccountMut<'_, T>, ProgramError>
 	where
 		T: AccountDeserialize + HasDiscriminator + Pod,
 	{
 		self.assert_owner(program_id)?;
 		self.assert_data_len(size_of::<T>())?;
 
-		// SAFETY: `try_borrow_mut` yields exclusive access to the backing bytes,
-		// and `assert_data_len` guarantees the slice is exactly `size_of::<T>()`
-		// bytes. `T::try_from_bytes_mut` then validates the discriminator and
-		// performs the bytemuck cast.
-		//
-		// The returned `&mut T` intentionally outlives the temporary borrow
-		// guard, so callers must not create any overlapping borrows or aliasing
-		// mutable views of the same account while the reference is still in use.
-		unsafe {
-			T::try_from_bytes_mut(from_raw_parts_mut(
-				self.try_borrow_mut()?.as_mut_ptr(),
-				size_of::<T>(),
-			))
-		}
+		let bytes = self.try_borrow_mut()?;
+		let account = AccountRefMut::try_map(bytes, |data| T::try_from_bytes_mut(data))
+			.map_err(|(_, error)| error)?;
+
+		Ok(LoadedAccountMut::new(account))
 	}
 }
 

--- a/crates/pina/src/traits.rs
+++ b/crates/pina/src/traits.rs
@@ -1,3 +1,6 @@
+use core::ops::Deref;
+use core::ops::DerefMut;
+
 use bytemuck::Pod;
 use pinocchio::ProgramResult;
 
@@ -414,12 +417,68 @@ pub trait HasDiscriminator: Sized {
 	}
 }
 
-/// Deserializes raw `AccountView` data into a typed account reference.
+/// Guard-backed immutable access to typed account data.
+///
+/// This wrapper keeps the underlying runtime borrow guard alive for as long as
+/// the typed access exists, preventing later overlapping borrows of the same
+/// account data from succeeding prematurely.
+#[derive(Debug)]
+#[must_use]
+pub struct LoadedAccount<'a, T: ?Sized> {
+	inner: pinocchio::account::Ref<'a, T>,
+}
+
+impl<'a, T: ?Sized> LoadedAccount<'a, T> {
+	pub(crate) fn new(inner: pinocchio::account::Ref<'a, T>) -> Self {
+		Self { inner }
+	}
+}
+
+impl<T: ?Sized> Deref for LoadedAccount<'_, T> {
+	type Target = T;
+
+	fn deref(&self) -> &Self::Target {
+		&self.inner
+	}
+}
+
+/// Guard-backed mutable access to typed account data.
+///
+/// This wrapper keeps the underlying runtime mutable borrow guard alive for as
+/// long as the typed access exists, preventing overlapping immutable or
+/// mutable borrows until the wrapper is dropped.
+#[derive(Debug)]
+#[must_use]
+pub struct LoadedAccountMut<'a, T: ?Sized> {
+	inner: pinocchio::account::RefMut<'a, T>,
+}
+
+impl<'a, T: ?Sized> LoadedAccountMut<'a, T> {
+	pub(crate) fn new(inner: pinocchio::account::RefMut<'a, T>) -> Self {
+		Self { inner }
+	}
+}
+
+impl<T: ?Sized> Deref for LoadedAccountMut<'_, T> {
+	type Target = T;
+
+	fn deref(&self) -> &Self::Target {
+		&self.inner
+	}
+}
+
+impl<T: ?Sized> DerefMut for LoadedAccountMut<'_, T> {
+	fn deref_mut(&mut self) -> &mut Self::Target {
+		&mut self.inner
+	}
+}
+
+/// Deserializes raw `AccountView` data into guard-backed typed account access.
 ///
 /// Performs:
 /// 1. Program owner check
 /// 2. Discriminator byte check
-/// 3. Checked bytemuck conversion of account data to `&T` or `&mut T`.
+/// 3. Checked bytemuck conversion of account data into a guard-backed wrapper.
 ///
 /// <!-- {=pinaPublicResultContract|trim|linePrefix:"/// ":true} -->/// All APIs in this section are designed for on-chain determinism.
 ///
@@ -432,25 +491,27 @@ pub trait HasDiscriminator: Sized {
 /// ```ignore
 /// // Inside an instruction handler:
 /// let escrow_account = &accounts[0];
-/// let escrow: &EscrowState = escrow_account.as_account(&program_id)?;
+/// let escrow = escrow_account.as_account::<EscrowState>(&program_id)?;
 ///
 /// // For mutable access:
-/// let escrow_mut: &mut EscrowState = escrow_account.as_account_mut(&program_id)?;
-/// escrow_mut.amount = PodU64::from(100u64);
+/// let mut escrow = escrow_account.as_account_mut::<EscrowState>(&program_id)?;
+/// escrow.amount = PodU64::from(100u64);
 /// ```
 pub trait AsAccount {
 	/// Validate ownership and deserialize the account data into an immutable
-	/// reference of type `T`. Returns `InvalidAccountData` if the
+	/// guard-backed view of type `T`. Returns `InvalidAccountData` if the
 	/// discriminator doesn't match or the data is the wrong size.
-	fn as_account<T>(&self, program_id: &Address) -> Result<&T, ProgramError>
+	fn as_account<T>(&self, program_id: &Address) -> Result<LoadedAccount<'_, T>, ProgramError>
 	where
 		T: AccountDeserialize + HasDiscriminator + Pod;
 
 	/// Validate ownership and deserialize the account data into a mutable
-	/// reference of type `T`. The Solana runtime guarantees exclusive access
-	/// when the mutable borrow succeeds.
-	#[allow(clippy::mut_from_ref)]
-	fn as_account_mut<T>(&self, program_id: &Address) -> Result<&mut T, ProgramError>
+	/// guard-backed view of type `T`. The Solana runtime keeps the mutable
+	/// borrow active until the returned wrapper is dropped.
+	fn as_account_mut<T>(
+		&self,
+		program_id: &Address,
+	) -> Result<LoadedAccountMut<'_, T>, ProgramError>
 	where
 		T: AccountDeserialize + HasDiscriminator + Pod;
 }

--- a/crates/pina/tests/integration.rs
+++ b/crates/pina/tests/integration.rs
@@ -153,7 +153,7 @@ impl<'a> ProcessAccountInfos<'a> for UpdateAccounts<'a> {
 			.assert_type::<TestState>(&TEST_PROGRAM_ID)?;
 
 		// Update state.
-		let state = self
+		let mut state = self
 			.state_account
 			.as_account_mut::<TestState>(&TEST_PROGRAM_ID)?;
 		state.value = args.new_value;
@@ -174,7 +174,7 @@ impl<'a> ProcessAccountInfos<'a> for CloseAccounts<'a> {
 			.assert_type::<TestState>(&TEST_PROGRAM_ID)?;
 
 		// Zero account data before closing.
-		let state = self
+		let mut state = self
 			.state_account
 			.as_account_mut::<TestState>(&TEST_PROGRAM_ID)?;
 		state.zeroed();
@@ -1433,7 +1433,7 @@ fn account_data_mutation_persists() {
 
 	// Mutate value.
 	{
-		let state = account_views[0]
+		let mut state = account_views[0]
 			.as_account_mut::<TestState>(&TEST_PROGRAM_ID)
 			.unwrap_or_else(|e| panic!("write failed: {e:?}"));
 		state.value = PodU64::from_primitive(12345);
@@ -1445,6 +1445,82 @@ fn account_data_mutation_persists() {
 		.unwrap_or_else(|e| panic!("read failed: {e:?}"));
 	assert_eq!(u64::from(state.value), 12345);
 	assert_eq!(state.bump, 10, "bump should be unchanged");
+}
+
+/// Tests that as_account keeps the runtime borrow active until drop.
+#[test]
+fn as_account_keeps_borrow_guard_alive_until_drop() {
+	let key: Address = address!("BHvLHF6mJpWxywWY5S2tsHdDtHirHyeRxoS6uF6T5FoY");
+	let state_bytes = build_test_state_bytes(7, 900);
+
+	let accounts = [AccountBuilder::new()
+		.address(key)
+		.owner(TEST_PROGRAM_ID)
+		.lamports(1_000_000)
+		.data(&state_bytes)
+		.is_writable(true)];
+
+	let dummy_data: &[u8] = &[0u8];
+	let mut input = unsafe { create_test_input(&accounts, dummy_data) };
+	let mut accts = [UNINIT; 10];
+	let (_, account_views, ..) = unsafe { deserialize_test_input::<10>(&mut input, &mut accts) };
+
+	let state = account_views[0]
+		.as_account::<TestState>(&TEST_PROGRAM_ID)
+		.unwrap_or_else(|e| panic!("read failed: {e:?}"));
+
+	assert_eq!(state.bump, 7);
+	assert!(matches!(
+		account_views[0].try_borrow_mut(),
+		Err(ProgramError::AccountBorrowFailed)
+	));
+
+	drop(state);
+
+	let borrow = account_views[0]
+		.try_borrow_mut()
+		.unwrap_or_else(|e| panic!("mutable borrow should succeed after drop: {e:?}"));
+	assert_eq!(borrow.len(), size_of::<TestState>());
+}
+
+/// Tests that as_account_mut blocks overlapping borrows until drop.
+#[test]
+fn as_account_mut_blocks_overlapping_borrows_until_drop() {
+	let key: Address = address!("BHvLHF6mJpWxywWY5S2tsHdDtHirHyeRxoS6uF6T5FoY");
+	let state_bytes = build_test_state_bytes(11, 77);
+
+	let accounts = [AccountBuilder::new()
+		.address(key)
+		.owner(TEST_PROGRAM_ID)
+		.lamports(1_000_000)
+		.data(&state_bytes)
+		.is_writable(true)];
+
+	let dummy_data: &[u8] = &[0u8];
+	let mut input = unsafe { create_test_input(&accounts, dummy_data) };
+	let mut accts = [UNINIT; 10];
+	let (_, account_views, ..) = unsafe { deserialize_test_input::<10>(&mut input, &mut accts) };
+
+	let mut state = account_views[0]
+		.as_account_mut::<TestState>(&TEST_PROGRAM_ID)
+		.unwrap_or_else(|e| panic!("write failed: {e:?}"));
+	state.value = PodU64::from_primitive(88);
+
+	assert!(matches!(
+		account_views[0].try_borrow(),
+		Err(ProgramError::AccountBorrowFailed)
+	));
+	assert!(matches!(
+		account_views[0].try_borrow_mut(),
+		Err(ProgramError::AccountBorrowFailed)
+	));
+
+	drop(state);
+
+	let state = account_views[0]
+		.as_account::<TestState>(&TEST_PROGRAM_ID)
+		.unwrap_or_else(|e| panic!("read after drop failed: {e:?}"));
+	assert_eq!(u64::from(state.value), 88);
 }
 
 // ---------------------------------------------------------------------------

--- a/docs/src/core-concepts.md
+++ b/docs/src/core-concepts.md
@@ -16,7 +16,7 @@ N      | ...  | payload fields
 This contract is what enables:
 
 - deterministic `size_of::<T>()` checks,
-- zero-copy validation with `as_account()` / `try_from_bytes()`,
+- guard-backed zero-copy validation with `as_account()` / `try_from_bytes()`,
 - alignment-safe offsets for fixed-size Pod fields.
 
 ### Why this is safer than implicit external headers
@@ -102,7 +102,7 @@ This pattern improves readability while keeping checks explicit and audit-able.
 
 ## Typed account conversions
 
-Traits in `crates/pina/src/impls.rs` provide typed conversion paths from raw `AccountView` values into strongly typed account states.
+Traits in `crates/pina/src/impls.rs` provide guard-backed typed conversion paths from raw `AccountView` values into strongly typed account states. `as_account()` and `as_account_mut()` keep the runtime borrow alive until the returned wrapper is dropped.
 
 ## Entrypoint model
 

--- a/docs/src/tutorials/token-escrow.md
+++ b/docs/src/tutorials/token-escrow.md
@@ -218,7 +218,7 @@ create_program_account_with_bump::<EscrowState>(
 	args.bump,
 )?;
 
-let escrow = self.escrow.as_account_mut::<EscrowState>(&ID)?;
+let mut escrow = self.escrow.as_account_mut::<EscrowState>(&ID)?;
 *escrow = EscrowState::builder()
 	.maker(*self.maker.address())
 	.mint_a(*self.mint_a.address())
@@ -286,13 +286,10 @@ impl<'a> ProcessAccountInfos<'a> for TakeAccounts<'a> {
 
 		// ... validation omitted for brevity ...
 
-		let EscrowState {
-			maker,
-			seed,
-			bump,
-			amount_b,
-			..
-		} = self.escrow.as_account::<EscrowState>(&ID)?;
+		let (maker, seed, bump, amount_b) = {
+			let escrow = self.escrow.as_account::<EscrowState>(&ID)?;
+			(escrow.maker, escrow.seed, escrow.bump, escrow.amount_b)
+		};
 
 		// Transfer token B: taker -> maker
 		token_2022::instructions::TransferChecked {
@@ -300,14 +297,14 @@ impl<'a> ProcessAccountInfos<'a> for TakeAccounts<'a> {
 			mint: self.mint_b,
 			to: self.maker_ata_b,
 			authority: self.taker,
-			amount: (*amount_b).into(),
+			amount: amount_b.into(),
 			decimals: self.mint_b.as_token_2022_mint()?.decimals(),
 			token_program: self.token_program.address(),
 		}
 		.invoke()?;
 
 		// Transfer token A: vault -> taker (PDA-signed)
-		let bump_as_seeds = [*bump];
+		let bump_as_seeds = [bump];
 		let escrow_seeds =
 			seeds_escrow!(true, self.maker.address().as_ref(), &seed.0, &bump_as_seeds);
 		let escrow_signer = Signer::from(&escrow_seeds);
@@ -341,7 +338,7 @@ impl<'a> ProcessAccountInfos<'a> for TakeAccounts<'a> {
 
 The PDA signer is constructed from the same seeds used to derive the escrow address. `invoke_signed` passes these seeds to the runtime so it can verify the PDA signature.
 
-`close_with_recipient` transfers remaining lamports to the maker and zeros the account data, reclaiming the rent.
+`as_account()` returns a guard-backed wrapper, so the example extracts the needed fields inside a small block before taking a later mutable borrow. `close_with_recipient` transfers remaining lamports to the maker and zeros the account data, reclaiming the rent.
 
 ## Entrypoint
 

--- a/examples/anchor_floats/src/lib.rs
+++ b/examples/anchor_floats/src/lib.rs
@@ -104,8 +104,8 @@ impl<'a> ProcessAccountInfos<'a> for CreateAccounts<'a> {
 			&ID,
 		)?;
 
-		let account = self.account.as_account_mut::<FloatDataAccount>(&ID)?;
-		apply_create(account, self.authority.address(), data_f32, data_f64);
+		let mut account = self.account.as_account_mut::<FloatDataAccount>(&ID)?;
+		apply_create(&mut account, self.authority.address(), data_f32, data_f64);
 
 		Ok(())
 	}
@@ -122,8 +122,8 @@ impl<'a> ProcessAccountInfos<'a> for UpdateAccounts<'a> {
 			.assert_writable()?
 			.assert_type::<FloatDataAccount>(&ID)?;
 
-		let account = self.account.as_account_mut::<FloatDataAccount>(&ID)?;
-		apply_update(account, self.authority.address(), data_f32, data_f64)
+		let mut account = self.account.as_account_mut::<FloatDataAccount>(&ID)?;
+		apply_update(&mut account, self.authority.address(), data_f32, data_f64)
 	}
 }
 

--- a/examples/counter_program/src/lib.rs
+++ b/examples/counter_program/src/lib.rs
@@ -196,7 +196,7 @@ impl<'a> ProcessAccountInfos<'a> for InitializeAccounts<'a> {
 		)?;
 
 		// Initialize account data
-		let counter = self.counter.as_account_mut::<CounterState>(&ID)?;
+		let mut counter = self.counter.as_account_mut::<CounterState>(&ID)?;
 		*counter = CounterState::builder()
 			.bump(args.bump)
 			.count(PodU64::from_primitive(0))
@@ -227,7 +227,7 @@ impl<'a> ProcessAccountInfos<'a> for IncrementAccounts<'a> {
 		self.counter.assert_seeds_with_bump(seeds_with_bump, &ID)?;
 
 		// Mutate state
-		let counter = self.counter.as_account_mut::<CounterState>(&ID)?;
+		let mut counter = self.counter.as_account_mut::<CounterState>(&ID)?;
 		let current: u64 = counter.count.into();
 		let next = current
 			.checked_add(1)

--- a/examples/escrow_program/src/lib.rs
+++ b/examples/escrow_program/src/lib.rs
@@ -168,7 +168,7 @@ impl<'a> ProcessAccountInfos<'a> for MakeAccounts<'a> {
 		)?;
 
 		// Initialize escrow state
-		let escrow = self.escrow.as_account_mut::<EscrowState>(&ID)?;
+		let mut escrow = self.escrow.as_account_mut::<EscrowState>(&ID)?;
 		*escrow = EscrowState::builder()
 			.maker(*self.maker.address())
 			.mint_a(*self.mint_a.address())
@@ -256,28 +256,31 @@ impl<'a> ProcessAccountInfos<'a> for TakeAccounts<'a> {
 			.assert_writable()?
 			.assert_type::<EscrowState>(&ID)?;
 
-		let EscrowState {
-			maker,
-			mint_a,
-			mint_b,
-			amount_b,
-			seed,
-			bump,
-			..
-		} = self.escrow.as_account::<EscrowState>(&ID)?;
+		let (maker, mint_a, mint_b, amount_b, seed, bump) = {
+			let escrow = self.escrow.as_account::<EscrowState>(&ID)?;
 
-		let escrow_seeds_with_bump = seeds_escrow!(self.maker.address().as_ref(), &seed.0, *bump);
+			(
+				escrow.maker,
+				escrow.mint_a,
+				escrow.mint_b,
+				escrow.amount_b,
+				escrow.seed,
+				escrow.bump,
+			)
+		};
+
+		let escrow_seeds_with_bump = seeds_escrow!(self.maker.address().as_ref(), &seed.0, bump);
 		self.escrow
 			.assert_seeds_with_bump(escrow_seeds_with_bump, &ID)?;
 
 		// Validate maker and mint accounts
-		self.maker.assert_address(maker)?;
+		self.maker.assert_address(&maker)?;
 		self.mint_a
 			.assert_owners(&SPL_PROGRAM_IDS)?
-			.assert_address(mint_a)?;
+			.assert_address(&mint_a)?;
 		self.mint_b
 			.assert_owners(&SPL_PROGRAM_IDS)?
-			.assert_address(mint_b)?;
+			.assert_address(&mint_b)?;
 
 		// Validate vault and maker ATA
 		self.vault
@@ -314,14 +317,14 @@ impl<'a> ProcessAccountInfos<'a> for TakeAccounts<'a> {
 			mint: self.mint_b,
 			to: self.maker_ata_b,
 			authority: self.taker,
-			amount: (*amount_b).into(),
+			amount: amount_b.into(),
 			decimals: self.mint_b.as_token_2022_mint()?.decimals(),
 			token_program: self.token_program.address(),
 		}
 		.invoke()?;
 
 		// Prepare escrow signer for vault operations
-		let bump_as_seeds = [*bump];
+		let bump_as_seeds = [bump];
 		let escrow_seeds =
 			seeds_escrow!(true, self.maker.address().as_ref(), &seed.0, &bump_as_seeds);
 		let escrow_signer = Signer::from(&escrow_seeds);

--- a/examples/role_registry_program/src/lib.rs
+++ b/examples/role_registry_program/src/lib.rs
@@ -203,7 +203,7 @@ impl<'a> ProcessAccountInfos<'a> for InitializeAccounts<'a> {
 			args.bump,
 		)?;
 
-		let registry_config = self.registry_config.as_account_mut::<RegistryConfig>(&ID)?;
+		let mut registry_config = self.registry_config.as_account_mut::<RegistryConfig>(&ID)?;
 		*registry_config = RegistryConfig::builder()
 			.admin(*self.admin.address())
 			.role_count(PodU64::from_primitive(0))
@@ -251,7 +251,7 @@ impl<'a> ProcessAccountInfos<'a> for AddRoleAccounts<'a> {
 			.checked_add(1)
 			.ok_or(ProgramError::ArithmeticOverflow)?;
 
-		let role_entry = self.role_entry.as_account_mut::<RoleEntry>(&ID)?;
+		let mut role_entry = self.role_entry.as_account_mut::<RoleEntry>(&ID)?;
 		*role_entry = RoleEntry::builder()
 			.registry(*self.registry_config.address())
 			.role_id(args.role_id)
@@ -261,7 +261,7 @@ impl<'a> ProcessAccountInfos<'a> for AddRoleAccounts<'a> {
 			.bump(args.bump)
 			.build();
 
-		let registry_config = self.registry_config.as_account_mut::<RegistryConfig>(&ID)?;
+		let mut registry_config = self.registry_config.as_account_mut::<RegistryConfig>(&ID)?;
 		registry_config.role_count = PodU64::from_primitive(role_count);
 
 		Ok(())
@@ -295,7 +295,7 @@ impl<'a> ProcessAccountInfos<'a> for UpdateRoleAccounts<'a> {
 			return Err(RegistryError::InvalidPermissions.into());
 		}
 
-		let role_entry = self.role_entry.as_account_mut::<RoleEntry>(&ID)?;
+		let mut role_entry = self.role_entry.as_account_mut::<RoleEntry>(&ID)?;
 		role_entry.permissions = args.permissions;
 
 		Ok(())
@@ -327,7 +327,7 @@ impl<'a> ProcessAccountInfos<'a> for DeactivateRoleAccounts<'a> {
 			return Err(RegistryError::RoleInactive.into());
 		}
 
-		let role_entry = self.role_entry.as_account_mut::<RoleEntry>(&ID)?;
+		let mut role_entry = self.role_entry.as_account_mut::<RoleEntry>(&ID)?;
 		role_entry.active = PodBool::from_bool(false);
 
 		Ok(())
@@ -346,7 +346,7 @@ impl<'a> ProcessAccountInfos<'a> for RotateAdminAccounts<'a> {
 
 		self.admin.assert_address(&registry_config.admin)?;
 
-		let registry_config = self.registry_config.as_account_mut::<RegistryConfig>(&ID)?;
+		let mut registry_config = self.registry_config.as_account_mut::<RegistryConfig>(&ID)?;
 		registry_config.admin = *self.new_admin.address();
 
 		Ok(())

--- a/examples/staking_rewards_program/src/lib.rs
+++ b/examples/staking_rewards_program/src/lib.rs
@@ -279,7 +279,7 @@ impl<'a> ProcessAccountInfos<'a> for InitializePoolAccounts<'a> {
 		)?;
 
 		// Initialize pool state
-		let pool_state = self.pool_state.as_account_mut::<PoolState>(&ID)?;
+		let mut pool_state = self.pool_state.as_account_mut::<PoolState>(&ID)?;
 		*pool_state = PoolState::builder()
 			.admin(*self.admin.address())
 			.stake_mint(*self.stake_mint.address())
@@ -358,7 +358,7 @@ impl<'a> ProcessAccountInfos<'a> for OpenPositionAccounts<'a> {
 		)?;
 
 		// Initialize position state
-		let position_state = self.position_state.as_account_mut::<PositionState>(&ID)?;
+		let mut position_state = self.position_state.as_account_mut::<PositionState>(&ID)?;
 		*position_state = PositionState::builder()
 			.pool(*self.pool_state.address())
 			.owner(*self.user.address())
@@ -409,8 +409,8 @@ impl<'a> ProcessAccountInfos<'a> for DepositAccounts<'a> {
 		if amount == 0 {
 			return Err(StakingError::InvalidAmount.into());
 		}
-		assert_pool_stake_mint(pool_state, self.stake_mint)?;
-		assert_position_access(self.pool_state, self.user, position_state)?;
+		assert_pool_stake_mint(&pool_state, self.stake_mint)?;
+		assert_position_access(self.pool_state, self.user, &position_state)?;
 
 		// Calculate updated amounts
 		let staked_amount = u64::from(position_state.staked_amount);
@@ -421,8 +421,11 @@ impl<'a> ProcessAccountInfos<'a> for DepositAccounts<'a> {
 			.checked_add(amount)
 			.ok_or(ProgramError::ArithmeticOverflow)?;
 
+		drop(position_state);
+		drop(pool_state);
+
 		// Update position state
-		let position_state = self.position_state.as_account_mut::<PositionState>(&ID)?;
+		let mut position_state = self.position_state.as_account_mut::<PositionState>(&ID)?;
 		position_state.staked_amount = PodU64::from_primitive(next_staked);
 		position_state.reward_debt = PodU64::from_primitive(
 			u64::from(position_state.reward_debt)
@@ -431,7 +434,7 @@ impl<'a> ProcessAccountInfos<'a> for DepositAccounts<'a> {
 		);
 
 		// Update pool state
-		let pool_state = self.pool_state.as_account_mut::<PoolState>(&ID)?;
+		let mut pool_state = self.pool_state.as_account_mut::<PoolState>(&ID)?;
 		pool_state.total_staked = PodU64::from_primitive(total_staked);
 
 		// Ensure user's stake ATA exists
@@ -486,20 +489,23 @@ impl<'a> ProcessAccountInfos<'a> for WithdrawAccounts<'a> {
 		if amount == 0 {
 			return Err(StakingError::InvalidAmount.into());
 		}
-		assert_pool_stake_mint(pool_state, self.stake_mint)?;
-		assert_position_access(self.pool_state, self.user, position_state)?;
+		assert_pool_stake_mint(&pool_state, self.stake_mint)?;
+		assert_position_access(self.pool_state, self.user, &position_state)?;
 
 		let staked_amount = u64::from(position_state.staked_amount);
 		if amount > staked_amount {
 			return Err(StakingError::InsufficientBalance.into());
 		}
 
+		drop(position_state);
+		drop(pool_state);
+
 		// Update position state
-		let position_state = self.position_state.as_account_mut::<PositionState>(&ID)?;
+		let mut position_state = self.position_state.as_account_mut::<PositionState>(&ID)?;
 		position_state.staked_amount = PodU64::from_primitive(staked_amount - amount);
 
 		// Update pool state
-		let pool_state = self.pool_state.as_account_mut::<PoolState>(&ID)?;
+		let mut pool_state = self.pool_state.as_account_mut::<PoolState>(&ID)?;
 		pool_state.total_staked =
 			PodU64::from_primitive(u64::from(pool_state.total_staked) - amount);
 
@@ -537,15 +543,18 @@ impl<'a> ProcessAccountInfos<'a> for ClaimAccounts<'a> {
 		if bool::from(pool_state.paused) {
 			return Err(StakingError::PoolPaused.into());
 		}
-		assert_pool_reward_mint(pool_state, self.reward_mint)?;
-		assert_position_access(self.pool_state, self.user, position_state)?;
+		assert_pool_reward_mint(&pool_state, self.reward_mint)?;
+		assert_position_access(self.pool_state, self.user, &position_state)?;
 
 		// Calculate and update pending rewards
 		let next_pending = u64::from(position_state.pending_rewards)
 			.checked_add(u64::from(pool_state.reward_index))
 			.ok_or(ProgramError::ArithmeticOverflow)?;
 
-		let position_state = self.position_state.as_account_mut::<PositionState>(&ID)?;
+		drop(position_state);
+		drop(pool_state);
+
+		let mut position_state = self.position_state.as_account_mut::<PositionState>(&ID)?;
 		position_state.pending_rewards = PodU64::from_primitive(next_pending);
 
 		// Ensure user's reward ATA exists

--- a/examples/todo_program/src/lib.rs
+++ b/examples/todo_program/src/lib.rs
@@ -101,7 +101,7 @@ impl<'a> ProcessAccountInfos<'a> for InitializeAccounts<'a> {
 		)?;
 
 		// Initialize account data
-		let todo = self.todo.as_account_mut::<TodoState>(&ID)?;
+		let mut todo = self.todo.as_account_mut::<TodoState>(&ID)?;
 		*todo = TodoState::builder()
 			.owner(*owner)
 			.bump(args.bump)
@@ -141,14 +141,14 @@ impl<'a> ProcessAccountInfos<'a> for UpdateAccounts<'a> {
 		match instruction {
 			TodoInstruction::ToggleCompleted => {
 				let _ = ToggleCompletedInstruction::try_from_bytes(data)?;
-				let todo = self.todo.as_account_mut::<TodoState>(&ID)?;
+				let mut todo = self.todo.as_account_mut::<TodoState>(&ID)?;
 				let completed = bool::from(todo.completed);
 
 				todo.completed = PodBool::from_bool(!completed);
 			}
 			TodoInstruction::UpdateDigest => {
 				let args = UpdateDigestInstruction::try_from_bytes(data)?;
-				let todo = self.todo.as_account_mut::<TodoState>(&ID)?;
+				let mut todo = self.todo.as_account_mut::<TodoState>(&ID)?;
 
 				todo.digest = args.digest;
 			}

--- a/examples/vesting_program/src/lib.rs
+++ b/examples/vesting_program/src/lib.rs
@@ -199,7 +199,7 @@ impl<'a> ProcessAccountInfos<'a> for InitializeAccounts<'a> {
 			args.bump,
 		)?;
 
-		let vesting_state = self.vesting_state.as_account_mut::<VestingState>(&ID)?;
+		let mut vesting_state = self.vesting_state.as_account_mut::<VestingState>(&ID)?;
 		*vesting_state = VestingState::builder()
 			.admin(*self.admin.address())
 			.beneficiary(*self.beneficiary.address())
@@ -284,7 +284,7 @@ impl<'a> ProcessAccountInfos<'a> for ClaimAccounts<'a> {
 			return Err(VestingError::ClaimTooLarge.into());
 		}
 
-		let vesting_state = self.vesting_state.as_account_mut::<VestingState>(&ID)?;
+		let mut vesting_state = self.vesting_state.as_account_mut::<VestingState>(&ID)?;
 		vesting_state.claimed_amount = PodU64::from_primitive(next_claimed);
 
 		associated_token_account::instructions::CreateIdempotent {
@@ -339,7 +339,7 @@ impl<'a> ProcessAccountInfos<'a> for CancelAccounts<'a> {
 			return Err(VestingError::AlreadyCancelled.into());
 		}
 
-		let vesting_state = self.vesting_state.as_account_mut::<VestingState>(&ID)?;
+		let mut vesting_state = self.vesting_state.as_account_mut::<VestingState>(&ID)?;
 		vesting_state.cancelled = PodBool::from_bool(true);
 
 		Ok(())

--- a/security/00-signer-authorization/insecure/src/lib.rs
+++ b/security/00-signer-authorization/insecure/src/lib.rs
@@ -54,7 +54,7 @@ impl<'a> ProcessAccountInfos<'a> for WithdrawAccounts<'a> {
 			.assert_writable()?
 			.assert_type::<VaultState>(&ID)?;
 
-		let vault = self.vault.as_account_mut::<VaultState>(&ID)?;
+		let mut vault = self.vault.as_account_mut::<VaultState>(&ID)?;
 		let current: u64 = vault.balance.into();
 		let amount: u64 = args.amount.into();
 

--- a/security/00-signer-authorization/secure/src/lib.rs
+++ b/security/00-signer-authorization/secure/src/lib.rs
@@ -61,7 +61,7 @@ impl<'a> ProcessAccountInfos<'a> for WithdrawAccounts<'a> {
 		// Also verify the authority matches the vault's stored authority.
 		self.authority.assert_address(&vault.authority)?;
 
-		let vault = self.vault.as_account_mut::<VaultState>(&ID)?;
+		let mut vault = self.vault.as_account_mut::<VaultState>(&ID)?;
 		let current: u64 = vault.balance.into();
 		let amount: u64 = args.amount.into();
 

--- a/security/03-type-cosplay/secure/src/lib.rs
+++ b/security/03-type-cosplay/secure/src/lib.rs
@@ -61,7 +61,7 @@ impl<'a> ProcessAccountInfos<'a> for AdminActionAccounts<'a> {
 
 		self.authority.assert_address(&config.authority)?;
 
-		let config_mut = self.config.as_account_mut::<AdminConfig>(&ID)?;
+		let mut config_mut = self.config.as_account_mut::<AdminConfig>(&ID)?;
 		config_mut.fee = args.new_fee;
 
 		Ok(())

--- a/security/04-initialization/insecure/src/lib.rs
+++ b/security/04-initialization/insecure/src/lib.rs
@@ -69,7 +69,7 @@ impl<'a> ProcessAccountInfos<'a> for InitializeAccounts<'a> {
 			args.bump,
 		)?;
 
-		let config = self.config.as_account_mut::<Config>(&ID)?;
+		let mut config = self.config.as_account_mut::<Config>(&ID)?;
 		*config = Config::builder()
 			.authority(*self.authority.address())
 			.value(args.value)

--- a/security/04-initialization/secure/src/lib.rs
+++ b/security/04-initialization/secure/src/lib.rs
@@ -64,7 +64,7 @@ impl<'a> ProcessAccountInfos<'a> for InitializeAccounts<'a> {
 			args.bump,
 		)?;
 
-		let config = self.config.as_account_mut::<Config>(&ID)?;
+		let mut config = self.config.as_account_mut::<Config>(&ID)?;
 
 		*config = Config::builder()
 			.authority(*self.authority.address())

--- a/security/06-duplicate-mutable-accounts/insecure/src/lib.rs
+++ b/security/06-duplicate-mutable-accounts/insecure/src/lib.rs
@@ -57,11 +57,11 @@ impl<'a> ProcessAccountInfos<'a> for TransferAccounts<'a> {
 		// operate on the same account.
 		let amount: u64 = args.amount.into();
 
-		let source = self.source.as_account_mut::<Balance>(&ID)?;
+		let mut source = self.source.as_account_mut::<Balance>(&ID)?;
 		let source_amount: u64 = source.amount.into();
 		source.amount = PodU64::from_primitive(source_amount.saturating_sub(amount));
 
-		let dest = self.dest.as_account_mut::<Balance>(&ID)?;
+		let mut dest = self.dest.as_account_mut::<Balance>(&ID)?;
 		let dest_amount: u64 = dest.amount.into();
 		dest.amount = PodU64::from_primitive(dest_amount.saturating_add(amount));
 

--- a/security/06-duplicate-mutable-accounts/secure/src/lib.rs
+++ b/security/06-duplicate-mutable-accounts/secure/src/lib.rs
@@ -77,10 +77,10 @@ impl<'a> ProcessAccountInfos<'a> for TransferAccounts<'a> {
 
 		let amount: u64 = args.amount.into();
 
-		let source = self.source.as_account_mut::<Balance>(&ID)?;
+		let mut source = self.source.as_account_mut::<Balance>(&ID)?;
 		let source_amount: u64 = source.amount.into();
 
-		let dest = self.dest.as_account_mut::<Balance>(&ID)?;
+		let mut dest = self.dest.as_account_mut::<Balance>(&ID)?;
 		let dest_amount: u64 = dest.amount.into();
 
 		let (new_source, new_dest) = checked_transfer_balances(source_amount, dest_amount, amount)?;

--- a/security/07-bump-seed-canonicalization/insecure/src/lib.rs
+++ b/security/07-bump-seed-canonicalization/insecure/src/lib.rs
@@ -69,7 +69,7 @@ impl<'a> ProcessAccountInfos<'a> for CreateAccounts<'a> {
 		let seeds = &[SEED, self.authority.address().as_ref()];
 		create_program_account_with_bump::<Data>(self.data, self.authority, &ID, seeds, args.bump)?;
 
-		let data_account = self.data.as_account_mut::<Data>(&ID)?;
+		let mut data_account = self.data.as_account_mut::<Data>(&ID)?;
 		*data_account = Data::builder()
 			.authority(*self.authority.address())
 			.value(args.value)

--- a/security/07-bump-seed-canonicalization/secure/src/lib.rs
+++ b/security/07-bump-seed-canonicalization/secure/src/lib.rs
@@ -60,7 +60,7 @@ impl<'a> ProcessAccountInfos<'a> for CreateAccounts<'a> {
 		let (_address, bump) =
 			create_program_account::<Data>(self.data, self.authority, &ID, seeds)?;
 
-		let data_account = self.data.as_account_mut::<Data>(&ID)?;
+		let mut data_account = self.data.as_account_mut::<Data>(&ID)?;
 
 		*data_account = Data::builder()
 			.authority(*self.authority.address())

--- a/security/08-pda-sharing/insecure/src/lib.rs
+++ b/security/08-pda-sharing/insecure/src/lib.rs
@@ -73,7 +73,7 @@ impl<'a> ProcessAccountInfos<'a> for CreateConfigAccounts<'a> {
 		let (_address, bump) =
 			create_program_account::<UserConfig>(self.config, self.authority, &ID, seeds)?;
 
-		let config = self.config.as_account_mut::<UserConfig>(&ID)?;
+		let mut config = self.config.as_account_mut::<UserConfig>(&ID)?;
 		*config = UserConfig::builder()
 			.authority(*self.authority.address())
 			.setting(args.setting)

--- a/security/08-pda-sharing/secure/src/lib.rs
+++ b/security/08-pda-sharing/secure/src/lib.rs
@@ -73,7 +73,7 @@ impl<'a> ProcessAccountInfos<'a> for CreateConfigAccounts<'a> {
 		let (_address, bump) =
 			create_program_account::<UserConfig>(self.config, self.authority, &ID, seeds)?;
 
-		let config = self.config.as_account_mut::<UserConfig>(&ID)?;
+		let mut config = self.config.as_account_mut::<UserConfig>(&ID)?;
 
 		*config = UserConfig::builder()
 			.authority(*self.authority.address())


### PR DESCRIPTION
## Summary

- make `as_account` and `as_account_mut` return guard-backed wrappers instead of bare references
- add `LoadedAccount` / `LoadedAccountMut` and use `pinocchio::account::Ref::try_map` to preserve runtime borrows
- update examples, security fixtures, and docs for the new wrapper-based API shape
- add regression tests proving immutable and mutable typed loads block overlapping borrows until drop

## Linked issues

- Closes #120
- Related to #119

## Testing

- `cargo test --workspace --all-features`
- `git diff --check`
- `dprint fmt`

## Notes

- Rebasing check: this branch was rebased against the latest `origin/main` before push.
- Token and token-2022 helper loaders are intentionally left for follow-up in #121.

## Title and history conventions

- [x] PR title uses Conventional Commits syntax
- [x] Commits in this PR use Conventional Commits syntax
- [x] Referenced issue titles are written in sentence case


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Account access methods now return guard-backed wrapper types enforcing lifetime-aware borrow semantics to prevent overlapping borrows at runtime.

* **Documentation**
  * Guides and tutorials updated to describe the guard-backed account access pattern and correct usage flow.

* **Tests**
  * Added integration tests validating runtime borrow-guard lifetimes.

* **Examples**
  * Updated example programs to use mutable bindings and scoped reads consistent with the new access pattern.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->