### PR TITLE
fix: resolve kani and security CI regressions

### DIFF
--- a/.github/actions/devenv/action.yml
+++ b/.github/actions/devenv/action.yml
@@ -7,7 +7,7 @@ inputs:
   cache-version:
     description: The version of the cache to use.
     required: false
-    default: "v1"
+    default: "v2"
   setup-retries:
     description: Number of retries for transient nix/devenv setup failures.
     required: false
@@ -19,13 +19,15 @@ runs:
     - name: cache rust dependencies
       uses: Swatinem/rust-cache@v2
       with:
-        prefix-key: "${{ inputs.cache-version }}"
+        # Include the devenv/toolchain wiring in the cache key so cached build
+        # scripts don't outlive the Nix environment that produced them.
+        prefix-key: "${{ inputs.cache-version }}-${{ hashFiles('devenv.nix', 'rust-toolchain.toml', '.github/actions/devenv/action.yml') }}"
 
     - name: cache cargo binaries
       uses: actions/cache@v4
       with:
         path: ./.bin
-        key: ${{ runner.os }}-cargo-bin-${{ inputs.cache-version }}-${{ env.RUSTUP_TOOLCHAIN }}-${{ hashFiles('rust-toolchain.toml', 'Cargo.toml') }}
+        key: ${{ runner.os }}-cargo-bin-${{ inputs.cache-version }}-${{ env.RUSTUP_TOOLCHAIN }}-${{ hashFiles('devenv.nix', 'rust-toolchain.toml', '.github/actions/devenv/action.yml', 'Cargo.toml') }}
         restore-keys: |
           ${{ runner.os }}-cargo-bin-${{ inputs.cache-version }}-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,10 +146,9 @@ jobs:
           path: |
             ${{ github.workspace }}/.cache/sbpf-linker-upstream-gallery/llvm-install
             ${{ github.workspace }}/.cache/sbpf-linker-upstream-gallery/bin
-            ${{ github.workspace }}/.cache/sbpf-linker-upstream-gallery/sbpf-linker
-          key: ${{ runner.os }}-sbpf-gallery-v1-${{ hashFiles('devenv.nix', 'rust-toolchain.toml') }}
+          key: ${{ runner.os }}-sbpf-gallery-v2-${{ hashFiles('devenv.nix', 'rust-toolchain.toml', '.github/workflows/ci.yml', '.github/workflows/compute-units.yml') }}
           restore-keys: |
-            ${{ runner.os }}-sbpf-gallery-v1-
+            ${{ runner.os }}-sbpf-gallery-v2-
 
       - name: run program e2e tests
         run: test:program-e2e

--- a/.github/workflows/compute-units.yml
+++ b/.github/workflows/compute-units.yml
@@ -34,10 +34,9 @@ jobs:
           path: |
             ${{ github.workspace }}/.cache/sbpf-linker-upstream-gallery/llvm-install
             ${{ github.workspace }}/.cache/sbpf-linker-upstream-gallery/bin
-            ${{ github.workspace }}/.cache/sbpf-linker-upstream-gallery/sbpf-linker
-          key: ${{ runner.os }}-sbpf-gallery-v1-${{ hashFiles('devenv.nix', 'rust-toolchain.toml') }}
+          key: ${{ runner.os }}-sbpf-gallery-v2-${{ hashFiles('devenv.nix', 'rust-toolchain.toml', '.github/workflows/ci.yml', '.github/workflows/compute-units.yml') }}
           restore-keys: |
-            ${{ runner.os }}-sbpf-gallery-v1-
+            ${{ runner.os }}-sbpf-gallery-v2-
 
       - name: create base worktree
         run: |

--- a/devenv.nix
+++ b/devenv.nix
@@ -300,8 +300,19 @@ in
 
         mkdir -p "$CACHE_DIR"
 
