### PR TITLE
fix(token): make helper loaders guard-backed

### DIFF
--- a/crates/pina/src/impls.rs
+++ b/crates/pina/src/impls.rs
@@ -464,19 +464,48 @@ impl_account_validation!(
 );
 
 #[cfg(feature = "token")]
+#[track_caller]
+fn load_token_state<'a, T: ?Sized>(
+	account: &'a AccountView,
+	owners: &[Address],
+	minimum_len: usize,
+	from_bytes: unsafe fn(&[u8]) -> &T,
+) -> Result<LoadedAccount<'a, T>, ProgramError> {
+	account.assert_owners(owners)?;
+
+	if account.data_len() < minimum_len {
+		log!(
+			"address: {} has an incorrect length",
+			account.address().as_ref()
+		);
+		log_caller();
+
+		return Err(ProgramError::InvalidAccountData);
+	}
+
+	let bytes = account.try_borrow()?;
+	let state = AccountRef::map(bytes, |data| {
+		// SAFETY: the base layout length was validated above, the allowed owner
+		// set was validated above, and the returned `LoadedAccount` keeps the
+		// underlying runtime borrow alive for the entire lifetime of the typed
+		// access.
+		unsafe { from_bytes(data) }
+	});
+
+	Ok(LoadedAccount::new(state))
+}
+
+#[cfg(feature = "token")]
 impl AsTokenAccount for AccountView {
 	#[track_caller]
-	fn as_token_mint(&self) -> Result<&crate::token::state::Mint, ProgramError> {
-		self.check_borrow()?;
-
-		// SECURITY: relies on pinocchio's internal layout validation inside
-		// `from_account_view_unchecked`. Callers should verify ownership before
-		// trusting the result.
-		unsafe { crate::token::state::Mint::from_account_view_unchecked(self) }
+	fn as_token_mint(&self) -> Result<LoadedAccount<'_, crate::token::state::Mint>, ProgramError> {
+		crate::token::state::Mint::from_account_view(self).map(LoadedAccount::new)
 	}
 
 	#[track_caller]
-	fn as_token_mint_checked(&self) -> Result<&crate::token::state::Mint, ProgramError> {
+	fn as_token_mint_checked(
+		&self,
+	) -> Result<LoadedAccount<'_, crate::token::state::Mint>, ProgramError> {
 		self.as_token_mint_checked_with_owners(&[crate::token::ID])
 	}
 
@@ -484,24 +513,26 @@ impl AsTokenAccount for AccountView {
 	fn as_token_mint_checked_with_owners(
 		&self,
 		owners: &[Address],
-	) -> Result<&crate::token::state::Mint, ProgramError> {
-		self.assert_owners(owners)?;
-		self.as_token_mint()
-	}
-
-	fn as_token_account(&self) -> Result<&crate::token::state::TokenAccount, ProgramError> {
-		self.check_borrow()?;
-
-		// SAFETY: `check_borrow()` verified the account is not already mutably
-		// borrowed. `from_account_view_unchecked` performs a pointer cast from
-		// the account data to the target type layout. The caller is responsible
-		// for verifying ownership before trusting the result — the `_checked`
-		// variants handle this automatically.
-		unsafe { crate::token::state::TokenAccount::from_account_view_unchecked(self) }
+	) -> Result<LoadedAccount<'_, crate::token::state::Mint>, ProgramError> {
+		load_token_state(
+			self,
+			owners,
+			crate::token::state::Mint::LEN,
+			crate::token::state::Mint::from_bytes_unchecked,
+		)
 	}
 
 	#[track_caller]
-	fn as_token_account_checked(&self) -> Result<&crate::token::state::TokenAccount, ProgramError> {
+	fn as_token_account(
+		&self,
+	) -> Result<LoadedAccount<'_, crate::token::state::TokenAccount>, ProgramError> {
+		crate::token::state::TokenAccount::from_account_view(self).map(LoadedAccount::new)
+	}
+
+	#[track_caller]
+	fn as_token_account_checked(
+		&self,
+	) -> Result<LoadedAccount<'_, crate::token::state::TokenAccount>, ProgramError> {
 		self.as_token_account_checked_with_owners(&[crate::token::ID])
 	}
 
