### PR TITLE
fix(ci): restore codama verification after prop amm merge

### DIFF
--- a/codama/clients/js/prop_amm_program/src/generated/accounts/index.ts
+++ b/codama/clients/js/prop_amm_program/src/generated/accounts/index.ts
@@ -6,4 +6,4 @@
  * @see https://github.com/codama-idl/codama
  */
 
-export * from './oracleState';
+export * from "./oracleState";

--- a/codama/clients/js/prop_amm_program/src/generated/accounts/oracleState.ts
+++ b/codama/clients/js/prop_amm_program/src/generated/accounts/oracleState.ts
@@ -6,71 +6,115 @@
  * @see https://github.com/codama-idl/codama
  */
 
-import { assertAccountExists, assertAccountsExist, combineCodec, decodeAccount, fetchEncodedAccount, fetchEncodedAccounts, getAddressDecoder, getAddressEncoder, getStructDecoder, getStructEncoder, getU64Decoder, getU64Encoder, getU8Encoder, type Account, type Address, type EncodedAccount, type FetchAccountConfig, type FetchAccountsConfig, type FixedSizeCodec, type FixedSizeDecoder, type FixedSizeEncoder, type MaybeAccount, type MaybeEncodedAccount } from '@solana/kit';
+import {
+	type Account,
+	type Address,
+	assertAccountExists,
+	assertAccountsExist,
+	combineCodec,
+	decodeAccount,
+	type EncodedAccount,
+	type FetchAccountConfig,
+	type FetchAccountsConfig,
+	fetchEncodedAccount,
+	fetchEncodedAccounts,
+	type FixedSizeCodec,
+	type FixedSizeDecoder,
+	type FixedSizeEncoder,
+	getAddressDecoder,
+	getAddressEncoder,
+	getStructDecoder,
+	getStructEncoder,
+	getU64Decoder,
+	getU64Encoder,
+	getU8Encoder,
+	type MaybeAccount,
+	type MaybeEncodedAccount,
+} from "@solana/kit";
 
 export const ORACLE_STATE_DISCRIMINATOR = 1;
 
-export function getOracleStateDiscriminatorBytes() { return getU8Encoder().encode(ORACLE_STATE_DISCRIMINATOR); }
+export function getOracleStateDiscriminatorBytes() {
+	return getU8Encoder().encode(ORACLE_STATE_DISCRIMINATOR);
+}
 
-export type OracleState = { authority: Address; price: bigint;  };
+export type OracleState = { authority: Address; price: bigint };
 
-export type OracleStateArgs = { authority: Address; price: number | bigint;  };
+export type OracleStateArgs = { authority: Address; price: number | bigint };
 
 /** Gets the encoder for {@link OracleStateArgs} account data. */
 export function getOracleStateEncoder(): FixedSizeEncoder<OracleStateArgs> {
-    return getStructEncoder([['authority', getAddressEncoder()], ['price', getU64Encoder()]]);
+	return getStructEncoder([["authority", getAddressEncoder()], [
+		"price",
+		getU64Encoder(),
+	]]);
 }
 
 /** Gets the decoder for {@link OracleState} account data. */
 export function getOracleStateDecoder(): FixedSizeDecoder<OracleState> {
-    return getStructDecoder([['authority', getAddressDecoder()], ['price', getU64Decoder()]]);
+	return getStructDecoder([["authority", getAddressDecoder()], [
+		"price",
+		getU64Decoder(),
+	]]);
 }
 
 /** Gets the codec for {@link OracleState} account data. */
