### PR TITLE
docs(pina): expand shared authoring guidance

### DIFF
--- a/.changeset/docs_mdt_sweep.md
+++ b/.changeset/docs_mdt_sweep.md
@@ -1,0 +1,5 @@
+---
+default: docs
+---
+
+Refresh the shared documentation after the Pinocchio 0.11 migration. This expands feature-selection guidance, adds explicit instruction-authoring tips for the new mutable `AccountView` and guard-backed loader model, clarifies close-account safety with `close_account_zeroed()`, and updates the security and design notes to match the current APIs.

--- a/.github/workflows/mutants-pr.yml
+++ b/.github/workflows/mutants-pr.yml
@@ -49,7 +49,7 @@ jobs:
           for manifest in crates/*/Cargo.toml; do
             dir=$(dirname "$manifest")
             pkg=$(basename "$dir")
-            if echo "$changed_files" | grep -qE "^${dir}/"; then
+            if echo "$changed_files" | grep -qE "^${dir}/(Cargo.toml|build.rs|src/|tests/|benches/|examples/)"; then
               packages+=("$pkg")
             fi
           done

--- a/crates/pina/readme.md
+++ b/crates/pina/readme.md
@@ -48,6 +48,20 @@ cargo add pina --features token
 
 <!-- {/pinaFeatureFlags} -->
 
+## Feature selection tips
+
+<br>
+
+<!-- {=pinaFeatureSelectionTips} -->
+
+- `derive` is the normal choice for program crates; disable it only when you want the low-level runtime traits without the proc macros.
+- `logs` is useful during bring-up, testing, and audits. Disable it when you want the smallest possible binary or completely silent runtime failures.
+- `token` enables `pina::token`, `pina::token_2022`, `pina::associated_token_account`, and the `TokenAccount` compatibility aliases over the upstream renamed account types.
+- `memo` is separate from `token`, so memo CPI support can be enabled without pulling in the token helper surface.
+- `account-resize` only unlocks realloc helpers such as `realloc_account()` and `realloc_account_zero()`. Close helpers still do not implicitly resize or zero account data.
+
+<!-- {/pinaFeatureSelectionTips} -->
+
 ## Minimal Program Skeleton
 
 <br>
@@ -84,6 +98,20 @@ fn process_instruction(
 	}
 }
 ```
+
+## Instruction authoring tips
+
+<br>
+
+<!-- {=pinaInstructionAuthoringTips} -->
+
+- Entry points should accept `&mut [AccountView]` and dispatch with `Accounts::try_from(accounts)?.process(data)`.
+- Use `&AccountView` for read-only accounts and `&mut AccountView` only when you need mutable loaders, direct lamport mutation, `close_*` helpers, or writable IDL inference.
+- Keep `assert_writable()` explicit even on `&mut AccountView`. Type-level mutability unlocks mutable APIs, but the runtime still decides whether the account is writable for the current instruction.
+- `as_account()` / `as_account_mut()` return `Ref<T>` / `RefMut<T>` borrow guards. Copy out the fields you need and `drop(...)` the guard before CPIs or later mutable borrows.
+- Keep validation chains direct inside `process(self, ...)` when possible. That makes audits easier and gives `pina idl` the clearest signal for signer, writable, PDA, and default-account inference.
+
+<!-- {/pinaInstructionAuthoringTips} -->
 
 ## Related Crates
 

--- a/crates/pina/readme.md
+++ b/crates/pina/readme.md
@@ -55,7 +55,7 @@ cargo add pina --features token
 <!-- {=pinaFeatureSelectionTips} -->
 
 - `derive` is the normal choice for program crates; disable it only when you want the low-level runtime traits without the proc macros.
-- `logs` is useful during bring-up, testing, and audits. Disable it when you want the smallest possible binary or completely silent runtime failures.
+- `logs` is useful during **initial development and debugging**, testing, and audits. Disable it when you want the smallest possible binary or completely silent runtime failures.
 - `token` enables `pina::token`, `pina::token_2022`, `pina::associated_token_account`, and the `TokenAccount` compatibility aliases over the upstream renamed account types.
 - `memo` is separate from `token`, so memo CPI support can be enabled without pulling in the token helper surface.
 - `account-resize` only unlocks realloc helpers such as `realloc_account()` and `realloc_account_zero()`. Close helpers still do not implicitly resize or zero account data.

--- a/devenv.nix
+++ b/devenv.nix
@@ -792,8 +792,8 @@ in
         set -euo pipefail
         mkdir -p "$DEVENV_ROOT/target/mutants"
         status=0
-        cargo mutants --all-features --output "$DEVENV_ROOT/target/mutants" || status=$?
-        if [ "$status" -eq 3 ]; then
+        cargo mutants --all-features --cargo-arg --locked --output "$DEVENV_ROOT/target/mutants" || status=$?
+        if [ "$status" -eq 2 ] || [ "$status" -eq 3 ]; then
           echo "cargo-mutants reported missed mutants; keeping CI non-blocking and uploading the report."
           exit 0
         fi
@@ -842,8 +842,8 @@ in
         done
 
         status=0
-        cargo mutants --all-features --output "$DEVENV_ROOT/target/mutants" "''${pkg_args[@]}" || status=$?
-        if [ "$status" -eq 3 ]; then
+        cargo mutants --all-features --cargo-arg --locked --output "$DEVENV_ROOT/target/mutants" "''${pkg_args[@]}" || status=$?
+        if [ "$status" -eq 2 ] || [ "$status" -eq 3 ]; then
           echo "cargo-mutants reported missed mutants; keeping CI non-blocking and uploading the report."
           exit 0
         fi
@@ -861,8 +861,8 @@ in
         fi
         mkdir -p "$DEVENV_ROOT/target/mutants"
         status=0
-        cargo mutants --all-features --output "$DEVENV_ROOT/target/mutants" -p "$1" || status=$?
-        if [ "$status" -eq 3 ]; then
+        cargo mutants --all-features --cargo-arg --locked --output "$DEVENV_ROOT/target/mutants" -p "$1" || status=$?
+        if [ "$status" -eq 2 ] || [ "$status" -eq 3 ]; then
           echo "cargo-mutants reported missed mutants; keeping CI non-blocking and uploading the report."
           exit 0
         fi

--- a/devenv.nix
+++ b/devenv.nix
@@ -878,6 +878,12 @@ in
         # the workspace-wide `unstable_features = "deny"` lint.
         export RUSTFLAGS="''${RUSTFLAGS:+$RUSTFLAGS }-A unstable-features"
 
+        # Kani downloads Linux binaries that must resolve against the host
+        # runtime, not Nix's glibc/libm from the devenv shell.
+        unset LD_LIBRARY_PATH
+        unset NIX_LD_LIBRARY_PATH
+        unset LD_PRELOAD
+
         # Run all Kani harnesses in pina_pod_primitives.
         cargo kani --manifest-path "$DEVENV_ROOT/crates/pina_pod_primitives/Cargo.toml" --all-features
       '';

--- a/docs/src/accounts-cursor-runtime-draft.md
+++ b/docs/src/accounts-cursor-runtime-draft.md
@@ -8,7 +8,7 @@ This document sketches a concrete path for reworking Pina's `#[derive(Accounts)]
 
 ## Why change the current model?
 
-Today `#[derive(Accounts)]` mainly expands to direct slice destructuring over `&[AccountView]`.
+Today `#[derive(Accounts)]` mainly expands to direct slice destructuring over `&mut [AccountView]`.
 
 That is simple and easy to audit, but it starts to strain when Pina needs richer account-loading behavior such as:
 
@@ -37,7 +37,7 @@ Any redesign must keep the following Pina invariants intact:
 
 A lightweight cursor owns:
 
-- the original `&'a [AccountView]`
+- the original `&'a mut [AccountView]`
 - the current index
 - duplicate-account bookkeeping state
 
@@ -57,7 +57,7 @@ Derive-generated code should stop directly destructuring account slices.
 Instead it should:
 
 1. parse structural account positions through the cursor
-2. produce a typed accounts struct of borrowed `&AccountView`
+2. produce a typed accounts struct of borrowed `&AccountView` / `&mut AccountView`
 3. leave semantic validation in user-authored `process(...)` methods
 
 This keeps Pina's existing style intact:

--- a/docs/src/core-concepts.md
+++ b/docs/src/core-concepts.md
@@ -104,6 +104,18 @@ A chain that starts with `&AccountView` stays shared, while a chain that starts 
 
 Traits in `crates/pina/src/impls.rs` provide typed conversion paths from raw `AccountView` values into strongly typed account states. `as_account()` returns `Ref<T>` and `as_account_mut()` returns `RefMut<T>` borrow guards.
 
+## Instruction authoring tips
+
+<!-- {=pinaInstructionAuthoringTips} -->
+
+- Entry points should accept `&mut [AccountView]` and dispatch with `Accounts::try_from(accounts)?.process(data)`.
+- Use `&AccountView` for read-only accounts and `&mut AccountView` only when you need mutable loaders, direct lamport mutation, `close_*` helpers, or writable IDL inference.
+- Keep `assert_writable()` explicit even on `&mut AccountView`. Type-level mutability unlocks mutable APIs, but the runtime still decides whether the account is writable for the current instruction.
+- `as_account()` / `as_account_mut()` return `Ref<T>` / `RefMut<T>` borrow guards. Copy out the fields you need and `drop(...)` the guard before CPIs or later mutable borrows.
+- Keep validation chains direct inside `process(self, ...)` when possible. That makes audits easier and gives `pina idl` the clearest signal for signer, writable, PDA, and default-account inference.
+
+<!-- {/pinaInstructionAuthoringTips} -->
+
 ## Entrypoint model
 
 `nostd_entrypoint!` wires BPF entrypoint plumbing while preserving `no_std` constraints for on-chain builds.

--- a/docs/src/crates-and-features.md
+++ b/docs/src/crates-and-features.md
@@ -46,7 +46,7 @@ Feature flags:
 <!-- {=pinaFeatureSelectionTips} -->
 
 - `derive` is the normal choice for program crates; disable it only when you want the low-level runtime traits without the proc macros.
-- `logs` is useful during bring-up, testing, and audits. Disable it when you want the smallest possible binary or completely silent runtime failures.
+- `logs` is useful during **initial development and debugging**, testing, and audits. Disable it when you want the smallest possible binary or completely silent runtime failures.
 - `token` enables `pina::token`, `pina::token_2022`, `pina::associated_token_account`, and the `TokenAccount` compatibility aliases over the upstream renamed account types.
 - `memo` is separate from `token`, so memo CPI support can be enabled without pulling in the token helper surface.
 - `account-resize` only unlocks realloc helpers such as `realloc_account()` and `realloc_account_zero()`. Close helpers still do not implicitly resize or zero account data.

--- a/docs/src/crates-and-features.md
+++ b/docs/src/crates-and-features.md
@@ -41,6 +41,18 @@ Feature flags:
 
 <!-- {/pinaFeatureFlags} -->
 
+## Feature selection tips
+
+<!-- {=pinaFeatureSelectionTips} -->
+
+- `derive` is the normal choice for program crates; disable it only when you want the low-level runtime traits without the proc macros.
+- `logs` is useful during bring-up, testing, and audits. Disable it when you want the smallest possible binary or completely silent runtime failures.
+- `token` enables `pina::token`, `pina::token_2022`, `pina::associated_token_account`, and the `TokenAccount` compatibility aliases over the upstream renamed account types.
+- `memo` is separate from `token`, so memo CPI support can be enabled without pulling in the token helper surface.
+- `account-resize` only unlocks realloc helpers such as `realloc_account()` and `realloc_account_zero()`. Close helpers still do not implicitly resize or zero account data.
+
+<!-- {/pinaFeatureSelectionTips} -->
+
 See [ADR 0004](./adrs/0004-no-std-and-no-allocator-boundary.md) and [ADR 0005](./adrs/0005-token-feature-boundaries.md) for the architectural rationale behind these feature and runtime boundaries. For concrete token CPI patterns, see [Token CPI Recipes](./tutorials/token-cpi-recipes.md).
 
 ## `crates/pina_macros`

--- a/docs/src/development-workflow.md
+++ b/docs/src/development-workflow.md
@@ -24,6 +24,7 @@ test:idl
 ## Reusable documentation blocks
 
 - Template providers live in `templates/*.t.md`.
+- Prefer updating the shared provider block first when the same guidance appears in the README, crate readmes, and mdBook.
 - Run `docs:sync` after changing provider blocks to refresh all consumer blocks.
 - Run `docs:check` (or `verify:docs`) in CI to ensure docs stay synchronized.
 

--- a/docs/src/security-model.md
+++ b/docs/src/security-model.md
@@ -52,6 +52,18 @@ For instruction payloads:
 - Ensure all token account types used by helper traits implement `AccountValidation`.
 - Keep close/transfer helpers conservation-safe (no temporary double-crediting).
 
+## Closing accounts safely
+
+<!-- {=pinaCloseAccountGuidance} -->
+
+Closing guidance under Pinocchio 0.11:
+
+- `close_with_recipient()` transfers lamports and closes the account handle, but it does not zero or resize account data for you.
+- When stale bytes must be invalidated, use `close_account_zeroed()` or manually call `zeroed()` before `close_with_recipient()`.
+- The `account-resize` feature only affects realloc helpers; it does not change close semantics.
+
+<!-- {/pinaCloseAccountGuidance} -->
+
 ## Best practices
 
 <!-- {=pinaSecurityBestPractices} -->
@@ -61,7 +73,7 @@ For instruction payloads:
 - **Always call `assert_empty()`** before account initialization to prevent reinitialization attacks
 - **Always verify program accounts** with `assert_address()` / `assert_program()` before CPI invocations
 - **Use `assert_type::<T>()`** to prevent type cosplay — it checks discriminator, owner, and data size
-- **Use `close_with_recipient()` with `zeroed()`** to safely close accounts and prevent revival attacks
+- **Use `close_account_zeroed()` or `zeroed()` + `close_with_recipient()`** when stale account bytes must be invalidated before close
 - **Prefer `assert_seeds()` / `assert_canonical_bump()`** over `assert_seeds_with_bump()` to enforce canonical PDA bumps
 - **Namespace PDA seeds** with type-specific prefixes to prevent PDA sharing across account types
 

--- a/readme.md
+++ b/readme.md
@@ -187,7 +187,7 @@ That last count-parity check is important because it catches silent extraction r
 <!-- {=pinaFeatureSelectionTips} -->
 
 - `derive` is the normal choice for program crates; disable it only when you want the low-level runtime traits without the proc macros.
-- `logs` is useful during bring-up, testing, and audits. Disable it when you want the smallest possible binary or completely silent runtime failures.
+- `logs` is useful during **initial development and debugging**, testing, and audits. Disable it when you want the smallest possible binary or completely silent runtime failures.
 - `token` enables `pina::token`, `pina::token_2022`, `pina::associated_token_account`, and the `TokenAccount` compatibility aliases over the upstream renamed account types.
 - `memo` is separate from `token`, so memo CPI support can be enabled without pulling in the token helper surface.
 - `account-resize` only unlocks realloc helpers such as `realloc_account()` and `realloc_account_zero()`. Close helpers still do not implicitly resize or zero account data.

--- a/readme.md
+++ b/readme.md
@@ -180,6 +180,20 @@ That last count-parity check is important because it catches silent extraction r
 
 <!-- {/pinaFeatureFlags} -->
 
+## Feature selection tips
+
+<br>
+
+<!-- {=pinaFeatureSelectionTips} -->
+
+- `derive` is the normal choice for program crates; disable it only when you want the low-level runtime traits without the proc macros.
+- `logs` is useful during bring-up, testing, and audits. Disable it when you want the smallest possible binary or completely silent runtime failures.
+- `token` enables `pina::token`, `pina::token_2022`, `pina::associated_token_account`, and the `TokenAccount` compatibility aliases over the upstream renamed account types.
+- `memo` is separate from `token`, so memo CPI support can be enabled without pulling in the token helper surface.
+- `account-resize` only unlocks realloc helpers such as `realloc_account()` and `realloc_account_zero()`. Close helpers still do not implicitly resize or zero account data.
+
+<!-- {/pinaFeatureSelectionTips} -->
+
 ## Documentation
 
 <br>
@@ -522,6 +536,20 @@ pub struct MyAccounts<'a> {
 }
 ```
 
+### Instruction authoring tips
+
+<br>
+
+<!-- {=pinaInstructionAuthoringTips} -->
+
+- Entry points should accept `&mut [AccountView]` and dispatch with `Accounts::try_from(accounts)?.process(data)`.
+- Use `&AccountView` for read-only accounts and `&mut AccountView` only when you need mutable loaders, direct lamport mutation, `close_*` helpers, or writable IDL inference.
+- Keep `assert_writable()` explicit even on `&mut AccountView`. Type-level mutability unlocks mutable APIs, but the runtime still decides whether the account is writable for the current instruction.
+- `as_account()` / `as_account_mut()` return `Ref<T>` / `RefMut<T>` borrow guards. Copy out the fields you need and `drop(...)` the guard before CPIs or later mutable borrows.
+- Keep validation chains direct inside `process(self, ...)` when possible. That makes audits easier and gives `pina idl` the clearest signal for signer, writable, PDA, and default-account inference.
+
+<!-- {/pinaInstructionAuthoringTips} -->
+
 ### Pod types
 
 <br>
@@ -642,6 +670,20 @@ destination.collect(1_000_000, source)?;
 // Close an account and return rent to recipient.
 account.close_with_recipient(recipient)?;
 ```
+
+#### Closing safety
+
+<br>
+
+<!-- {=pinaCloseAccountGuidance} -->
+
+Closing guidance under Pinocchio 0.11:
+
+- `close_with_recipient()` transfers lamports and closes the account handle, but it does not zero or resize account data for you.
+- When stale bytes must be invalidated, use `close_account_zeroed()` or manually call `zeroed()` before `close_with_recipient()`.
+- The `account-resize` feature only affects realloc helpers; it does not change close semantics.
+
+<!-- {/pinaCloseAccountGuidance} -->
 
 #### PDA seed combination
 
@@ -791,7 +833,7 @@ Pina provides strong built-in protections against common Solana vulnerabilities 
 - **Always call `assert_empty()`** before account initialization to prevent reinitialization attacks
 - **Always verify program accounts** with `assert_address()` / `assert_program()` before CPI invocations
 - **Use `assert_type::<T>()`** to prevent type cosplay — it checks discriminator, owner, and data size
-- **Use `close_with_recipient()` with `zeroed()`** to safely close accounts and prevent revival attacks
+- **Use `close_account_zeroed()` or `zeroed()` + `close_with_recipient()`** when stale account bytes must be invalidated before close
 - **Prefer `assert_seeds()` / `assert_canonical_bump()`** over `assert_seeds_with_bump()` to enforce canonical PDA bumps
 - **Namespace PDA seeds** with type-specific prefixes to prevent PDA sharing across account types
 

--- a/security/09-closing-accounts/readme.md
+++ b/security/09-closing-accounts/readme.md
@@ -28,11 +28,26 @@ An attacker can:
 
 <br>
 
-See [`secure/src/lib.rs`](secure/src/lib.rs). The program calls `zeroed()` on the account data to clear it, then calls `close_with_recipient()` to transfer the remaining lamports and close the account.
+See [`secure/src/lib.rs`](secure/src/lib.rs). The program invalidates the account bytes before closing so a revived account cannot reuse stale state in the same transaction.
+
+## Closing guidance
+
+<br>
+
+<!-- {=pinaCloseAccountGuidance} -->
+
+Closing guidance under Pinocchio 0.11:
+
+- `close_with_recipient()` transfers lamports and closes the account handle, but it does not zero or resize account data for you.
+- When stale bytes must be invalidated, use `close_account_zeroed()` or manually call `zeroed()` before `close_with_recipient()`.
+- The `account-resize` feature only affects realloc helpers; it does not change close semantics.
+
+<!-- {/pinaCloseAccountGuidance} -->
 
 ## Pina API Reference
 
 <br>
 
-- `CloseAccountWithRecipient::close_with_recipient()` — transfers lamports to the recipient and closes the account
-- Account data `zeroed()` method — zeros all account data before closing to prevent stale data reuse
+- `CloseAccountWithRecipient::close_with_recipient()` — close after you have already invalidated any sensitive or authority-bearing state
+- `CloseAccountWithRecipient::close_account_zeroed()` — zero the current raw account bytes, then close and return rent to the recipient
+- Account data `zeroed()` method — explicit typed/raw-state invalidation before `close_with_recipient()` when you need custom close sequencing

--- a/security/loaders-audit.md
+++ b/security/loaders-audit.md
@@ -1,10 +1,12 @@
-# `crates/pina/src/loaders.rs` audit
+# Historical loader audit
 
 _Audit date: 2026-03-23_
 
+_Status note (2026-04-22): the high-severity escaped-borrow findings in this audit were resolved by the guard-backed loader redesign that landed with the Pinocchio 0.11 migration. The implementation now lives in `crates/pina/src/impls.rs` rather than `crates/pina/src/loaders.rs`. Keep this document as historical context for why the API moved to `Ref<T>` / `RefMut<T>`-backed loaders._
+
 ## Scope
 
-This audit covers only:
+This audit originally covered only:
 
 - `crates/pina/src/loaders.rs`
 
@@ -12,7 +14,7 @@ Line numbers below refer to the current working tree at the time of writing.
 
 ## Executive summary
 
-`crates/pina/src/loaders.rs` is mostly disciplined about validation, logging, and arithmetic checks. The main issue is **not** the presence of `unsafe` by itself. The real problem is that several loader APIs construct references from guard-backed account borrows and then return those references **after the temporary borrow guard has already been dropped**.
+At the time of the audit, `crates/pina/src/loaders.rs` was mostly disciplined about validation, logging, and arithmetic checks. The main issue was **not** the presence of `unsafe` by itself. The real problem was that several loader APIs constructed references from guard-backed account borrows and then returned those references **after the temporary borrow guard had already been dropped**.
 
 That pattern appears in:
 
@@ -30,12 +32,12 @@ The short-lived `unsafe { self.owner() }` reads in `assert_owner` and `assert_ow
 
 ## Findings
 
-| ID | Severity | Status | Summary                                                                                |
-| -- | -------- | ------ | -------------------------------------------------------------------------------------- |
-| F1 | High     | Open   | `as_account` / `as_account_mut` return references that outlive temporary borrow guards |
-| F2 | High     | Open   | Token loaders repeat the same escaped-borrow lifetime pattern                          |
-| F3 | Low      | Accept | `unsafe { self.owner() }` is acceptable here as a short-lived runtime read             |
-| F4 | Low      | Open   | Lamport mutation helpers rely on caller-enforced ownership preconditions               |
+| ID | Severity | Status    | Summary                                                                                         |
+| -- | -------- | --------- | ----------------------------------------------------------------------------------------------- |
+| F1 | High     | Resolved  | `as_account` / `as_account_mut` used to return references that outlived temporary borrow guards |
+| F2 | High     | Resolved  | Token loaders used to repeat the same escaped-borrow lifetime pattern                           |
+| F3 | Low      | Accept    | `unsafe { self.owner() }` was acceptable here as a short-lived runtime read                     |
+| F4 | Low      | Mitigated | Lamport mutation helpers still rely on caller-enforced ownership preconditions                  |
 
 ---
 

--- a/security/readme.md
+++ b/security/readme.md
@@ -14,19 +14,19 @@ Based on the [sealevel-attacks](https://github.com/coral-xyz/sealevel-attacks) t
 
 <br>
 
-| #                                    | Attack                     | Key Pina Mitigation                                 |
-| ------------------------------------ | -------------------------- | --------------------------------------------------- |
-| [00](00-signer-authorization/)       | Signer Authorization       | `assert_signer()`                                   |
-| [01](01-account-data-matching/)      | Account Data Matching      | `assert_address()` on deserialized fields           |
-| [02](02-owner-checks/)               | Owner Checks               | `assert_owner()` / `assert_owners()`                |
-| [03](03-type-cosplay/)               | Type Cosplay               | `assert_type::<T>()` (discriminator + owner + size) |
-| [04](04-initialization/)             | Initialization             | `assert_empty()` before `create_program_account`    |
-| [05](05-arbitrary-cpi/)              | Arbitrary CPI              | `assert_address()` / `assert_program()`             |
-| [06](06-duplicate-mutable-accounts/) | Duplicate Mutable Accounts | Address inequality check                            |
-| [07](07-bump-seed-canonicalization/) | Bump Seed Canonicalization | `assert_seeds()` / `assert_canonical_bump()`        |
-| [08](08-pda-sharing/)                | PDA Sharing                | Namespaced seeds + `assert_type::<T>()`             |
-| [09](09-closing-accounts/)           | Closing Accounts           | `zeroed()` + `close_with_recipient()`               |
-| [10](10-sysvar-address-checking/)    | Sysvar Address Checking    | `assert_sysvar()`                                   |
+| #                                    | Attack                     | Key Pina Mitigation                                               |
+| ------------------------------------ | -------------------------- | ----------------------------------------------------------------- |
+| [00](00-signer-authorization/)       | Signer Authorization       | `assert_signer()`                                                 |
+| [01](01-account-data-matching/)      | Account Data Matching      | `assert_address()` on deserialized fields                         |
+| [02](02-owner-checks/)               | Owner Checks               | `assert_owner()` / `assert_owners()`                              |
+| [03](03-type-cosplay/)               | Type Cosplay               | `assert_type::<T>()` (discriminator + owner + size)               |
+| [04](04-initialization/)             | Initialization             | `assert_empty()` before `create_program_account`                  |
+| [05](05-arbitrary-cpi/)              | Arbitrary CPI              | `assert_address()` / `assert_program()`                           |
+| [06](06-duplicate-mutable-accounts/) | Duplicate Mutable Accounts | Address inequality check                                          |
+| [07](07-bump-seed-canonicalization/) | Bump Seed Canonicalization | `assert_seeds()` / `assert_canonical_bump()`                      |
+| [08](08-pda-sharing/)                | PDA Sharing                | Namespaced seeds + `assert_type::<T>()`                           |
+| [09](09-closing-accounts/)           | Closing Accounts           | `close_account_zeroed()` or `zeroed()` + `close_with_recipient()` |
+| [10](10-sysvar-address-checking/)    | Sysvar Address Checking    | `assert_sysvar()`                                                 |
 
 ## How to Use
 

--- a/templates/pina-overview.t.md
+++ b/templates/pina-overview.t.md
@@ -13,7 +13,7 @@
 <!-- {@pinaFeatureSelectionTips} -->
 
 - `derive` is the normal choice for program crates; disable it only when you want the low-level runtime traits without the proc macros.
-- `logs` is useful during bring-up, testing, and audits. Disable it when you want the smallest possible binary or completely silent runtime failures.
+- `logs` is useful during **initial development and debugging**, testing, and audits. Disable it when you want the smallest possible binary or completely silent runtime failures.
 - `token` enables `pina::token`, `pina::token_2022`, `pina::associated_token_account`, and the `TokenAccount` compatibility aliases over the upstream renamed account types.
 - `memo` is separate from `token`, so memo CPI support can be enabled without pulling in the token helper surface.
 - `account-resize` only unlocks realloc helpers such as `realloc_account()` and `realloc_account_zero()`. Close helpers still do not implicitly resize or zero account data.

--- a/templates/pina-overview.t.md
+++ b/templates/pina-overview.t.md
@@ -10,6 +10,16 @@
 
 <!-- {/pinaFeatureFlags} -->
 
+<!-- {@pinaFeatureSelectionTips} -->
+
+- `derive` is the normal choice for program crates; disable it only when you want the low-level runtime traits without the proc macros.
+- `logs` is useful during bring-up, testing, and audits. Disable it when you want the smallest possible binary or completely silent runtime failures.
+- `token` enables `pina::token`, `pina::token_2022`, `pina::associated_token_account`, and the `TokenAccount` compatibility aliases over the upstream renamed account types.
+- `memo` is separate from `token`, so memo CPI support can be enabled without pulling in the token helper surface.
+- `account-resize` only unlocks realloc helpers such as `realloc_account()` and `realloc_account_zero()`. Close helpers still do not implicitly resize or zero account data.
+
+<!-- {/pinaFeatureSelectionTips} -->
+
 <!-- {@pinaProjectDescription} -->
 
 A performant Solana smart contract framework built on top of [pinocchio](https://github.com/anza-xyz/pinocchio) — a zero-dependency alternative to `solana-program` that massively reduces compute units and dependency bloat.
@@ -102,6 +112,16 @@ Each Pod integer type provides `ZERO`, `MIN`, and `MAX` constants.
 
 <!-- {/pinaFeatureHighlights} -->
 
+<!-- {@pinaInstructionAuthoringTips} -->
+
+- Entry points should accept `&mut [AccountView]` and dispatch with `Accounts::try_from(accounts)?.process(data)`.
+- Use `&AccountView` for read-only accounts and `&mut AccountView` only when you need mutable loaders, direct lamport mutation, `close_*` helpers, or writable IDL inference.
+- Keep `assert_writable()` explicit even on `&mut AccountView`. Type-level mutability unlocks mutable APIs, but the runtime still decides whether the account is writable for the current instruction.
+- `as_account()` / `as_account_mut()` return `Ref<T>` / `RefMut<T>` borrow guards. Copy out the fields you need and `drop(...)` the guard before CPIs or later mutable borrows.
+- Keep validation chains direct inside `process(self, ...)` when possible. That makes audits easier and gives `pina idl` the clearest signal for signer, writable, PDA, and default-account inference.
+
+<!-- {/pinaInstructionAuthoringTips} -->
+
 <!-- {@sbfBuildInstructions} -->
 
 Programs are compiled to the `bpfel-unknown-none` target using `sbpf-linker`:
@@ -182,8 +202,18 @@ The profiler decodes each SBF instruction opcode and assigns costs: regular inst
 - **Always call `assert_empty()`** before account initialization to prevent reinitialization attacks
 - **Always verify program accounts** with `assert_address()` / `assert_program()` before CPI invocations
 - **Use `assert_type::<T>()`** to prevent type cosplay — it checks discriminator, owner, and data size
-- **Use `close_with_recipient()` with `zeroed()`** to safely close accounts and prevent revival attacks
+- **Use `close_account_zeroed()` or `zeroed()` + `close_with_recipient()`** when stale account bytes must be invalidated before close
 - **Prefer `assert_seeds()` / `assert_canonical_bump()`** over `assert_seeds_with_bump()` to enforce canonical PDA bumps
 - **Namespace PDA seeds** with type-specific prefixes to prevent PDA sharing across account types
 
 <!-- {/pinaSecurityBestPractices} -->
+
+<!-- {@pinaCloseAccountGuidance} -->
+
+Closing guidance under Pinocchio 0.11:
+
+- `close_with_recipient()` transfers lamports and closes the account handle, but it does not zero or resize account data for you.
+- When stale bytes must be invalidated, use `close_account_zeroed()` or manually call `zeroed()` before `close_with_recipient()`.
+- The `account-resize` feature only affects realloc helpers; it does not change close semantics.
+
+<!-- {/pinaCloseAccountGuidance} -->


### PR DESCRIPTION
## Summary
- expand the shared mdt-backed docs for feature selection, instruction authoring, and close-account safety
- refresh the root README, `crates/pina/readme.md`, and mdBook pages to match the Pinocchio 0.11 mutable-account + guard-backed loader model
- update the security docs and historical loader audit so close semantics and resolved loader findings match the current implementation
- add a docs changeset for the sweep

## Validation
- `devenv shell fix:format`
- `devenv shell docs:sync`
- `devenv shell verify:docs`
- `devenv shell lint:all`

## Notes
- this prefers shared `templates/*.t.md` providers so the README, crate readmes, and mdBook stay aligned through `mdt`
- `lint:all` completed successfully; any remaining clippy output in the run is pre-existing warning-only noise outside this docs-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded feature-selection guidance, instruction-authoring best practices, and account-closing safety guidance for Pinocchio 0.11
  * Updated security materials to record resolved loader/borrow issues and revised closing-account recommendations
  * Added/updated README, templates, and multiple docs pages for consistent guidance and workflow

* **Chores**
  * Adjusted CI/dev scripts and workflow detection to refine changed-crate logic and test tooling behavior

* **Documentation**
  * Expanded feature-selection guidance to clarify intended use, scope, and behavioral boundaries of core framework capabilities
  * Added comprehensive instruction-authoring best practices covering safe account handling, validation flows, and proper memory management patterns
  * Clarified account closing behavior and safe data invalidation approaches in Pinocchio 0.11 releases
  * Updated security documentation to reflect resolution of previously identified borrow-escape and loader issues
  * Refreshed development workflow guidelines for consistent documentation authoring and maintenance practices across the project
<!-- end of auto-generated comment: release notes by coderabbit.ai -->