@@ -509,24 +540,26 @@ impl AsTokenAccount for AccountView {
 	fn as_token_account_checked_with_owners(
 		&self,
 		owners: &[Address],
-	) -> Result<&crate::token::state::TokenAccount, ProgramError> {
-		self.assert_owners(owners)?;
-		self.as_token_account()
-	}
-
-	fn as_token_2022_mint(&self) -> Result<&crate::token_2022::state::Mint, ProgramError> {
-		self.check_borrow()?;
-
-		// SAFETY: `check_borrow()` verified the account is not already mutably
-		// borrowed. `from_account_view_unchecked` performs a pointer cast from
-		// the account data to the target type layout. The caller is responsible
-		// for verifying ownership before trusting the result — the `_checked`
-		// variants handle this automatically.
-		unsafe { crate::token_2022::state::Mint::from_account_view_unchecked(self) }
+	) -> Result<LoadedAccount<'_, crate::token::state::TokenAccount>, ProgramError> {
+		load_token_state(
+			self,
+			owners,
+			crate::token::state::TokenAccount::LEN,
+			crate::token::state::TokenAccount::from_bytes_unchecked,
+		)
 	}
 
 	#[track_caller]
-	fn as_token_2022_mint_checked(&self) -> Result<&crate::token_2022::state::Mint, ProgramError> {
+	fn as_token_2022_mint(
+		&self,
+	) -> Result<LoadedAccount<'_, crate::token_2022::state::Mint>, ProgramError> {
+		crate::token_2022::state::Mint::from_account_view(self).map(LoadedAccount::new)
+	}
+
+	#[track_caller]
+	fn as_token_2022_mint_checked(
+		&self,
+	) -> Result<LoadedAccount<'_, crate::token_2022::state::Mint>, ProgramError> {
 		self.as_token_2022_mint_checked_with_owners(&[crate::token_2022::ID])
 	}
 
@@ -534,28 +567,26 @@ impl AsTokenAccount for AccountView {
 	fn as_token_2022_mint_checked_with_owners(
 		&self,
 		owners: &[Address],
-	) -> Result<&crate::token_2022::state::Mint, ProgramError> {
-		self.assert_owners(owners)?;
-		self.as_token_2022_mint()
+	) -> Result<LoadedAccount<'_, crate::token_2022::state::Mint>, ProgramError> {
+		load_token_state(
+			self,
+			owners,
+			crate::token_2022::state::Mint::BASE_LEN,
+			crate::token_2022::state::Mint::from_bytes_unchecked,
+		)
 	}
 
+	#[track_caller]
 	fn as_token_2022_account(
 		&self,
-	) -> Result<&crate::token_2022::state::TokenAccount, ProgramError> {
-		self.check_borrow()?;
-
-		// SAFETY: `check_borrow()` verified the account is not already mutably
-		// borrowed. `from_account_view_unchecked` performs a pointer cast from
-		// the account data to the target type layout. The caller is responsible
-		// for verifying ownership before trusting the result — the `_checked`
-		// variants handle this automatically.
-		unsafe { crate::token_2022::state::TokenAccount::from_account_view_unchecked(self) }
+	) -> Result<LoadedAccount<'_, crate::token_2022::state::TokenAccount>, ProgramError> {
+		crate::token_2022::state::TokenAccount::from_account_view(self).map(LoadedAccount::new)
 	}
 
 	#[track_caller]
 	fn as_token_2022_account_checked(
 		&self,
-	) -> Result<&crate::token_2022::state::TokenAccount, ProgramError> {
+	) -> Result<LoadedAccount<'_, crate::token_2022::state::TokenAccount>, ProgramError> {
 		self.as_token_2022_account_checked_with_owners(&[crate::token_2022::ID])
 	}
 
@@ -563,30 +594,31 @@ impl AsTokenAccount for AccountView {
 	fn as_token_2022_account_checked_with_owners(
 		&self,
 		owners: &[Address],
-	) -> Result<&crate::token_2022::state::TokenAccount, ProgramError> {
-		self.assert_owners(owners)?;
-		self.as_token_2022_account()
+	) -> Result<LoadedAccount<'_, crate::token_2022::state::TokenAccount>, ProgramError> {
+		load_token_state(
+			self,
+			owners,
+			crate::token_2022::state::TokenAccount::BASE_LEN,
+			crate::token_2022::state::TokenAccount::from_bytes_unchecked,
+		)
 	}
 