-export function getOracleStateCodec(): FixedSizeCodec<OracleStateArgs, OracleState> {
-    return combineCodec(getOracleStateEncoder(), getOracleStateDecoder());
+export function getOracleStateCodec(): FixedSizeCodec<
+	OracleStateArgs,
+	OracleState
+> {
+	return combineCodec(getOracleStateEncoder(), getOracleStateDecoder());
 }
 
-export function decodeOracleState<TAddress extends string = string>(encodedAccount: EncodedAccount<TAddress>): Account<OracleState, TAddress>;
-export function decodeOracleState<TAddress extends string = string>(encodedAccount: MaybeEncodedAccount<TAddress>): MaybeAccount<OracleState, TAddress>;
-export function decodeOracleState<TAddress extends string = string>(encodedAccount: EncodedAccount<TAddress> | MaybeEncodedAccount<TAddress>): Account<OracleState, TAddress> | MaybeAccount<OracleState, TAddress> {
-  return decodeAccount(encodedAccount as MaybeEncodedAccount<TAddress>, getOracleStateDecoder());
+export function decodeOracleState<TAddress extends string = string>(
+	encodedAccount: EncodedAccount<TAddress>,
+): Account<OracleState, TAddress>;
+export function decodeOracleState<TAddress extends string = string>(
+	encodedAccount: MaybeEncodedAccount<TAddress>,
+): MaybeAccount<OracleState, TAddress>;
+export function decodeOracleState<TAddress extends string = string>(
+	encodedAccount: EncodedAccount<TAddress> | MaybeEncodedAccount<TAddress>,
+): Account<OracleState, TAddress> | MaybeAccount<OracleState, TAddress> {
+	return decodeAccount(
+		encodedAccount as MaybeEncodedAccount<TAddress>,
+		getOracleStateDecoder(),
+	);
 }
 
 export async function fetchOracleState<TAddress extends string = string>(
-  rpc: Parameters<typeof fetchEncodedAccount>[0],
-  address: Address<TAddress>,
-  config?: FetchAccountConfig,
+	rpc: Parameters<typeof fetchEncodedAccount>[0],
+	address: Address<TAddress>,
+	config?: FetchAccountConfig,
 ): Promise<Account<OracleState, TAddress>> {
-  const maybeAccount = await fetchMaybeOracleState(rpc, address, config);
-  assertAccountExists(maybeAccount);
-  return maybeAccount;
+	const maybeAccount = await fetchMaybeOracleState(rpc, address, config);
+	assertAccountExists(maybeAccount);
+	return maybeAccount;
 }
 
 export async function fetchMaybeOracleState<TAddress extends string = string>(
-  rpc: Parameters<typeof fetchEncodedAccount>[0],
-  address: Address<TAddress>,
-  config?: FetchAccountConfig,
+	rpc: Parameters<typeof fetchEncodedAccount>[0],
+	address: Address<TAddress>,
+	config?: FetchAccountConfig,
 ): Promise<MaybeAccount<OracleState, TAddress>> {
-  const maybeAccount = await fetchEncodedAccount(rpc, address, config);
-  return decodeOracleState(maybeAccount);
+	const maybeAccount = await fetchEncodedAccount(rpc, address, config);
+	return decodeOracleState(maybeAccount);
 }
 
 export async function fetchAllOracleState(
-  rpc: Parameters<typeof fetchEncodedAccounts>[0],
-  addresses: Array<Address>,
-  config?: FetchAccountsConfig,
+	rpc: Parameters<typeof fetchEncodedAccounts>[0],
+	addresses: Array<Address>,
+	config?: FetchAccountsConfig,
 ): Promise<Account<OracleState>[]> {
-  const maybeAccounts = await fetchAllMaybeOracleState(rpc, addresses, config);
-  assertAccountsExist(maybeAccounts);
-  return maybeAccounts;
+	const maybeAccounts = await fetchAllMaybeOracleState(rpc, addresses, config);
+	assertAccountsExist(maybeAccounts);
+	return maybeAccounts;
 }
 
 export async function fetchAllMaybeOracleState(
-  rpc: Parameters<typeof fetchEncodedAccounts>[0],
-  addresses: Array<Address>,
-  config?: FetchAccountsConfig,
+	rpc: Parameters<typeof fetchEncodedAccounts>[0],
+	addresses: Array<Address>,
+	config?: FetchAccountsConfig,
 ): Promise<MaybeAccount<OracleState>[]> {
-  const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
-  return maybeAccounts.map((maybeAccount) => decodeOracleState(maybeAccount));
+	const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
+	return maybeAccounts.map((maybeAccount) => decodeOracleState(maybeAccount));
 }

--- a/codama/clients/js/prop_amm_program/src/generated/errors/index.ts
+++ b/codama/clients/js/prop_amm_program/src/generated/errors/index.ts
@@ -6,4 +6,4 @@
  * @see https://github.com/codama-idl/codama
  */
 
-export * from './propAmmProgram';
+export * from "./propAmmProgram";

--- a/codama/clients/js/prop_amm_program/src/generated/errors/propAmmProgram.ts
+++ b/codama/clients/js/prop_amm_program/src/generated/errors/propAmmProgram.ts
@@ -6,31 +6,58 @@
  * @see https://github.com/codama-idl/codama
  */
 
-import { isProgramError, type Address, type SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM, type SolanaError } from '@solana/kit';
-import { PROP_AMM_PROGRAM_PROGRAM_ADDRESS } from '../programs';
+import {
+	type Address,
+	isProgramError,
+	type SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM,
+	type SolanaError,
+} from "@solana/kit";
+import { PROP_AMM_PROGRAM_PROGRAM_ADDRESS } from "../programs";
 
 export const PROP_AMM_PROGRAM_ERROR__UNAUTHORIZED_UPDATE_AUTHORITY = 0x0; // 0
 export const PROP_AMM_PROGRAM_ERROR__UNAUTHORIZED_ORACLE_AUTHORITY = 0x1; // 1
 
-export type PropAmmProgramError = typeof PROP_AMM_PROGRAM_ERROR__UNAUTHORIZED_ORACLE_AUTHORITY | typeof PROP_AMM_PROGRAM_ERROR__UNAUTHORIZED_UPDATE_AUTHORITY;
+export type PropAmmProgramError =
+	| typeof PROP_AMM_PROGRAM_ERROR__UNAUTHORIZED_ORACLE_AUTHORITY
+	| typeof PROP_AMM_PROGRAM_ERROR__UNAUTHORIZED_UPDATE_AUTHORITY;
 
-let propAmmProgramErrorMessages: Record<PropAmmProgramError, string> | undefined;
-if (process.env.NODE_ENV !== 'production') {
-  propAmmProgramErrorMessages = { [PROP_AMM_PROGRAM_ERROR__UNAUTHORIZED_ORACLE_AUTHORITY]: ``, [PROP_AMM_PROGRAM_ERROR__UNAUTHORIZED_UPDATE_AUTHORITY]: `` };
+let propAmmProgramErrorMessages:
+	| Record<PropAmmProgramError, string>
+	| undefined;
+if (process.env.NODE_ENV !== "production") {
+	propAmmProgramErrorMessages = {
+		[PROP_AMM_PROGRAM_ERROR__UNAUTHORIZED_ORACLE_AUTHORITY]: ``,
+		[PROP_AMM_PROGRAM_ERROR__UNAUTHORIZED_UPDATE_AUTHORITY]: ``,
+	};
 }
 
-export function getPropAmmProgramErrorMessage(code: PropAmmProgramError): string {
-  if (process.env.NODE_ENV !== 'production') {
-    return (propAmmProgramErrorMessages as Record<PropAmmProgramError, string>)[code];
-  }
+export function getPropAmmProgramErrorMessage(
+	code: PropAmmProgramError,
+): string {
+	if (process.env.NODE_ENV !== "production") {
+		return (propAmmProgramErrorMessages as Record<PropAmmProgramError, string>)[
+			code
+		];
+	}
 
-  return 'Error message not available in production bundles.';
+	return "Error message not available in production bundles.";
 }
 
-export function isPropAmmProgramError<TProgramErrorCode extends PropAmmProgramError>(
-    error: unknown,
-    transactionMessage: { instructions: Record<number, { programAddress: Address }> },
-    code?: TProgramErrorCode,
-): error is SolanaError<typeof SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM> & Readonly<{ context: Readonly<{ code: TProgramErrorCode }> }> {
-  return isProgramError<TProgramErrorCode>(error, transactionMessage, PROP_AMM_PROGRAM_PROGRAM_ADDRESS, code);
+export function isPropAmmProgramError<
+	TProgramErrorCode extends PropAmmProgramError,
+>(
+	error: unknown,
+	transactionMessage: {
+		instructions: Record<number, { programAddress: Address }>;
+	},
+	code?: TProgramErrorCode,
+): error is
+	& SolanaError<typeof SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM>
+	& Readonly<{ context: Readonly<{ code: TProgramErrorCode }> }> {
+	return isProgramError<TProgramErrorCode>(
+		error,
+		transactionMessage,
+		PROP_AMM_PROGRAM_PROGRAM_ADDRESS,
+		code,
+	);
 }

--- a/codama/clients/js/prop_amm_program/src/generated/index.ts
+++ b/codama/clients/js/prop_amm_program/src/generated/index.ts
@@ -6,7 +6,7 @@
  * @see https://github.com/codama-idl/codama
  */
 
-export * from './accounts';
-export * from './errors';
-export * from './instructions';
-export * from './programs';
+export * from "./accounts";
+export * from "./errors";
+export * from "./instructions";
+export * from "./programs";

--- a/codama/clients/js/prop_amm_program/src/generated/instructions/index.ts
+++ b/codama/clients/js/prop_amm_program/src/generated/instructions/index.ts
@@ -6,6 +6,6 @@
  * @see https://github.com/codama-idl/codama
  */
 
-export * from './initialize';
-export * from './rotateAuthority';
-export * from './update';
+export * from "./initialize";
+export * from "./rotateAuthority";
+export * from "./update";

--- a/codama/clients/js/prop_amm_program/src/generated/instructions/initialize.ts
+++ b/codama/clients/js/prop_amm_program/src/generated/instructions/initialize.ts
@@ -6,57 +6,159 @@
  * @see https://github.com/codama-idl/codama
  */
 
-import { getU8Encoder, SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, SolanaError, type AccountMeta, type AccountSignerMeta, type Address, type Instruction, type InstructionWithAccounts, type ReadonlyAccount, type TransactionSigner, type WritableSignerAccount } from '@solana/kit';
-import { getAccountMetaFactory, type ResolvedInstructionAccount } from '@solana/program-client-core';
-import { PROP_AMM_PROGRAM_PROGRAM_ADDRESS } from '../programs';
+import {
+	type AccountMeta,
+	type AccountSignerMeta,
+	type Address,
+	getU8Encoder,
+	type Instruction,
+	type InstructionWithAccounts,
+	type ReadonlyAccount,
+	SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+	SolanaError,
+	type TransactionSigner,
+	type WritableSignerAccount,
+} from "@solana/kit";
+import {
+	getAccountMetaFactory,
+	type ResolvedInstructionAccount,
+} from "@solana/program-client-core";
+import { PROP_AMM_PROGRAM_PROGRAM_ADDRESS } from "../programs";
 
 export const INITIALIZE_DISCRIMINATOR = 0;
 
-export function getInitializeDiscriminatorBytes() { return getU8Encoder().encode(INITIALIZE_DISCRIMINATOR); }
-
-export type InitializeInstruction<TProgram extends string = typeof PROP_AMM_PROGRAM_PROGRAM_ADDRESS, TAccountPayer extends string | AccountMeta<string> = string, TAccountOracle extends string | AccountMeta<string> = string, TAccountSystemProgram extends string | AccountMeta<string> = "11111111111111111111111111111111", TRemainingAccounts extends readonly AccountMeta<string>[] = []> =
-Instruction<TProgram> & InstructionWithAccounts<[TAccountPayer extends string ? WritableSignerAccount<TAccountPayer> & AccountSignerMeta<TAccountPayer> : TAccountPayer, TAccountOracle extends string ? WritableSignerAccount<TAccountOracle> & AccountSignerMeta<TAccountOracle> : TAccountOracle, TAccountSystemProgram extends string ? ReadonlyAccount<TAccountSystemProgram> : TAccountSystemProgram, ...TRemainingAccounts]>;
-
-export type InitializeInput<TAccountPayer extends string = string, TAccountOracle extends string = string, TAccountSystemProgram extends string = string> =  {
-  payer: TransactionSigner<TAccountPayer>;
-oracle: TransactionSigner<TAccountOracle>;
-systemProgram?: Address<TAccountSystemProgram>;
+export function getInitializeDiscriminatorBytes() {
+	return getU8Encoder().encode(INITIALIZE_DISCRIMINATOR);
 }
 
-export function getInitializeInstruction<TAccountPayer extends string, TAccountOracle extends string, TAccountSystemProgram extends string, TProgramAddress extends Address = typeof PROP_AMM_PROGRAM_PROGRAM_ADDRESS>(input: InitializeInput<TAccountPayer, TAccountOracle, TAccountSystemProgram>, config?: { programAddress?: TProgramAddress } ): InitializeInstruction<TProgramAddress, TAccountPayer, TAccountOracle, TAccountSystemProgram> {
-  // Program address.
-const programAddress = config?.programAddress ?? PROP_AMM_PROGRAM_PROGRAM_ADDRESS;
+export type InitializeInstruction<
+	TProgram extends string = typeof PROP_AMM_PROGRAM_PROGRAM_ADDRESS,
+	TAccountPayer extends string | AccountMeta<string> = string,
+	TAccountOracle extends string | AccountMeta<string> = string,
+	TAccountSystemProgram extends string | AccountMeta<string> =
+		"11111111111111111111111111111111",
+	TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> =
+	& Instruction<TProgram>
+	& InstructionWithAccounts<
+		[
+			TAccountPayer extends string ?
+					& WritableSignerAccount<TAccountPayer>
+					& AccountSignerMeta<TAccountPayer>
+				: TAccountPayer,
+			TAccountOracle extends string ?
+					& WritableSignerAccount<TAccountOracle>
+					& AccountSignerMeta<TAccountOracle>
+				: TAccountOracle,
+			TAccountSystemProgram extends string
+				? ReadonlyAccount<TAccountSystemProgram>
+				: TAccountSystemProgram,
+			...TRemainingAccounts,
+		]
+	>;
 
- // Original accounts.
-const originalAccounts = { payer: { value: input.payer ?? null, isWritable: true }, oracle: { value: input.oracle ?? null, isWritable: true }, systemProgram: { value: input.systemProgram ?? null, isWritable: false } }
-const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedInstructionAccount>;
+export type InitializeInput<
+	TAccountPayer extends string = string,
+	TAccountOracle extends string = string,
+	TAccountSystemProgram extends string = string,
+> = {
+	payer: TransactionSigner<TAccountPayer>;
+	oracle: TransactionSigner<TAccountOracle>;
+	systemProgram?: Address<TAccountSystemProgram>;
+};
 
+export function getInitializeInstruction<
+	TAccountPayer extends string,
+	TAccountOracle extends string,
+	TAccountSystemProgram extends string,
+	TProgramAddress extends Address = typeof PROP_AMM_PROGRAM_PROGRAM_ADDRESS,
+>(
+	input: InitializeInput<TAccountPayer, TAccountOracle, TAccountSystemProgram>,
+	config?: { programAddress?: TProgramAddress },
+): InitializeInstruction<
+	TProgramAddress,
+	TAccountPayer,
+	TAccountOracle,
+	TAccountSystemProgram
+> {
+	// Program address.
+	const programAddress = config?.programAddress ??
+		PROP_AMM_PROGRAM_PROGRAM_ADDRESS;
 
-// Resolve default values.
-if (!accounts.systemProgram.value) {
-accounts.systemProgram.value = '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
+	// Original accounts.
+	const originalAccounts = {
+		payer: { value: input.payer ?? null, isWritable: true },
+		oracle: { value: input.oracle ?? null, isWritable: true },
+		systemProgram: { value: input.systemProgram ?? null, isWritable: false },
+	};
+	const accounts = originalAccounts as Record<
+		keyof typeof originalAccounts,
+		ResolvedInstructionAccount
+	>;
+
+	// Resolve default values.
+	if (!accounts.systemProgram.value) {
+		accounts.systemProgram.value =
+			"11111111111111111111111111111111" as Address<
+				"11111111111111111111111111111111"
+			>;
+	}
+
+	const getAccountMeta = getAccountMetaFactory(programAddress, "programId");
+	return Object.freeze({
+		accounts: [
+			getAccountMeta("payer", accounts.payer),
+			getAccountMeta("oracle", accounts.oracle),
+			getAccountMeta("systemProgram", accounts.systemProgram),
+		],
+		programAddress,
+	} as InitializeInstruction<
+		TProgramAddress,
+		TAccountPayer,
+		TAccountOracle,
+		TAccountSystemProgram
+	>);
 }
 
-const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-return Object.freeze({ accounts: [getAccountMeta("payer", accounts.payer), getAccountMeta("oracle", accounts.oracle), getAccountMeta("systemProgram", accounts.systemProgram)], programAddress } as InitializeInstruction<TProgramAddress, TAccountPayer, TAccountOracle, TAccountSystemProgram>);
-}
+export type ParsedInitializeInstruction<
+	TProgram extends string = typeof PROP_AMM_PROGRAM_PROGRAM_ADDRESS,
+	TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+> = {
+	programAddress: Address<TProgram>;
+	accounts: {
+		payer: TAccountMetas[0];
+		oracle: TAccountMetas[1];
+		systemProgram: TAccountMetas[2];
+	};
+};
 
-export type ParsedInitializeInstruction<TProgram extends string = typeof PROP_AMM_PROGRAM_PROGRAM_ADDRESS, TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[]> = { programAddress: Address<TProgram>;
-accounts: {
-payer: TAccountMetas[0];
-oracle: TAccountMetas[1];
-systemProgram: TAccountMetas[2];
-}; };
-
-export function parseInitializeInstruction<TProgram extends string, TAccountMetas extends readonly AccountMeta[]>(instruction: Instruction<TProgram> & InstructionWithAccounts<TAccountMetas>): ParsedInitializeInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 3) {
-  throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, { actualAccountMetas: instruction.accounts.length, expectedAccountMetas: 3 });
-}
-let accountIndex = 0;
-const getNextAccount = () => {
-  const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-  accountIndex += 1;
-  return accountMeta;
-}
-  return { programAddress: instruction.programAddress, accounts: { payer: getNextAccount(), oracle: getNextAccount(), systemProgram: getNextAccount() } };
+export function parseInitializeInstruction<
+	TProgram extends string,
+	TAccountMetas extends readonly AccountMeta[],
+>(
+	instruction: Instruction<TProgram> & InstructionWithAccounts<TAccountMetas>,
+): ParsedInitializeInstruction<TProgram, TAccountMetas> {
+	if (instruction.accounts.length < 3) {
+		throw new SolanaError(
+			SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+			{
+				actualAccountMetas: instruction.accounts.length,
+				expectedAccountMetas: 3,
+			},
+		);
+	}
+	let accountIndex = 0;
+	const getNextAccount = () => {
+		const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+		accountIndex += 1;
+		return accountMeta;
+	};
+	return {
+		programAddress: instruction.programAddress,
+		accounts: {
+			payer: getNextAccount(),
+			oracle: getNextAccount(),
+			systemProgram: getNextAccount(),
+		},
+	};
 }

--- a/codama/clients/js/prop_amm_program/src/generated/instructions/rotateAuthority.ts
+++ b/codama/clients/js/prop_amm_program/src/generated/instructions/rotateAuthority.ts
@@ -6,74 +6,181 @@
  * @see https://github.com/codama-idl/codama
  */
 
-import { combineCodec, getAddressDecoder, getAddressEncoder, getStructDecoder, getStructEncoder, getU8Encoder, SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, SolanaError, type AccountMeta, type AccountSignerMeta, type Address, type FixedSizeCodec, type FixedSizeDecoder, type FixedSizeEncoder, type Instruction, type InstructionWithAccounts, type InstructionWithData, type ReadonlySignerAccount, type ReadonlyUint8Array, type TransactionSigner, type WritableAccount } from '@solana/kit';
-import { getAccountMetaFactory, type ResolvedInstructionAccount } from '@solana/program-client-core';
-import { PROP_AMM_PROGRAM_PROGRAM_ADDRESS } from '../programs';
+import {
+	type AccountMeta,
+	type AccountSignerMeta,
+	type Address,
+	combineCodec,
+	type FixedSizeCodec,
+	type FixedSizeDecoder,
+	type FixedSizeEncoder,
+	getAddressDecoder,
+	getAddressEncoder,
+	getStructDecoder,
+	getStructEncoder,
+	getU8Encoder,
+	type Instruction,
+	type InstructionWithAccounts,
+	type InstructionWithData,
+	type ReadonlySignerAccount,
+	type ReadonlyUint8Array,
+	SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+	SolanaError,
+	type TransactionSigner,
+	type WritableAccount,
+} from "@solana/kit";
+import {
+	getAccountMetaFactory,
+	type ResolvedInstructionAccount,
+} from "@solana/program-client-core";
+import { PROP_AMM_PROGRAM_PROGRAM_ADDRESS } from "../programs";
 
 export const ROTATE_AUTHORITY_DISCRIMINATOR = 2;
 
-export function getRotateAuthorityDiscriminatorBytes() { return getU8Encoder().encode(ROTATE_AUTHORITY_DISCRIMINATOR); }
+export function getRotateAuthorityDiscriminatorBytes() {
+	return getU8Encoder().encode(ROTATE_AUTHORITY_DISCRIMINATOR);
+}
 
-export type RotateAuthorityInstruction<TProgram extends string = typeof PROP_AMM_PROGRAM_PROGRAM_ADDRESS, TAccountOracle extends string | AccountMeta<string> = string, TAccountAuthority extends string | AccountMeta<string> = string, TRemainingAccounts extends readonly AccountMeta<string>[] = []> =
-Instruction<TProgram> & InstructionWithData<ReadonlyUint8Array> & InstructionWithAccounts<[TAccountOracle extends string ? WritableAccount<TAccountOracle> : TAccountOracle, TAccountAuthority extends string ? ReadonlySignerAccount<TAccountAuthority> & AccountSignerMeta<TAccountAuthority> : TAccountAuthority, ...TRemainingAccounts]>;
+export type RotateAuthorityInstruction<
+	TProgram extends string = typeof PROP_AMM_PROGRAM_PROGRAM_ADDRESS,
+	TAccountOracle extends string | AccountMeta<string> = string,
+	TAccountAuthority extends string | AccountMeta<string> = string,
+	TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> =
+	& Instruction<TProgram>
+	& InstructionWithData<ReadonlyUint8Array>
+	& InstructionWithAccounts<
+		[
+			TAccountOracle extends string ? WritableAccount<TAccountOracle>
+				: TAccountOracle,
+			TAccountAuthority extends string ?
+					& ReadonlySignerAccount<TAccountAuthority>
+					& AccountSignerMeta<TAccountAuthority>
+				: TAccountAuthority,
+			...TRemainingAccounts,
+		]
+	>;
 
-export type RotateAuthorityInstructionData = { newAuthority: Address;  };
+export type RotateAuthorityInstructionData = { newAuthority: Address };
 
 export type RotateAuthorityInstructionDataArgs = RotateAuthorityInstructionData;
 
-export function getRotateAuthorityInstructionDataEncoder(): FixedSizeEncoder<RotateAuthorityInstructionDataArgs> {
-    return getStructEncoder([['newAuthority', getAddressEncoder()]]);
+export function getRotateAuthorityInstructionDataEncoder(): FixedSizeEncoder<
+	RotateAuthorityInstructionDataArgs
+> {
+	return getStructEncoder([["newAuthority", getAddressEncoder()]]);
 }
 
-export function getRotateAuthorityInstructionDataDecoder(): FixedSizeDecoder<RotateAuthorityInstructionData> {
-    return getStructDecoder([['newAuthority', getAddressDecoder()]]);
+export function getRotateAuthorityInstructionDataDecoder(): FixedSizeDecoder<
+	RotateAuthorityInstructionData
+> {
+	return getStructDecoder([["newAuthority", getAddressDecoder()]]);
 }
 
-export function getRotateAuthorityInstructionDataCodec(): FixedSizeCodec<RotateAuthorityInstructionDataArgs, RotateAuthorityInstructionData> {
-    return combineCodec(getRotateAuthorityInstructionDataEncoder(), getRotateAuthorityInstructionDataDecoder());
+export function getRotateAuthorityInstructionDataCodec(): FixedSizeCodec<
+	RotateAuthorityInstructionDataArgs,
+	RotateAuthorityInstructionData
+> {
+	return combineCodec(
+		getRotateAuthorityInstructionDataEncoder(),
+		getRotateAuthorityInstructionDataDecoder(),
+	);
 }
 
-export type RotateAuthorityInput<TAccountOracle extends string = string, TAccountAuthority extends string = string> =  {
-  oracle: Address<TAccountOracle>;
-authority: TransactionSigner<TAccountAuthority>;
-newAuthority: RotateAuthorityInstructionDataArgs["newAuthority"];
-}
-
-export function getRotateAuthorityInstruction<TAccountOracle extends string, TAccountAuthority extends string, TProgramAddress extends Address = typeof PROP_AMM_PROGRAM_PROGRAM_ADDRESS>(input: RotateAuthorityInput<TAccountOracle, TAccountAuthority>, config?: { programAddress?: TProgramAddress } ): RotateAuthorityInstruction<TProgramAddress, TAccountOracle, TAccountAuthority> {
-  // Program address.
-const programAddress = config?.programAddress ?? PROP_AMM_PROGRAM_PROGRAM_ADDRESS;
-
- // Original accounts.
-const originalAccounts = { oracle: { value: input.oracle ?? null, isWritable: true }, authority: { value: input.authority ?? null, isWritable: false } }
-const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedInstructionAccount>;
-
-
-// Original args.
-const args = { ...input,  };
-
-
-
-
-const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-return Object.freeze({ accounts: [getAccountMeta("oracle", accounts.oracle), getAccountMeta("authority", accounts.authority)], data: getRotateAuthorityInstructionDataEncoder().encode(args as RotateAuthorityInstructionDataArgs), programAddress } as RotateAuthorityInstruction<TProgramAddress, TAccountOracle, TAccountAuthority>);
-}
-
-export type ParsedRotateAuthorityInstruction<TProgram extends string = typeof PROP_AMM_PROGRAM_PROGRAM_ADDRESS, TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[]> = { programAddress: Address<TProgram>;
-accounts: {
-oracle: TAccountMetas[0];
-authority: TAccountMetas[1];
+export type RotateAuthorityInput<
+	TAccountOracle extends string = string,
+	TAccountAuthority extends string = string,
+> = {
+	oracle: Address<TAccountOracle>;
+	authority: TransactionSigner<TAccountAuthority>;
+	newAuthority: RotateAuthorityInstructionDataArgs["newAuthority"];
 };
-data: RotateAuthorityInstructionData; };
 
-export function parseRotateAuthorityInstruction<TProgram extends string, TAccountMetas extends readonly AccountMeta[]>(instruction: Instruction<TProgram> & InstructionWithAccounts<TAccountMetas> & InstructionWithData<ReadonlyUint8Array>): ParsedRotateAuthorityInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 2) {
-  throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, { actualAccountMetas: instruction.accounts.length, expectedAccountMetas: 2 });
+export function getRotateAuthorityInstruction<
+	TAccountOracle extends string,
+	TAccountAuthority extends string,
+	TProgramAddress extends Address = typeof PROP_AMM_PROGRAM_PROGRAM_ADDRESS,
+>(
+	input: RotateAuthorityInput<TAccountOracle, TAccountAuthority>,
+	config?: { programAddress?: TProgramAddress },
+): RotateAuthorityInstruction<
+	TProgramAddress,
+	TAccountOracle,
+	TAccountAuthority
+> {
+	// Program address.
+	const programAddress = config?.programAddress ??
+		PROP_AMM_PROGRAM_PROGRAM_ADDRESS;
+
+	// Original accounts.
+	const originalAccounts = {
+		oracle: { value: input.oracle ?? null, isWritable: true },
+		authority: { value: input.authority ?? null, isWritable: false },
+	};
+	const accounts = originalAccounts as Record<
+		keyof typeof originalAccounts,
+		ResolvedInstructionAccount
+	>;
+
+	// Original args.
+	const args = { ...input };
+
+	const getAccountMeta = getAccountMetaFactory(programAddress, "programId");
+	return Object.freeze({
+		accounts: [
+			getAccountMeta("oracle", accounts.oracle),
+			getAccountMeta("authority", accounts.authority),
+		],
+		data: getRotateAuthorityInstructionDataEncoder().encode(
+			args as RotateAuthorityInstructionDataArgs,
+		),
+		programAddress,
+	} as RotateAuthorityInstruction<
+		TProgramAddress,
+		TAccountOracle,
+		TAccountAuthority
+	>);
 }
-let accountIndex = 0;
-const getNextAccount = () => {
-  const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-  accountIndex += 1;
-  return accountMeta;
-}
-  return { programAddress: instruction.programAddress, accounts: { oracle: getNextAccount(), authority: getNextAccount() }, data: getRotateAuthorityInstructionDataDecoder().decode(instruction.data) };
+
+export type ParsedRotateAuthorityInstruction<
+	TProgram extends string = typeof PROP_AMM_PROGRAM_PROGRAM_ADDRESS,
+	TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+> = {
+	programAddress: Address<TProgram>;
+	accounts: {
+		oracle: TAccountMetas[0];
+		authority: TAccountMetas[1];
+	};
+	data: RotateAuthorityInstructionData;
+};
+
+export function parseRotateAuthorityInstruction<
+	TProgram extends string,
+	TAccountMetas extends readonly AccountMeta[],
+>(
+	instruction:
+		& Instruction<TProgram>
+		& InstructionWithAccounts<TAccountMetas>
+		& InstructionWithData<ReadonlyUint8Array>,
+): ParsedRotateAuthorityInstruction<TProgram, TAccountMetas> {
+	if (instruction.accounts.length < 2) {
+		throw new SolanaError(
+			SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+			{
+				actualAccountMetas: instruction.accounts.length,
+				expectedAccountMetas: 2,
+			},
+		);
+	}
+	let accountIndex = 0;
+	const getNextAccount = () => {
+		const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+		accountIndex += 1;
+		return accountMeta;
+	};
+	return {
+		programAddress: instruction.programAddress,
+		accounts: { oracle: getNextAccount(), authority: getNextAccount() },
+		data: getRotateAuthorityInstructionDataDecoder().decode(instruction.data),
+	};
 }

--- a/codama/clients/js/prop_amm_program/src/generated/instructions/update.ts
+++ b/codama/clients/js/prop_amm_program/src/generated/instructions/update.ts
@@ -6,74 +6,173 @@
  * @see https://github.com/codama-idl/codama
  */
 
-import { combineCodec, getStructDecoder, getStructEncoder, getU64Decoder, getU64Encoder, getU8Encoder, SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, SolanaError, type AccountMeta, type AccountSignerMeta, type Address, type FixedSizeCodec, type FixedSizeDecoder, type FixedSizeEncoder, type Instruction, type InstructionWithAccounts, type InstructionWithData, type ReadonlySignerAccount, type ReadonlyUint8Array, type TransactionSigner, type WritableAccount } from '@solana/kit';
-import { getAccountMetaFactory, type ResolvedInstructionAccount } from '@solana/program-client-core';
-import { PROP_AMM_PROGRAM_PROGRAM_ADDRESS } from '../programs';
+import {
+	type AccountMeta,
+	type AccountSignerMeta,
+	type Address,
+	combineCodec,
+	type FixedSizeCodec,
+	type FixedSizeDecoder,
+	type FixedSizeEncoder,
+	getStructDecoder,
+	getStructEncoder,
+	getU64Decoder,
+	getU64Encoder,
+	getU8Encoder,
+	type Instruction,
+	type InstructionWithAccounts,
+	type InstructionWithData,
+	type ReadonlySignerAccount,
+	type ReadonlyUint8Array,
+	SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+	SolanaError,
+	type TransactionSigner,
+	type WritableAccount,
+} from "@solana/kit";
+import {
+	getAccountMetaFactory,
+	type ResolvedInstructionAccount,
+} from "@solana/program-client-core";
+import { PROP_AMM_PROGRAM_PROGRAM_ADDRESS } from "../programs";
 
 export const UPDATE_DISCRIMINATOR = 1;
 
-export function getUpdateDiscriminatorBytes() { return getU8Encoder().encode(UPDATE_DISCRIMINATOR); }
-
-export type UpdateInstruction<TProgram extends string = typeof PROP_AMM_PROGRAM_PROGRAM_ADDRESS, TAccountOracle extends string | AccountMeta<string> = string, TAccountAuthority extends string | AccountMeta<string> = string, TRemainingAccounts extends readonly AccountMeta<string>[] = []> =
-Instruction<TProgram> & InstructionWithData<ReadonlyUint8Array> & InstructionWithAccounts<[TAccountOracle extends string ? WritableAccount<TAccountOracle> : TAccountOracle, TAccountAuthority extends string ? ReadonlySignerAccount<TAccountAuthority> & AccountSignerMeta<TAccountAuthority> : TAccountAuthority, ...TRemainingAccounts]>;
-
-export type UpdateInstructionData = { newPrice: bigint;  };
-
-export type UpdateInstructionDataArgs = { newPrice: number | bigint;  };
-
-export function getUpdateInstructionDataEncoder(): FixedSizeEncoder<UpdateInstructionDataArgs> {
-    return getStructEncoder([['newPrice', getU64Encoder()]]);
+export function getUpdateDiscriminatorBytes() {
+	return getU8Encoder().encode(UPDATE_DISCRIMINATOR);
 }
 
-export function getUpdateInstructionDataDecoder(): FixedSizeDecoder<UpdateInstructionData> {
-    return getStructDecoder([['newPrice', getU64Decoder()]]);
+export type UpdateInstruction<
+	TProgram extends string = typeof PROP_AMM_PROGRAM_PROGRAM_ADDRESS,
+	TAccountOracle extends string | AccountMeta<string> = string,
+	TAccountAuthority extends string | AccountMeta<string> = string,
+	TRemainingAccounts extends readonly AccountMeta<string>[] = [],
+> =
+	& Instruction<TProgram>
+	& InstructionWithData<ReadonlyUint8Array>
+	& InstructionWithAccounts<
+		[
+			TAccountOracle extends string ? WritableAccount<TAccountOracle>
+				: TAccountOracle,
+			TAccountAuthority extends string ?
+					& ReadonlySignerAccount<TAccountAuthority>
+					& AccountSignerMeta<TAccountAuthority>
+				: TAccountAuthority,
+			...TRemainingAccounts,
+		]
+	>;
+
+export type UpdateInstructionData = { newPrice: bigint };
+
+export type UpdateInstructionDataArgs = { newPrice: number | bigint };
+
+export function getUpdateInstructionDataEncoder(): FixedSizeEncoder<
+	UpdateInstructionDataArgs
+> {
+	return getStructEncoder([["newPrice", getU64Encoder()]]);
 }
 
-export function getUpdateInstructionDataCodec(): FixedSizeCodec<UpdateInstructionDataArgs, UpdateInstructionData> {
-    return combineCodec(getUpdateInstructionDataEncoder(), getUpdateInstructionDataDecoder());
+export function getUpdateInstructionDataDecoder(): FixedSizeDecoder<
+	UpdateInstructionData
+> {
+	return getStructDecoder([["newPrice", getU64Decoder()]]);
 }
 
-export type UpdateInput<TAccountOracle extends string = string, TAccountAuthority extends string = string> =  {
-  oracle: Address<TAccountOracle>;
-authority: TransactionSigner<TAccountAuthority>;
-newPrice: UpdateInstructionDataArgs["newPrice"];
+export function getUpdateInstructionDataCodec(): FixedSizeCodec<
+	UpdateInstructionDataArgs,
+	UpdateInstructionData
+> {
+	return combineCodec(
+		getUpdateInstructionDataEncoder(),
+		getUpdateInstructionDataDecoder(),
+	);
 }
 
-export function getUpdateInstruction<TAccountOracle extends string, TAccountAuthority extends string, TProgramAddress extends Address = typeof PROP_AMM_PROGRAM_PROGRAM_ADDRESS>(input: UpdateInput<TAccountOracle, TAccountAuthority>, config?: { programAddress?: TProgramAddress } ): UpdateInstruction<TProgramAddress, TAccountOracle, TAccountAuthority> {
-  // Program address.
-const programAddress = config?.programAddress ?? PROP_AMM_PROGRAM_PROGRAM_ADDRESS;
-
- // Original accounts.
-const originalAccounts = { oracle: { value: input.oracle ?? null, isWritable: true }, authority: { value: input.authority ?? null, isWritable: false } }
-const accounts = originalAccounts as Record<keyof typeof originalAccounts, ResolvedInstructionAccount>;
-
-
-// Original args.
-const args = { ...input,  };
-
-
-
-
-const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
-return Object.freeze({ accounts: [getAccountMeta("oracle", accounts.oracle), getAccountMeta("authority", accounts.authority)], data: getUpdateInstructionDataEncoder().encode(args as UpdateInstructionDataArgs), programAddress } as UpdateInstruction<TProgramAddress, TAccountOracle, TAccountAuthority>);
-}
-
-export type ParsedUpdateInstruction<TProgram extends string = typeof PROP_AMM_PROGRAM_PROGRAM_ADDRESS, TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[]> = { programAddress: Address<TProgram>;
-accounts: {
-oracle: TAccountMetas[0];
-authority: TAccountMetas[1];
+export type UpdateInput<
+	TAccountOracle extends string = string,
+	TAccountAuthority extends string = string,
+> = {
+	oracle: Address<TAccountOracle>;
+	authority: TransactionSigner<TAccountAuthority>;
+	newPrice: UpdateInstructionDataArgs["newPrice"];
 };
-data: UpdateInstructionData; };
 
-export function parseUpdateInstruction<TProgram extends string, TAccountMetas extends readonly AccountMeta[]>(instruction: Instruction<TProgram> & InstructionWithAccounts<TAccountMetas> & InstructionWithData<ReadonlyUint8Array>): ParsedUpdateInstruction<TProgram, TAccountMetas> {
-  if (instruction.accounts.length < 2) {
-  throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS, { actualAccountMetas: instruction.accounts.length, expectedAccountMetas: 2 });
+export function getUpdateInstruction<
+	TAccountOracle extends string,
+	TAccountAuthority extends string,
+	TProgramAddress extends Address = typeof PROP_AMM_PROGRAM_PROGRAM_ADDRESS,
+>(
+	input: UpdateInput<TAccountOracle, TAccountAuthority>,
+	config?: { programAddress?: TProgramAddress },
+): UpdateInstruction<TProgramAddress, TAccountOracle, TAccountAuthority> {
+	// Program address.
+	const programAddress = config?.programAddress ??
+		PROP_AMM_PROGRAM_PROGRAM_ADDRESS;
+
+	// Original accounts.
+	const originalAccounts = {
+		oracle: { value: input.oracle ?? null, isWritable: true },
+		authority: { value: input.authority ?? null, isWritable: false },
+	};
+	const accounts = originalAccounts as Record<
+		keyof typeof originalAccounts,
+		ResolvedInstructionAccount
+	>;
+
+	// Original args.
+	const args = { ...input };
+
+	const getAccountMeta = getAccountMetaFactory(programAddress, "programId");
+	return Object.freeze({
+		accounts: [
+			getAccountMeta("oracle", accounts.oracle),
+			getAccountMeta("authority", accounts.authority),
+		],
+		data: getUpdateInstructionDataEncoder().encode(
+			args as UpdateInstructionDataArgs,
+		),
+		programAddress,
+	} as UpdateInstruction<TProgramAddress, TAccountOracle, TAccountAuthority>);
 }
-let accountIndex = 0;
-const getNextAccount = () => {
-  const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
-  accountIndex += 1;
-  return accountMeta;
-}
-  return { programAddress: instruction.programAddress, accounts: { oracle: getNextAccount(), authority: getNextAccount() }, data: getUpdateInstructionDataDecoder().decode(instruction.data) };
+
+export type ParsedUpdateInstruction<
+	TProgram extends string = typeof PROP_AMM_PROGRAM_PROGRAM_ADDRESS,
+	TAccountMetas extends readonly AccountMeta[] = readonly AccountMeta[],
+> = {
+	programAddress: Address<TProgram>;
+	accounts: {
+		oracle: TAccountMetas[0];
+		authority: TAccountMetas[1];
+	};
+	data: UpdateInstructionData;
+};
+
+export function parseUpdateInstruction<
+	TProgram extends string,
+	TAccountMetas extends readonly AccountMeta[],
+>(
+	instruction:
+		& Instruction<TProgram>
+		& InstructionWithAccounts<TAccountMetas>
+		& InstructionWithData<ReadonlyUint8Array>,
+): ParsedUpdateInstruction<TProgram, TAccountMetas> {
+	if (instruction.accounts.length < 2) {
+		throw new SolanaError(
+			SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
+			{
+				actualAccountMetas: instruction.accounts.length,
+				expectedAccountMetas: 2,
+			},
+		);
+	}
+	let accountIndex = 0;
+	const getNextAccount = () => {
+		const accountMeta = (instruction.accounts as TAccountMetas)[accountIndex]!;
+		accountIndex += 1;
+		return accountMeta;
+	};
+	return {
+		programAddress: instruction.programAddress,
+		accounts: { oracle: getNextAccount(), authority: getNextAccount() },
+		data: getUpdateInstructionDataDecoder().decode(instruction.data),
+	};
 }

--- a/codama/clients/js/prop_amm_program/src/generated/programs/index.ts
+++ b/codama/clients/js/prop_amm_program/src/generated/programs/index.ts
@@ -6,4 +6,4 @@
  * @see https://github.com/codama-idl/codama
  */
 
-export * from './propAmmProgram';
+export * from "./propAmmProgram";

--- a/codama/clients/js/prop_amm_program/src/generated/programs/propAmmProgram.ts
+++ b/codama/clients/js/prop_amm_program/src/generated/programs/propAmmProgram.ts
@@ -6,63 +6,199 @@
  * @see https://github.com/codama-idl/codama
  */
 
-import { assertIsInstructionWithAccounts, containsBytes, getU8Encoder, SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_ACCOUNT, SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_INSTRUCTION, SOLANA_ERROR__PROGRAM_CLIENTS__UNRECOGNIZED_INSTRUCTION_TYPE, SolanaError, type Address, type ClientWithRpc, type ClientWithTransactionPlanning, type ClientWithTransactionSending, type GetAccountInfoApi, type GetMultipleAccountsApi, type Instruction, type InstructionWithData, type ReadonlyUint8Array } from '@solana/kit';
-import { addSelfFetchFunctions, addSelfPlanAndSendFunctions, type SelfFetchFunctions, type SelfPlanAndSendFunctions } from '@solana/program-client-core';
-import { getOracleStateCodec, type OracleState, type OracleStateArgs } from '../accounts';
-import { getInitializeInstruction, getRotateAuthorityInstruction, getUpdateInstruction, parseInitializeInstruction, parseRotateAuthorityInstruction, parseUpdateInstruction, type InitializeInput, type ParsedInitializeInstruction, type ParsedRotateAuthorityInstruction, type ParsedUpdateInstruction, type RotateAuthorityInput, type UpdateInput } from '../instructions';
+import {
+	type Address,
+	assertIsInstructionWithAccounts,
+	type ClientWithRpc,
+	type ClientWithTransactionPlanning,
+	type ClientWithTransactionSending,
+	containsBytes,
+	type GetAccountInfoApi,
+	type GetMultipleAccountsApi,
+	getU8Encoder,
+	type Instruction,
+	type InstructionWithData,
+	type ReadonlyUint8Array,
+	SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_ACCOUNT,
+	SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_INSTRUCTION,
+	SOLANA_ERROR__PROGRAM_CLIENTS__UNRECOGNIZED_INSTRUCTION_TYPE,
+	SolanaError,
+} from "@solana/kit";
+import {
+	addSelfFetchFunctions,
+	addSelfPlanAndSendFunctions,
+	type SelfFetchFunctions,
+	type SelfPlanAndSendFunctions,
+} from "@solana/program-client-core";
+import {
+	getOracleStateCodec,
+	type OracleState,
+	type OracleStateArgs,
+} from "../accounts";
+import {
+	getInitializeInstruction,
+	getRotateAuthorityInstruction,
+	getUpdateInstruction,
+	type InitializeInput,
+	type ParsedInitializeInstruction,
+	type ParsedRotateAuthorityInstruction,
+	type ParsedUpdateInstruction,
+	parseInitializeInstruction,
+	parseRotateAuthorityInstruction,
+	parseUpdateInstruction,
+	type RotateAuthorityInput,
+	type UpdateInput,
+} from "../instructions";
 
-export const PROP_AMM_PROGRAM_PROGRAM_ADDRESS = '55555555555555555555555555555555555555555555' as Address<'55555555555555555555555555555555555555555555'>;
+export const PROP_AMM_PROGRAM_PROGRAM_ADDRESS =
+	"55555555555555555555555555555555555555555555" as Address<
+		"55555555555555555555555555555555555555555555"
+	>;
 
-export enum PropAmmProgramAccount { OracleState }
-
-export function identifyPropAmmProgramAccount(account: { data: ReadonlyUint8Array } | ReadonlyUint8Array): PropAmmProgramAccount {
-    const data = 'data' in account ? account.data : account;
-    if (containsBytes(data, getU8Encoder().encode(1), 0)) { return PropAmmProgramAccount.OracleState; }
-    throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_ACCOUNT, { accountData: data, programName: "propAmmProgram" });
+export enum PropAmmProgramAccount {
+	OracleState,
 }
 
-export enum PropAmmProgramInstruction { Initialize, Update, RotateAuthority }
-
-export function identifyPropAmmProgramInstruction(instruction: { data: ReadonlyUint8Array } | ReadonlyUint8Array): PropAmmProgramInstruction {
-    const data = 'data' in instruction ? instruction.data : instruction;
-    if (containsBytes(data, getU8Encoder().encode(0), 0)) { return PropAmmProgramInstruction.Initialize; }
-if (containsBytes(data, getU8Encoder().encode(1), 0)) { return PropAmmProgramInstruction.Update; }
-if (containsBytes(data, getU8Encoder().encode(2), 0)) { return PropAmmProgramInstruction.RotateAuthority; }
-    throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_INSTRUCTION, { instructionData: data, programName: "propAmmProgram" });
+export function identifyPropAmmProgramAccount(
+	account: { data: ReadonlyUint8Array } | ReadonlyUint8Array,
+): PropAmmProgramAccount {
+	const data = "data" in account ? account.data : account;
+	if (containsBytes(data, getU8Encoder().encode(1), 0)) {
+		return PropAmmProgramAccount.OracleState;
+	}
+	throw new SolanaError(
+		SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_ACCOUNT,
+		{ accountData: data, programName: "propAmmProgram" },
+	);
 }
 
-export type ParsedPropAmmProgramInstruction<TProgram extends string = '55555555555555555555555555555555555555555555'> =
-| { instructionType: PropAmmProgramInstruction.Initialize } & ParsedInitializeInstruction<TProgram>
-| { instructionType: PropAmmProgramInstruction.Update } & ParsedUpdateInstruction<TProgram>
-| { instructionType: PropAmmProgramInstruction.RotateAuthority } & ParsedRotateAuthorityInstruction<TProgram>
+export enum PropAmmProgramInstruction {
+	Initialize,
+	Update,
+	RotateAuthority,
+}
 
+export function identifyPropAmmProgramInstruction(
+	instruction: { data: ReadonlyUint8Array } | ReadonlyUint8Array,
+): PropAmmProgramInstruction {
+	const data = "data" in instruction ? instruction.data : instruction;
+	if (containsBytes(data, getU8Encoder().encode(0), 0)) {
+		return PropAmmProgramInstruction.Initialize;
+	}
+	if (containsBytes(data, getU8Encoder().encode(1), 0)) {
+		return PropAmmProgramInstruction.Update;
+	}
+	if (containsBytes(data, getU8Encoder().encode(2), 0)) {
+		return PropAmmProgramInstruction.RotateAuthority;
+	}
+	throw new SolanaError(
+		SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_INSTRUCTION,
+		{ instructionData: data, programName: "propAmmProgram" },
+	);
+}
 
-        export function parsePropAmmProgramInstruction<TProgram extends string>(
-            instruction: Instruction<TProgram> 
-                & InstructionWithData<ReadonlyUint8Array>
-        ): ParsedPropAmmProgramInstruction<TProgram> {
-            const instructionType = identifyPropAmmProgramInstruction(instruction);
-            switch (instructionType) {
-                case PropAmmProgramInstruction.Initialize: { assertIsInstructionWithAccounts(instruction);
-return { instructionType: PropAmmProgramInstruction.Initialize, ...parseInitializeInstruction(instruction) }; }
-case PropAmmProgramInstruction.Update: { assertIsInstructionWithAccounts(instruction);
-return { instructionType: PropAmmProgramInstruction.Update, ...parseUpdateInstruction(instruction) }; }
-case PropAmmProgramInstruction.RotateAuthority: { assertIsInstructionWithAccounts(instruction);
-return { instructionType: PropAmmProgramInstruction.RotateAuthority, ...parseRotateAuthorityInstruction(instruction) }; }
-                default: throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__UNRECOGNIZED_INSTRUCTION_TYPE, { instructionType: instructionType as string, programName: "propAmmProgram" });
-            }
-        }
+export type ParsedPropAmmProgramInstruction<
+	TProgram extends string = "55555555555555555555555555555555555555555555",
+> =
+	| { instructionType: PropAmmProgramInstruction.Initialize }
+		& ParsedInitializeInstruction<TProgram>
+	| { instructionType: PropAmmProgramInstruction.Update }
+		& ParsedUpdateInstruction<TProgram>
+	| { instructionType: PropAmmProgramInstruction.RotateAuthority }
+		& ParsedRotateAuthorityInstruction<TProgram>;
 
-export type PropAmmProgramPlugin = { accounts: PropAmmProgramPluginAccounts; instructions: PropAmmProgramPluginInstructions; }
+export function parsePropAmmProgramInstruction<TProgram extends string>(
+	instruction:
+		& Instruction<TProgram>
+		& InstructionWithData<ReadonlyUint8Array>,
+): ParsedPropAmmProgramInstruction<TProgram> {
+	const instructionType = identifyPropAmmProgramInstruction(instruction);
+	switch (instructionType) {
+		case PropAmmProgramInstruction.Initialize: {
+			assertIsInstructionWithAccounts(instruction);
+			return {
+				instructionType: PropAmmProgramInstruction.Initialize,
+				...parseInitializeInstruction(instruction),
+			};
+		}
+		case PropAmmProgramInstruction.Update: {
+			assertIsInstructionWithAccounts(instruction);
+			return {
+				instructionType: PropAmmProgramInstruction.Update,
+				...parseUpdateInstruction(instruction),
+			};
+		}
+		case PropAmmProgramInstruction.RotateAuthority: {
+			assertIsInstructionWithAccounts(instruction);
+			return {
+				instructionType: PropAmmProgramInstruction.RotateAuthority,
+				...parseRotateAuthorityInstruction(instruction),
+			};
+		}
+		default:
+			throw new SolanaError(
+				SOLANA_ERROR__PROGRAM_CLIENTS__UNRECOGNIZED_INSTRUCTION_TYPE,
+				{
+					instructionType: instructionType as string,
+					programName: "propAmmProgram",
+				},
+			);
+	}
+}
 
-export type PropAmmProgramPluginAccounts = { oracleState: ReturnType<typeof getOracleStateCodec> & SelfFetchFunctions<OracleStateArgs, OracleState>; }
+export type PropAmmProgramPlugin = {
+	accounts: PropAmmProgramPluginAccounts;
+	instructions: PropAmmProgramPluginInstructions;
+};
 
-export type PropAmmProgramPluginInstructions = { initialize: (input: InitializeInput) => ReturnType<typeof getInitializeInstruction> & SelfPlanAndSendFunctions; update: (input: UpdateInput) => ReturnType<typeof getUpdateInstruction> & SelfPlanAndSendFunctions; rotateAuthority: (input: RotateAuthorityInput) => ReturnType<typeof getRotateAuthorityInstruction> & SelfPlanAndSendFunctions; }
+export type PropAmmProgramPluginAccounts = {
+	oracleState:
+		& ReturnType<typeof getOracleStateCodec>
+		& SelfFetchFunctions<OracleStateArgs, OracleState>;
+};
 
-export type PropAmmProgramPluginRequirements = ClientWithRpc<GetAccountInfoApi & GetMultipleAccountsApi> & ClientWithTransactionPlanning & ClientWithTransactionSending
+export type PropAmmProgramPluginInstructions = {
+	initialize: (
+		input: InitializeInput,
+	) => ReturnType<typeof getInitializeInstruction> & SelfPlanAndSendFunctions;
+	update: (
+		input: UpdateInput,
+	) => ReturnType<typeof getUpdateInstruction> & SelfPlanAndSendFunctions;
+	rotateAuthority: (
+		input: RotateAuthorityInput,
+	) =>
+		& ReturnType<typeof getRotateAuthorityInstruction>
+		& SelfPlanAndSendFunctions;
+};
+
+export type PropAmmProgramPluginRequirements =
+	& ClientWithRpc<GetAccountInfoApi & GetMultipleAccountsApi>
+	& ClientWithTransactionPlanning
+	& ClientWithTransactionSending;
 
 export function propAmmProgramProgram() {
-    return <T extends PropAmmProgramPluginRequirements>(client: T) => {
-        return { ...client, propAmmProgram: <PropAmmProgramPlugin>{ accounts: { oracleState: addSelfFetchFunctions(client, getOracleStateCodec()) }, instructions: { initialize: input => addSelfPlanAndSendFunctions(client, getInitializeInstruction(input)), update: input => addSelfPlanAndSendFunctions(client, getUpdateInstruction(input)), rotateAuthority: input => addSelfPlanAndSendFunctions(client, getRotateAuthorityInstruction(input)) } } };
-    };
+	return <T extends PropAmmProgramPluginRequirements>(client: T) => {
+		return {
+			...client,
+			propAmmProgram: <PropAmmProgramPlugin> {
+				accounts: {
+					oracleState: addSelfFetchFunctions(client, getOracleStateCodec()),
+				},
+				instructions: {
+					initialize: (input) =>
+						addSelfPlanAndSendFunctions(
+							client,
+							getInitializeInstruction(input),
+						),
+					update: (input) =>
+						addSelfPlanAndSendFunctions(client, getUpdateInstruction(input)),
+					rotateAuthority: (input) =>
+						addSelfPlanAndSendFunctions(
+							client,
+							getRotateAuthorityInstruction(input),
+						),
+				},
+			},
+		};
+	};
 }

--- a/codama/clients/rust/prop_amm_program/src/generated/accounts/oracle_state.rs
+++ b/codama/clients/rust/prop_amm_program/src/generated/accounts/oracle_state.rs
@@ -41,7 +41,9 @@ impl OracleState {
 		Ok(account)
 	}
 
-	pub fn from_bytes_mut(data: &mut [u8]) -> Result<&mut Self, solana_program_error::ProgramError> {
+	pub fn from_bytes_mut(
+		data: &mut [u8],
+	) -> Result<&mut Self, solana_program_error::ProgramError> {
 		let account = bytemuck::try_from_bytes_mut::<Self>(data)
 			.map_err(|_| solana_program_error::ProgramError::InvalidAccountData)?;
 		if account.discriminator != ORACLE_STATE_DISCRIMINATOR {

--- a/codama/clients/rust/prop_amm_program/src/generated/errors/prop_amm_program.rs
+++ b/codama/clients/rust/prop_amm_program/src/generated/errors/prop_amm_program.rs
@@ -13,10 +13,10 @@ use thiserror::Error;
 
 #[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]
 pub enum PropAmmProgramError {
-	/// 0 - 
+	/// 0 -
 	#[error("")]
 	UnauthorizedUpdateAuthority = 0x0,
-	/// 1 - 
+	/// 1 -
 	#[error("")]
 	UnauthorizedOracleAuthority = 0x1,
 }

--- a/codama/clients/rust/prop_amm_program/src/generated/instructions/initialize.rs
+++ b/codama/clients/rust/prop_amm_program/src/generated/instructions/initialize.rs
@@ -40,7 +40,10 @@ impl Initialize {
 		let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
 		accounts.push(solana_instruction::AccountMeta::new(self.payer, true));
 		accounts.push(solana_instruction::AccountMeta::new(self.oracle, true));
-		accounts.push(solana_instruction::AccountMeta::new_readonly(self.system_program, false));
+		accounts.push(solana_instruction::AccountMeta::new_readonly(
+			self.system_program,
+			false,
+		));
 		accounts.extend_from_slice(remaining_accounts);
 		let data = bytemuck::bytes_of(&data).to_vec();
 

--- a/codama/clients/rust/prop_amm_program/src/generated/instructions/mod.rs
+++ b/codama/clients/rust/prop_amm_program/src/generated/instructions/mod.rs
@@ -9,9 +9,9 @@
 )]
 
 pub(crate) mod r#initialize;
-pub(crate) mod r#update;
 pub(crate) mod r#rotate_authority;
+pub(crate) mod r#update;
 
 pub use self::r#initialize::*;
-pub use self::r#update::*;
 pub use self::r#rotate_authority::*;
+pub use self::r#update::*;

--- a/codama/clients/rust/prop_amm_program/src/generated/instructions/rotate_authority.rs
+++ b/codama/clients/rust/prop_amm_program/src/generated/instructions/rotate_authority.rs
@@ -19,13 +19,13 @@ pub struct RotateAuthority {
 
 impl RotateAuthority {
 	pub fn new(oracle: solana_pubkey::Pubkey, authority: solana_pubkey::Pubkey) -> Self {
-		Self {
-			oracle,
-			authority,
-		}
+		Self { oracle, authority }
 	}
 
-	pub fn instruction(&self, data: RotateAuthorityInstructionData) -> solana_instruction::Instruction {
+	pub fn instruction(
+		&self,
+		data: RotateAuthorityInstructionData,
+	) -> solana_instruction::Instruction {
 		self.instruction_with_remaining_accounts(data, &[])
 	}
 
@@ -37,7 +37,10 @@ impl RotateAuthority {
 	) -> solana_instruction::Instruction {
 		let mut accounts = Vec::with_capacity(2 + remaining_accounts.len());
 		accounts.push(solana_instruction::AccountMeta::new(self.oracle, false));
-		accounts.push(solana_instruction::AccountMeta::new_readonly(self.authority, true));
+		accounts.push(solana_instruction::AccountMeta::new_readonly(
+			self.authority,
+			true,
+		));
 		accounts.extend_from_slice(remaining_accounts);
 		let data = bytemuck::bytes_of(&data).to_vec();
 

--- a/codama/clients/rust/prop_amm_program/src/generated/instructions/update.rs
+++ b/codama/clients/rust/prop_amm_program/src/generated/instructions/update.rs
@@ -19,10 +19,7 @@ pub struct Update {
 
 impl Update {
 	pub fn new(oracle: solana_pubkey::Pubkey, authority: solana_pubkey::Pubkey) -> Self {
-		Self {
-			oracle,
-			authority,
-		}
+		Self { oracle, authority }
 	}
 
 	pub fn instruction(&self, data: UpdateInstructionData) -> solana_instruction::Instruction {
@@ -37,7 +34,10 @@ impl Update {
 	) -> solana_instruction::Instruction {
 		let mut accounts = Vec::with_capacity(2 + remaining_accounts.len());
 		accounts.push(solana_instruction::AccountMeta::new(self.oracle, false));
-		accounts.push(solana_instruction::AccountMeta::new_readonly(self.authority, true));
+		accounts.push(solana_instruction::AccountMeta::new_readonly(
+			self.authority,
+			true,
+		));
 		accounts.extend_from_slice(remaining_accounts);
 		let data = bytemuck::bytes_of(&data).to_vec();
 

--- a/codama/clients/rust/prop_amm_program/src/generated/programs.rs
+++ b/codama/clients/rust/prop_amm_program/src/generated/programs.rs
@@ -8,6 +8,7 @@
 	clippy::too_many_arguments
 )]
 
-use solana_pubkey::{pubkey, Pubkey};
+use solana_pubkey::Pubkey;
+use solana_pubkey::pubkey;
 
 pub const PROP_AMM_PROGRAM_ID: Pubkey = pubkey!("55555555555555555555555555555555555555555555");

--- a/crates/pina_cli/tests/snapshots/cli_snapshots__codama_generate_unknown_example_error.snap
+++ b/crates/pina_cli/tests/snapshots/cli_snapshots__codama_generate_unknown_example_error.snap
@@ -23,4 +23,4 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-Error: Unknown example `does_not_exist`. Available examples: anchor_declare_id, anchor_declare_program, anchor_duplicate_mutable_accounts, anchor_errors, anchor_events, anchor_floats, anchor_realloc, anchor_system_accounts, anchor_sysvars, counter_program, escrow_program, hello_solana, pina_bpf, role_registry_program, staking_rewards_program, todo_program, transfer_sol, vesting_program
+Error: Unknown example `does_not_exist`. Available examples: anchor_declare_id, anchor_declare_program, anchor_duplicate_mutable_accounts, anchor_errors, anchor_events, anchor_floats, anchor_realloc, anchor_system_accounts, anchor_sysvars, counter_program, escrow_program, hello_solana, pina_bpf, prop_amm_program, role_registry_program, staking_rewards_program, todo_program, transfer_sol, vesting_program

--- a/examples/prop_amm_program/src/cpi.rs
+++ b/examples/prop_amm_program/src/cpi.rs
@@ -94,8 +94,32 @@ pub mod accounts {
 	}
 }
 
+#[derive(Clone, Copy, Debug)]
+struct ProgramAddressCheck<'a> {
+	address: &'a Address,
+}
+
+impl<'a> ProgramAddressCheck<'a> {
+	#[inline(always)]
+	const fn new(address: &'a Address) -> Self {
+		Self { address }
+	}
+
+	#[inline(always)]
+	fn assert_address(&self, expected: &Address) -> ProgramResult {
+		if self.address != expected {
+			return Err(ProgramError::IncorrectProgramId);
+		}
+
+		Ok(())
+	}
+}
+
 #[inline(always)]
 pub fn initialize<'a>(ctx: &CpiContext<'a, accounts::Initialize<'a>, 3>) -> ProgramResult {
+	let program_account = ProgramAddressCheck::new(ctx.program);
+	program_account.assert_address(&ID)?;
+
 	let data = InitializeInstruction::builder().build();
 	ctx.invoke(data.to_bytes(), &[])
 }
@@ -105,6 +129,9 @@ pub fn update<'a>(
 	ctx: &CpiContext<'a, accounts::Update<'a>, 2>,
 	new_price: PodU64,
 ) -> ProgramResult {
+	let program_account = ProgramAddressCheck::new(ctx.program);
+	program_account.assert_address(&ID)?;
+
 	let data = UpdateInstruction::builder().new_price(new_price).build();
 	ctx.invoke(data.to_bytes(), &[])
 }
@@ -114,6 +141,9 @@ pub fn rotate_authority<'a>(
 	ctx: &CpiContext<'a, accounts::RotateAuthority<'a>, 2>,
 	new_authority: Address,
 ) -> ProgramResult {
+	let program_account = ProgramAddressCheck::new(ctx.program);
+	program_account.assert_address(&ID)?;
+
 	let data = RotateAuthorityInstruction::builder()
 		.new_authority(new_authority)
 		.build();
@@ -166,5 +196,16 @@ mod tests {
 			.unwrap_or_else(|e| panic!("decode rotate cpi bytes: {e:?}"));
 
 		assert_eq!(decoded.new_authority, next_authority);
+	}
+
+	#[test]
+	fn program_address_check_rejects_wrong_program() {
+		let wrong_program = Address::new_from_array([3u8; ADDRESS_BYTES]);
+		let program_account = ProgramAddressCheck::new(&wrong_program);
+		let error = program_account
+			.assert_address(&ID)
+			.expect_err("reject wrong cpi program id");
+
+		assert_eq!(error, ProgramError::IncorrectProgramId);
 	}
 }

--- a/scripts/verify-codama-idls.sh
+++ b/scripts/verify-codama-idls.sh
@@ -30,10 +30,21 @@ show_codama_diff() {
 }
 
 format_codama_outputs() {
-	dprint fmt --config "$ROOT/dprint.json" \
-		"$IDL_DIR/*.json" \
-		"$RUST_CLIENTS_DIR/**" \
-		"$JS_CLIENTS_DIR/**"
+	(
+		cd "$ROOT"
+
+		FORMAT_FILES=()
+		while IFS= read -r file; do
+			FORMAT_FILES+=("$file")
+		done < <(find codama/idls codama/clients/rust codama/clients/js -type f | sort)
+
+		if [ "${#FORMAT_FILES[@]}" -eq 0 ]; then
+			echo "No Codama output files found to format." >&2
+			exit 1
+		fi
+
+		dprint fmt --config "$ROOT/dprint.json" "${FORMAT_FILES[@]}"
+	)
 }
 
 trap '


### PR DESCRIPTION
## Summary

- restore the Codama verification script so it formats generated outputs reliably
- update the CLI snapshot for the new `prop_amm_program` example name list
- commit the deterministically regenerated `prop_amm_program` Codama clients so `verify:idls` passes on main again

## Validation

- `cargo test -p pina_cli --test cli_snapshots -- --nocapture`
- `bash scripts/verify-codama-idls.sh`
- `verify:security`

## Context

This fixes the post-merge failures introduced after #145 landed before all checks were green.