+        if [ -x "$SBPF_BIN" ] && "$SBPF_BIN" --version >/dev/null 2>&1; then
+          export PATH="$CACHE_DIR/bin:$PATH"
+          echo "Using cached sbpf-linker binary at $SBPF_BIN"
+          exit 0
+        fi
+
+        if [ -e "$LLVM_CONFIG" ] && ! "$LLVM_CONFIG" --version >/dev/null 2>&1; then
+          echo "Cached LLVM install is invalid; rebuilding." >&2
+          rm -rf "$LLVM_BUILD" "$LLVM_INSTALL"
+        fi
+
         # Step 1: Build custom LLVM (BPF target only)
-        if [ ! -f "$LLVM_CONFIG" ]; then
+        if [ ! -x "$LLVM_CONFIG" ]; then
           if [ ! -d "$LLVM_SRC" ]; then
             echo "=== [1/3] Cloning Blueshift LLVM fork ==="
             git clone --depth 1 --branch upstream-gallery-21 \
@@ -370,7 +381,11 @@ in
           fi
         fi
 
+        SBPF_TARGET_DIR="$CACHE_DIR/sbpf-linker-target"
+        rm -rf "$SBPF_TARGET_DIR"
+
         LLVM_PREFIX="$LLVM_INSTALL" \
+          CARGO_TARGET_DIR="$SBPF_TARGET_DIR" \
           cargo install \
             --path "$SBPF_SRC" \
             --root "$CACHE_DIR" \