+	#[track_caller]
 	fn as_associated_token_account(
 		&self,
 		owner: &Address,
 		mint: &Address,
 		token_program: &Address,
-	) -> Result<&crate::token::state::TokenAccount, ProgramError> {
-		self.check_borrow()?;
+	) -> Result<LoadedAccount<'_, crate::token::state::TokenAccount>, ProgramError> {
+		let owners = [*token_program];
+		let account = self.assert_associated_token_address(owner, mint, token_program)?;
 
-		// SAFETY: `check_borrow()` verified the account is not already mutably
-		// borrowed. `from_account_view_unchecked` performs a pointer cast from
-		// the account data to the target type layout. The caller is responsible
-		// for verifying ownership before trusting the result — the `_checked`
-		// variants handle this automatically. Additionally, the address is
-		// verified against the derived ATA address before the unchecked cast.
-		unsafe {
-			crate::token::state::TokenAccount::from_account_view_unchecked(
-				self.assert_associated_token_address(owner, mint, token_program)?,
-			)
-		}
+		load_token_state(
+			account,
+			&owners,
+			crate::token::state::TokenAccount::LEN,
+			crate::token::state::TokenAccount::from_bytes_unchecked,
+		)
 	}
 
 	#[track_caller]
@@ -595,7 +627,7 @@ impl AsTokenAccount for AccountView {
 		owner: &Address,
 		mint: &Address,
 		token_program: &Address,
-	) -> Result<&crate::token::state::TokenAccount, ProgramError> {
+	) -> Result<LoadedAccount<'_, crate::token::state::TokenAccount>, ProgramError> {
 		self.assert_owner(token_program)?;
 		self.as_associated_token_account(owner, mint, token_program)
 	}

--- a/crates/pina/src/traits.rs
+++ b/crates/pina/src/traits.rs
@@ -519,57 +519,71 @@ pub trait AsAccount {
 /// Convenience methods for interpreting `AccountView` as SPL token account
 /// types.
 ///
-/// The `*_checked` variants enforce owner checks before casting. The raw
-/// variants are lower-level and assume caller-side owner validation.
+/// All token loaders return guard-backed wrappers so the runtime borrow stays
+/// active for the full lifetime of the typed access.
+///
+/// The raw variants validate the canonical owner for the loader they expose.
+/// The `*_checked_with_owners` variants accept a custom owner allowlist before
+/// reinterpreting the shared token base layout.
 ///
 /// <!-- {=pinaTokenFeatureGateContract|trim|linePrefix:"/// ":true} -->/// This API is gated behind the `token` feature. Keep token-specific code behind `#[cfg(feature = "token")]` so on-chain programs that do not use SPL token interfaces can avoid extra dependencies.<!-- {/pinaTokenFeatureGateContract} -->
 #[cfg(feature = "token")]
 pub trait AsTokenAccount {
 	/// Interpret the account data as an SPL Token mint.
-	fn as_token_mint(&self) -> Result<&crate::token::state::Mint, ProgramError>;
+	fn as_token_mint(&self) -> Result<LoadedAccount<'_, crate::token::state::Mint>, ProgramError>;
 	/// Interpret the account data as an SPL Token mint, validating owner.
-	fn as_token_mint_checked(&self) -> Result<&crate::token::state::Mint, ProgramError>;
+	fn as_token_mint_checked(
+		&self,
+	) -> Result<LoadedAccount<'_, crate::token::state::Mint>, ProgramError>;
 	/// Interpret the account data as an SPL Token mint, validating owner is one
 	/// of the provided program ids.
 	fn as_token_mint_checked_with_owners(
 		&self,
 		owners: &[Address],
-	) -> Result<&crate::token::state::Mint, ProgramError>;
+	) -> Result<LoadedAccount<'_, crate::token::state::Mint>, ProgramError>;
 	/// Interpret the account data as an SPL Token account.
-	fn as_token_account(&self) -> Result<&crate::token::state::TokenAccount, ProgramError>;
+	fn as_token_account(
+		&self,
+	) -> Result<LoadedAccount<'_, crate::token::state::TokenAccount>, ProgramError>;
 	/// Interpret the account data as an SPL Token account, validating owner.
-	fn as_token_account_checked(&self) -> Result<&crate::token::state::TokenAccount, ProgramError>;
+	fn as_token_account_checked(
+		&self,
+	) -> Result<LoadedAccount<'_, crate::token::state::TokenAccount>, ProgramError>;
 	/// Interpret the account data as an SPL Token account, validating owner is
 	/// one of the provided program ids.
 	fn as_token_account_checked_with_owners(
 		&self,
 		owners: &[Address],
-	) -> Result<&crate::token::state::TokenAccount, ProgramError>;
+	) -> Result<LoadedAccount<'_, crate::token::state::TokenAccount>, ProgramError>;
 	/// Interpret the account data as a Token-2022 mint.
-	fn as_token_2022_mint(&self) -> Result<&crate::token_2022::state::Mint, ProgramError>;
+	fn as_token_2022_mint(
+		&self,
+	) -> Result<LoadedAccount<'_, crate::token_2022::state::Mint>, ProgramError>;
 	/// Interpret the account data as a Token-2022 mint, validating owner.
-	fn as_token_2022_mint_checked(&self) -> Result<&crate::token_2022::state::Mint, ProgramError>;
+	fn as_token_2022_mint_checked(
+		&self,
+	) -> Result<LoadedAccount<'_, crate::token_2022::state::Mint>, ProgramError>;
 	/// Interpret the account data as a Token-2022 mint, validating owner is one
 	/// of the provided program ids.
 	fn as_token_2022_mint_checked_with_owners(
 		&self,
 		owners: &[Address],
-	) -> Result<&crate::token_2022::state::Mint, ProgramError>;
+	) -> Result<LoadedAccount<'_, crate::token_2022::state::Mint>, ProgramError>;
 	/// Interpret the account data as a Token-2022 token account.
 	fn as_token_2022_account(
 		&self,
-	) -> Result<&crate::token_2022::state::TokenAccount, ProgramError>;
+	) -> Result<LoadedAccount<'_, crate::token_2022::state::TokenAccount>, ProgramError>;
 	/// Interpret the account data as a Token-2022 token account, validating
 	/// owner.
 	fn as_token_2022_account_checked(
 		&self,
-	) -> Result<&crate::token_2022::state::TokenAccount, ProgramError>;
+	) -> Result<LoadedAccount<'_, crate::token_2022::state::TokenAccount>, ProgramError>;
 	/// Interpret the account data as a Token-2022 token account, validating
 	/// owner is one of the provided program ids.
 	fn as_token_2022_account_checked_with_owners(
 		&self,
 		owners: &[Address],
-	) -> Result<&crate::token_2022::state::TokenAccount, ProgramError>;
+	) -> Result<LoadedAccount<'_, crate::token_2022::state::TokenAccount>, ProgramError>;
 	/// Interpret the account data as an associated token account, verifying
 	/// the address matches the derived ATA for the given wallet, mint, and
 	/// token program.
@@ -578,7 +592,7 @@ pub trait AsTokenAccount {
 		owner: &Address,
 		mint: &Address,
 		token_program: &Address,
-	) -> Result<&crate::token::state::TokenAccount, ProgramError>;
+	) -> Result<LoadedAccount<'_, crate::token::state::TokenAccount>, ProgramError>;
 	/// Interpret the account data as an associated token account, validating
 	/// both owner and ATA derivation.
 	fn as_associated_token_account_checked(
@@ -586,7 +600,7 @@ pub trait AsTokenAccount {
 		owner: &Address,
 		mint: &Address,
 		token_program: &Address,
-	) -> Result<&crate::token::state::TokenAccount, ProgramError>;
+	) -> Result<LoadedAccount<'_, crate::token::state::TokenAccount>, ProgramError>;
 }
 
 /// Direct lamport transfer between accounts.