@@ -436,7 +451,7 @@ in
     "build:all" = {
       exec = ''
         set -euo pipefail
-        if [ -z "$CI" ]; then
+        if [ -z "''${CI:-}" ]; then
           echo "Building project locally"
           cargo build --all-features
         else
@@ -630,17 +645,25 @@ in
         # Run LiteSVM e2e tests with the generated TypeScript clients.
         # These verify that TS instruction builders with pina's discriminator
         # model produce transactions the on-chain programs accept.
-        pnpm --dir "$DEVENV_ROOT/codama/tests/litesvm" install --frozen-lockfile
-        SBF_OUT_DIR="$DEVENV_ROOT/target/deploy" \
-          pnpm --dir "$DEVENV_ROOT/codama/tests/litesvm" test
+        litesvm_dir="$DEVENV_ROOT/codama/tests/litesvm"
+        pnpm --dir "$litesvm_dir" install --frozen-lockfile
+        (
+          cd "$litesvm_dir"
+          SBF_OUT_DIR="$DEVENV_ROOT/target/deploy" \
+            node "$litesvm_dir/node_modules/vitest/vitest.mjs" run --pool threads
+        )
 
         # Run Quasar SVM tests alongside LiteSVM. These execute generated
         # instructions directly against the compiled program ELF in-process,
         # which is useful for fast instruction/account-cycle validation
         # without a validator.
-        pnpm --dir "$DEVENV_ROOT/codama/tests/quasar-svm" install --frozen-lockfile
-        SBF_OUT_DIR="$DEVENV_ROOT/target/deploy" \
-          pnpm --dir "$DEVENV_ROOT/codama/tests/quasar-svm" test
+        quasar_svm_dir="$DEVENV_ROOT/codama/tests/quasar-svm"
+        pnpm --dir "$quasar_svm_dir" install --frozen-lockfile
+        (
+          cd "$quasar_svm_dir"
+          SBF_OUT_DIR="$DEVENV_ROOT/target/deploy" \
+            node "$quasar_svm_dir/node_modules/vitest/vitest.mjs" run --pool threads
+        )
       '';
       description = "Build SBF binaries and run end-to-end program tests including mollusk-svm integration.";
       binary = "bash";
@@ -833,8 +856,12 @@ in
     "kani:proofs" = {
       exec = ''
         set -euo pipefail
+        # Kani injects `#![feature(register_tool)]`, which would otherwise trip
+        # the workspace-wide `unstable_features = "deny"` lint.
+        export RUSTFLAGS="''${RUSTFLAGS:+$RUSTFLAGS }-A unstable-features"
+
         # Run all Kani harnesses in pina_pod_primitives.
-        cargo kani --manifest-path "$DEVENV_ROOT/crates/pina_pod_primitives/Cargo.toml" --all-features --locked
+        cargo kani --manifest-path "$DEVENV_ROOT/crates/pina_pod_primitives/Cargo.toml" --all-features
       '';
       description = "Run Kani model-checking proofs for pina_pod_primitives.";
       binary = "bash";
@@ -906,9 +933,22 @@ in
           exit 1
         fi
 
-        cargo_dylint_bin="$(find "$bin_root" -path '*/cargo-dylint/*/bin/cargo-dylint' | sort | tail -n 1)"
-        if [ -z "$cargo_dylint_bin" ] || [ ! -x "$cargo_dylint_bin" ]; then
-          echo "Missing cargo-dylint in $bin_root. Run 'install:cargo:bin'." >&2
+        cargo_dylint_version="5.0.0"
+        cargo_dylint_root="$bin_root/manual/cargo-dylint/$cargo_dylint_version"
+        cargo_dylint_bin="$cargo_dylint_root/bin/cargo-dylint"
+
+        if [ ! -x "$cargo_dylint_bin" ]; then
+          mkdir -p "$cargo_dylint_root"
+          CARGO_TARGET_DIR="$DEVENV_ROOT/target/cargo-install/cargo-dylint" \
+            cargo install \
+              --locked \
+              --root "$cargo_dylint_root" \
+              cargo-dylint \
+              --version "$cargo_dylint_version"
+        fi
+
+        if [ ! -x "$cargo_dylint_bin" ]; then
+          echo "Unable to install cargo-dylint into $cargo_dylint_root." >&2
           exit 1
         fi
 

--- a/scripts/verify-codama-idls.sh
+++ b/scripts/verify-codama-idls.sh
@@ -78,10 +78,23 @@ cargo test -p pina_cli --locked --test codama_idls
 
 echo "Running Codama JS IDL validation..."
 pnpm --dir "$ROOT" run test:idls
-pnpm --dir "$ROOT" run test:nodes-from-pina
+
+NODES_FROM_PINA_DIR="$ROOT/packages/nodes-from-pina"
+
+echo "Type-checking nodes-from-pina..."
+(
+	cd "$NODES_FROM_PINA_DIR"
+	node "$NODES_FROM_PINA_DIR/node_modules/typescript/bin/tsc" --noEmit
+)
+
+echo "Running nodes-from-pina unit tests..."
+(
+	cd "$NODES_FROM_PINA_DIR"
+	node "$NODES_FROM_PINA_DIR/node_modules/vitest/vitest.mjs" run
+)
 
 echo "Type-checking generated JS clients..."
-pnpm --dir "$ROOT" run check:js
+node "$ROOT/node_modules/typescript/bin/tsc" --noEmit -p "$ROOT/codama/tsconfig.json"
 
 echo "Compile-checking generated Rust client crates..."
 CLIENT_MANIFESTS=()


### PR DESCRIPTION
## Summary
- remove the unsupported `--locked` flag from `cargo kani` invocations
- make `dylint-link` resolution work across git worktrees by reusing the repository-level `.bin` cache
- make `security:dylint` resolve `cargo-dylint` and `dylint-link` from the shared bin root before running

## Context
This fixes the post-merge CI failures from PR #150:
- `kani` failed because `cargo-kani` rejects `--locked`
- `security` failed because the generated `dylint-link` task wrapper fell back to `cargo bin` in lint crate directories

## Notes
- I am **not** enabling auto-merge on this PR.
- CI should validate the exact failures that regressed on #150.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI/toolchain caching to avoid stale or colliding artifacts and bumped cache namespace.
  * Reuse validated cached linker binaries; detect and remove invalid toolchain caches (including LLVM).
  * Isolate build artifact directories to prevent cross-run collisions and ensure clean installs.
  * Adjusted test and verification steps to run local type-checks and Vitest directly.
  * Updated proof and linter invocations to allow needed flags and install a deterministic linter binary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->