--- a/crates/pina/tests/integration.rs
+++ b/crates/pina/tests/integration.rs
@@ -477,6 +477,34 @@ fn build_test_state_bytes(bump: u8, value: u64) -> Vec<u8> {
 	bytemuck::bytes_of(&state).to_vec()
 }
 
+#[cfg(feature = "token")]
+fn write_address_bytes(data: &mut [u8], offset: usize, address: &Address) {
+	data[offset..offset + ADDRESS_BYTES].copy_from_slice(address.as_ref());
+}
+
+#[cfg(feature = "token")]
+fn build_token_mint_bytes(decimals: u8, supply: u64) -> Vec<u8> {
+	let mut data = vec![0u8; token::state::Mint::LEN];
+	data[0] = 1;
+	write_address_bytes(&mut data, 4, &system::ID);
+	data[36..44].copy_from_slice(&supply.to_le_bytes());
+	data[44] = decimals;
+	data[45] = 1;
+	data[46] = 1;
+	write_address_bytes(&mut data, 50, &TEST_PROGRAM_ID);
+	data
+}
+
+#[cfg(feature = "token")]
+fn build_token_account_bytes(mint: &Address, owner: &Address, amount: u64) -> Vec<u8> {
+	let mut data = vec![0u8; token::state::TokenAccount::LEN];
+	write_address_bytes(&mut data, 0, mint);
+	write_address_bytes(&mut data, 32, owner);
+	data[64..72].copy_from_slice(&amount.to_le_bytes());
+	data[104] = 1;
+	data
+}
+
 // ---------------------------------------------------------------------------
 // Test: Full account lifecycle
 // ---------------------------------------------------------------------------
@@ -1521,6 +1549,220 @@ fn as_account_mut_blocks_overlapping_borrows_until_drop() {
 		.as_account::<TestState>(&TEST_PROGRAM_ID)
 		.unwrap_or_else(|e| panic!("read after drop failed: {e:?}"));
 	assert_eq!(u64::from(state.value), 88);
+}
+
+#[cfg(feature = "token")]
+#[test]
+fn as_token_mint_keeps_borrow_guard_alive_until_drop() {
+	let mint_key: Address = address!("BHvLHF6mJpWxywWY5S2tsHdDtHirHyeRxoS6uF6T5FoY");
+	let mint_data = build_token_mint_bytes(6, 1_000);
+
+	let accounts = [AccountBuilder::new()
+		.address(mint_key)
+		.owner(token::ID)
+		.lamports(1_000_000)
+		.data(&mint_data)
+		.is_writable(true)];
+
+	let dummy_data: &[u8] = &[0u8];
+	let mut input = unsafe { create_test_input(&accounts, dummy_data) };
+	let mut accts = [UNINIT; 10];
+	let (_, account_views, ..) = unsafe { deserialize_test_input::<10>(&mut input, &mut accts) };
+
+	let mint = account_views[0]
+		.as_token_mint()
+		.unwrap_or_else(|e| panic!("mint load failed: {e:?}"));
+	assert_eq!(mint.decimals(), 6);
+	assert_eq!(mint.supply(), 1_000);
+
+	assert!(matches!(
+		account_views[0].try_borrow_mut(),
+		Err(ProgramError::AccountBorrowFailed)
+	));
+
+	drop(mint);
+
+	assert!(account_views[0].try_borrow_mut().is_ok());
+}
+
+#[cfg(feature = "token")]
+#[test]
+fn as_token_account_keeps_borrow_guard_alive_until_drop() {
+	let token_account_key: Address = address!("3Jiy8N6ZGv3ueH9k3svLRaHscmQbE6v7W9FHJaGH2mki");
+	let mint: Address = address!("4hT5gDpr9HMmXzttW2Kz7LxyzKDn5XxhxL7sRKqGZo4x");
+	let owner: Address = address!("6QWeT6FpJrm8AF1btu6WH2k2Xhq6t5vbheKVfQavmeoZ");
+	let token_account_data = build_token_account_bytes(&mint, &owner, 77);
+
+	let accounts = [AccountBuilder::new()
+		.address(token_account_key)
+		.owner(token::ID)
+		.lamports(1_000_000)
+		.data(&token_account_data)
+		.is_writable(true)];
+
+	let dummy_data: &[u8] = &[0u8];
+	let mut input = unsafe { create_test_input(&accounts, dummy_data) };
+	let mut accts = [UNINIT; 10];
+	let (_, account_views, ..) = unsafe { deserialize_test_input::<10>(&mut input, &mut accts) };
+
+	let token_account = account_views[0]
+		.as_token_account()
+		.unwrap_or_else(|e| panic!("token account load failed: {e:?}"));
+	assert_eq!(token_account.amount(), 77);
+	assert_eq!(token_account.mint(), &mint);
+	assert_eq!(token_account.owner(), &owner);
+
+	assert!(matches!(
+		account_views[0].try_borrow_mut(),
+		Err(ProgramError::AccountBorrowFailed)
+	));
+
+	drop(token_account);
+
+	assert!(account_views[0].try_borrow_mut().is_ok());
+}
+
+#[cfg(feature = "token")]
+#[test]
+fn as_token_2022_mint_keeps_borrow_guard_alive_until_drop() {
+	let mint_key: Address = address!("8qbHbw2BbbTHBW1sK7d7Yx4Z4DccnE9vrFica8FWHQrP");
+	let mint_data = build_token_mint_bytes(9, 42);
+
+	let accounts = [AccountBuilder::new()
+		.address(mint_key)
+		.owner(token_2022::ID)
+		.lamports(1_000_000)
+		.data(&mint_data)
+		.is_writable(true)];
+
+	let dummy_data: &[u8] = &[0u8];
+	let mut input = unsafe { create_test_input(&accounts, dummy_data) };
+	let mut accts = [UNINIT; 10];
+	let (_, account_views, ..) = unsafe { deserialize_test_input::<10>(&mut input, &mut accts) };
+
+	let mint = account_views[0]
+		.as_token_2022_mint()
+		.unwrap_or_else(|e| panic!("token-2022 mint load failed: {e:?}"));
+	assert_eq!(mint.decimals(), 9);
+	assert_eq!(mint.supply(), 42);
+
+	assert!(matches!(
+		account_views[0].try_borrow_mut(),
+		Err(ProgramError::AccountBorrowFailed)
+	));
+
+	drop(mint);
+
+	assert!(account_views[0].try_borrow_mut().is_ok());
+}
+
+#[cfg(feature = "token")]
+#[test]
+fn as_token_2022_account_keeps_borrow_guard_alive_until_drop() {
+	let token_account_key: Address = address!("4vJ9JU1bJJE96FWSJKv9J5xBqHkM7SspGq2pZ7uS5k4x");
+	let mint: Address = address!("CktRuQ2mttxyPjdvVSxGJySLjeRGna43E77gzHu6HotE");
+	let owner: Address = address!("4Nd1mL5g7dUvNbKQjnYQgQki71RJKVQ1BM8DT6vKrrf5");
+	let token_account_data = build_token_account_bytes(&mint, &owner, 123);
+
+	let accounts = [AccountBuilder::new()
+		.address(token_account_key)
+		.owner(token_2022::ID)
+		.lamports(1_000_000)
+		.data(&token_account_data)
+		.is_writable(true)];
+
+	let dummy_data: &[u8] = &[0u8];
+	let mut input = unsafe { create_test_input(&accounts, dummy_data) };
+	let mut accts = [UNINIT; 10];
+	let (_, account_views, ..) = unsafe { deserialize_test_input::<10>(&mut input, &mut accts) };
+
+	let token_account = account_views[0]
+		.as_token_2022_account()
+		.unwrap_or_else(|e| panic!("token-2022 account load failed: {e:?}"));
+	assert_eq!(token_account.amount(), 123);
+	assert_eq!(token_account.mint(), &mint);
+	assert_eq!(token_account.owner(), &owner);
+
+	assert!(matches!(
+		account_views[0].try_borrow_mut(),
+		Err(ProgramError::AccountBorrowFailed)
+	));
+
+	drop(token_account);
+
+	assert!(account_views[0].try_borrow_mut().is_ok());
+}
+
+#[cfg(feature = "token")]
+#[test]
+fn as_token_account_checked_with_owners_accepts_token_2022_owner() {
+	let token_account_key: Address = address!("6QWeT6FpJrm8AF1btu6WH2k2Xhq6t5vbheKVfQavmeoZ");
+	let mint: Address = address!("4hT5gDpr9HMmXzttW2Kz7LxyzKDn5XxhxL7sRKqGZo4x");
+	let owner: Address = address!("BHvLHF6mJpWxywWY5S2tsHdDtHirHyeRxoS6uF6T5FoY");
+	let token_account_data = build_token_account_bytes(&mint, &owner, 88);
+
+	let accounts = [AccountBuilder::new()
+		.address(token_account_key)
+		.owner(token_2022::ID)
+		.lamports(1_000_000)
+		.data(&token_account_data)
+		.is_writable(true)];
+
+	let dummy_data: &[u8] = &[0u8];
+	let mut input = unsafe { create_test_input(&accounts, dummy_data) };
+	let mut accts = [UNINIT; 10];
+	let (_, account_views, ..) = unsafe { deserialize_test_input::<10>(&mut input, &mut accts) };
+
+	let token_account = account_views[0]
+		.as_token_account_checked_with_owners(&[token::ID, token_2022::ID])
+		.unwrap_or_else(|e| panic!("multi-owner token account load failed: {e:?}"));
+	assert_eq!(token_account.amount(), 88);
+
+	assert!(matches!(
+		account_views[0].try_borrow_mut(),
+		Err(ProgramError::AccountBorrowFailed)
+	));
+
+	drop(token_account);
+
+	assert!(account_views[0].try_borrow_mut().is_ok());
+}
+
+#[cfg(feature = "token")]
+#[test]
+fn as_associated_token_account_checked_accepts_token_2022_owner() {
+	let wallet: Address = address!("4Nd1mL5g7dUvNbKQjnYQgQki71RJKVQ1BM8DT6vKrrf5");
+	let mint: Address = address!("CktRuQ2mttxyPjdvVSxGJySLjeRGna43E77gzHu6HotE");
+	let (ata_address, _bump) = try_get_associated_token_address(&wallet, &mint, &token_2022::ID)
+		.unwrap_or_else(|| panic!("failed to derive ata"));
+	let token_account_data = build_token_account_bytes(&mint, &wallet, 99);
+
+	let accounts = [AccountBuilder::new()
+		.address(ata_address)
+		.owner(token_2022::ID)
+		.lamports(1_000_000)
+		.data(&token_account_data)
+		.is_writable(true)];
+
+	let dummy_data: &[u8] = &[0u8];
+	let mut input = unsafe { create_test_input(&accounts, dummy_data) };
+	let mut accts = [UNINIT; 10];
+	let (_, account_views, ..) = unsafe { deserialize_test_input::<10>(&mut input, &mut accts) };
+
+	let token_account = account_views[0]
+		.as_associated_token_account_checked(&wallet, &mint, &token_2022::ID)
+		.unwrap_or_else(|e| panic!("associated token account load failed: {e:?}"));
+	assert_eq!(token_account.amount(), 99);
+	assert_eq!(token_account.owner(), &wallet);
+
+	assert!(matches!(
+		account_views[0].try_borrow_mut(),
+		Err(ProgramError::AccountBorrowFailed)
+	));
+
+	drop(token_account);
+
+	assert!(account_views[0].try_borrow_mut().is_ok());
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- make token, token-2022, and associated token helper loaders return guard-backed wrappers
- preserve runtime borrows for the full typed-access lifetime, including multi-owner and ATA helper paths
- add regression tests for token/token-2022 mint and account loaders plus multi-owner and ATA compatibility cases

## Linked issues

- Closes #121
- Related to #119

## Testing

- `cargo test -p pina --tests --all-features`
- `cargo test --workspace --all-features`
- `git diff --check`
- `dprint fmt`

## Notes

- This PR was rebased onto the latest `origin/main` so it can merge directly once #120 lands on `main`.
- Rebase check: the branch was verified against the latest `origin/main` before push.

## Title and history conventions

- [x] PR title uses Conventional Commits syntax
- [x] Commits in this PR use Conventional Commits syntax
- [x] Referenced issue titles are written in sentence case
