### PR TITLE
feat: resolve PDA account defaults in generated clients

### DIFF
--- a/.changeset/client_account_resolution.md
+++ b/.changeset/client_account_resolution.md
@@ -1,0 +1,6 @@
+---
+pina_cli: minor
+pina_codama_renderer: minor
+---
+
+Resolve explicit PDA-derived account defaults in generated clients. Codama lowering now preserves deterministic PDA default metadata from account seeds, and the Rust renderer emits builders that derive those defaults while keeping signer and writable expectations explicit.

--- a/codama/clients/js/counter_program/src/generated/instructions/increment.ts
+++ b/codama/clients/js/counter_program/src/generated/instructions/increment.ts
@@ -21,8 +21,10 @@ import {
 } from "@solana/kit";
 import {
 	getAccountMetaFactory,
+	getAddressFromResolvedInstructionAccount,
 	type ResolvedInstructionAccount,
 } from "@solana/program-client-core";
+import { findCounterPda } from "../pdas";
 import { COUNTER_PROGRAM_PROGRAM_ADDRESS } from "../programs";
 
 export const INCREMENT_DISCRIMINATOR = 1;
@@ -49,6 +51,66 @@ export type IncrementInstruction<
 			...TRemainingAccounts,
 		]
 	>;
+
+export type IncrementAsyncInput<
+	TAccountAuthority extends string = string,
+	TAccountCounter extends string = string,
+> = {
+	/** The counter's authority. Must sign to prove ownership. */
+	authority: TransactionSigner<TAccountAuthority>;
+	/** The counter PDA account (must already exist and be writable). */
+	counter?: Address<TAccountCounter>;
+};
+
+export async function getIncrementInstructionAsync<
+	TAccountAuthority extends string,
+	TAccountCounter extends string,
+	TProgramAddress extends Address = typeof COUNTER_PROGRAM_PROGRAM_ADDRESS,
+>(
+	input: IncrementAsyncInput<TAccountAuthority, TAccountCounter>,
+	config?: { programAddress?: TProgramAddress },
+): Promise<
+	IncrementInstruction<TProgramAddress, TAccountAuthority, TAccountCounter>
+> {
+	// Program address.
+	const programAddress = config?.programAddress ??
+		COUNTER_PROGRAM_PROGRAM_ADDRESS;
+
+	// Original accounts.
+	const originalAccounts = {
+		authority: { value: input.authority ?? null, isWritable: false },
+		counter: { value: input.counter ?? null, isWritable: true },
+	};
+	const accounts = originalAccounts as Record<
+		keyof typeof originalAccounts,
+		ResolvedInstructionAccount
+	>;
+
+	// Resolve default values.
+	if (!accounts.counter.value) {
+		accounts.counter.value = await findCounterPda({
+			authority: getAddressFromResolvedInstructionAccount(
+				"authority",
+				accounts.authority.value,
+			),
+		});
+	}
+
+	const getAccountMeta = getAccountMetaFactory(programAddress, "programId");
+	return Object.freeze(
+		{
+			accounts: [
+				getAccountMeta("authority", accounts.authority),
+				getAccountMeta("counter", accounts.counter),
+			],
+			programAddress,
+		} as IncrementInstruction<
+			TProgramAddress,
+			TAccountAuthority,
+			TAccountCounter
+		>,
+	);
+}
 
 export type IncrementInput<
 	TAccountAuthority extends string = string,

--- a/codama/clients/js/counter_program/src/generated/instructions/initialize.ts
+++ b/codama/clients/js/counter_program/src/generated/instructions/initialize.ts
@@ -31,8 +31,10 @@ import {
 } from "@solana/kit";
 import {
 	getAccountMetaFactory,
+	getAddressFromResolvedInstructionAccount,
 	type ResolvedInstructionAccount,
 } from "@solana/program-client-core";
+import { findCounterPda } from "../pdas";
 import { COUNTER_PROGRAM_PROGRAM_ADDRESS } from "../programs";
 
 export const INITIALIZE_DISCRIMINATOR = 0;
@@ -90,6 +92,96 @@ export function getInitializeInstructionDataCodec(): FixedSizeCodec<
 		getInitializeInstructionDataEncoder(),
 		getInitializeInstructionDataDecoder(),
 	);
+}
+
+export type InitializeAsyncInput<
+	TAccountAuthority extends string = string,
+	TAccountCounter extends string = string,
+	TAccountSystemProgram extends string = string,
+> = {
+	/**
+	 * The wallet creating the counter. Pays for account creation and becomes
+	 * the authority whose address seeds the PDA.
+	 */
+	authority: TransactionSigner<TAccountAuthority>;
+	/** The counter PDA account (must be empty — not yet created). */
+	counter?: Address<TAccountCounter>;
+	/** The system program, required for `CreateAccount` CPI. */
+	systemProgram?: Address<TAccountSystemProgram>;
+	bump: InitializeInstructionDataArgs["bump"];
+};
+
+export async function getInitializeInstructionAsync<
+	TAccountAuthority extends string,
+	TAccountCounter extends string,
+	TAccountSystemProgram extends string,
+	TProgramAddress extends Address = typeof COUNTER_PROGRAM_PROGRAM_ADDRESS,
+>(
+	input: InitializeAsyncInput<
+		TAccountAuthority,
+		TAccountCounter,
+		TAccountSystemProgram
+	>,
+	config?: { programAddress?: TProgramAddress },
+): Promise<
+	InitializeInstruction<
+		TProgramAddress,
+		TAccountAuthority,
+		TAccountCounter,
+		TAccountSystemProgram
+	>
+> {
+	// Program address.
+	const programAddress = config?.programAddress ??
+		COUNTER_PROGRAM_PROGRAM_ADDRESS;
+
+	// Original accounts.
+	const originalAccounts = {
+		authority: { value: input.authority ?? null, isWritable: false },
+		counter: { value: input.counter ?? null, isWritable: true },
+		systemProgram: { value: input.systemProgram ?? null, isWritable: false },
+	};
+	const accounts = originalAccounts as Record<
+		keyof typeof originalAccounts,
+		ResolvedInstructionAccount
+	>;
+
+	// Original args.
+	const args = { ...input };
+
+	// Resolve default values.
+	if (!accounts.counter.value) {
+		accounts.counter.value = await findCounterPda({
+			authority: getAddressFromResolvedInstructionAccount(
+				"authority",
+				accounts.authority.value,
+			),
+		});
+	}
+	if (!accounts.systemProgram.value) {
+		accounts.systemProgram.value =
+			"11111111111111111111111111111111" as Address<
+				"11111111111111111111111111111111"
+			>;
+	}
+
+	const getAccountMeta = getAccountMetaFactory(programAddress, "programId");
+	return Object.freeze({
+		accounts: [
+			getAccountMeta("authority", accounts.authority),
+			getAccountMeta("counter", accounts.counter),
+			getAccountMeta("systemProgram", accounts.systemProgram),
+		],
+		data: getInitializeInstructionDataEncoder().encode(
+			args as InitializeInstructionDataArgs,
+		),
+		programAddress,
+	} as InitializeInstruction<
+		TProgramAddress,
+		TAccountAuthority,
+		TAccountCounter,
+		TAccountSystemProgram
+	>);
 }
 
 export type InitializeInput<

--- a/codama/clients/js/counter_program/src/generated/programs/counterProgram.ts
+++ b/codama/clients/js/counter_program/src/generated/programs/counterProgram.ts
@@ -36,10 +36,10 @@ import {
 	getCounterStateCodec,
 } from "../accounts";
 import {
-	getIncrementInstruction,
-	getInitializeInstruction,
-	type IncrementInput,
-	type InitializeInput,
+	getIncrementInstructionAsync,
+	getInitializeInstructionAsync,
+	type IncrementAsyncInput,
+	type InitializeAsyncInput,
 	type ParsedIncrementInstruction,
 	type ParsedInitializeInstruction,
 	parseIncrementInstruction,
@@ -144,11 +144,15 @@ export type CounterProgramPluginAccounts = {
 
 export type CounterProgramPluginInstructions = {
 	initialize: (
-		input: InitializeInput,
-	) => ReturnType<typeof getInitializeInstruction> & SelfPlanAndSendFunctions;
+		input: InitializeAsyncInput,
+	) =>
+		& ReturnType<typeof getInitializeInstructionAsync>
+		& SelfPlanAndSendFunctions;
 	increment: (
-		input: IncrementInput,
-	) => ReturnType<typeof getIncrementInstruction> & SelfPlanAndSendFunctions;
+		input: IncrementAsyncInput,
+	) =>
+		& ReturnType<typeof getIncrementInstructionAsync>
+		& SelfPlanAndSendFunctions;
 };
 
 export type CounterProgramPluginPdas = { counter: typeof findCounterPda };
@@ -170,10 +174,13 @@ export function counterProgramProgram() {
 					initialize: (input) =>
 						addSelfPlanAndSendFunctions(
 							client,
-							getInitializeInstruction(input),
+							getInitializeInstructionAsync(input),
 						),
 					increment: (input) =>
-						addSelfPlanAndSendFunctions(client, getIncrementInstruction(input)),
+						addSelfPlanAndSendFunctions(
+							client,
+							getIncrementInstructionAsync(input),
+						),
 				},
 				pdas: { counter: findCounterPda },
 			},

--- a/codama/clients/js/role_registry_program/src/generated/instructions/initialize.ts
+++ b/codama/clients/js/role_registry_program/src/generated/instructions/initialize.ts
@@ -31,8 +31,10 @@ import {
 } from "@solana/kit";
 import {
 	getAccountMetaFactory,
+	getAddressFromResolvedInstructionAccount,
 	type ResolvedInstructionAccount,
 } from "@solana/program-client-core";
+import { findRegistryConfigPda } from "../pdas";
 import { ROLE_REGISTRY_PROGRAM_PROGRAM_ADDRESS } from "../programs";
 
 export const INITIALIZE_DISCRIMINATOR = 0;
@@ -91,6 +93,91 @@ export function getInitializeInstructionDataCodec(): FixedSizeCodec<
 		getInitializeInstructionDataEncoder(),
 		getInitializeInstructionDataDecoder(),
 	);
+}
+
+export type InitializeAsyncInput<
+	TAccountAdmin extends string = string,
+	TAccountRegistryConfig extends string = string,
+	TAccountSystemProgram extends string = string,
+> = {
+	admin: TransactionSigner<TAccountAdmin>;
+	registryConfig?: Address<TAccountRegistryConfig>;
+	systemProgram?: Address<TAccountSystemProgram>;
+	bump: InitializeInstructionDataArgs["bump"];
+};
+
+export async function getInitializeInstructionAsync<
+	TAccountAdmin extends string,
+	TAccountRegistryConfig extends string,
+	TAccountSystemProgram extends string,
+	TProgramAddress extends Address =
+		typeof ROLE_REGISTRY_PROGRAM_PROGRAM_ADDRESS,
+>(
+	input: InitializeAsyncInput<
+		TAccountAdmin,
+		TAccountRegistryConfig,
+		TAccountSystemProgram
+	>,
+	config?: { programAddress?: TProgramAddress },
+): Promise<
+	InitializeInstruction<
+		TProgramAddress,
+		TAccountAdmin,
+		TAccountRegistryConfig,
+		TAccountSystemProgram
+	>
+> {
+	// Program address.
+	const programAddress = config?.programAddress ??
+		ROLE_REGISTRY_PROGRAM_PROGRAM_ADDRESS;
+
+	// Original accounts.
+	const originalAccounts = {
+		admin: { value: input.admin ?? null, isWritable: true },
+		registryConfig: { value: input.registryConfig ?? null, isWritable: true },
+		systemProgram: { value: input.systemProgram ?? null, isWritable: false },
+	};
+	const accounts = originalAccounts as Record<
+		keyof typeof originalAccounts,
+		ResolvedInstructionAccount
+	>;
+
+	// Original args.
+	const args = { ...input };
+
+	// Resolve default values.
+	if (!accounts.registryConfig.value) {
+		accounts.registryConfig.value = await findRegistryConfigPda({
+			admin: getAddressFromResolvedInstructionAccount(
+				"admin",
+				accounts.admin.value,
+			),
+		});
+	}
+	if (!accounts.systemProgram.value) {
+		accounts.systemProgram.value =
+			"11111111111111111111111111111111" as Address<
+				"11111111111111111111111111111111"
+			>;
+	}
+
+	const getAccountMeta = getAccountMetaFactory(programAddress, "programId");
+	return Object.freeze({
+		accounts: [
+			getAccountMeta("admin", accounts.admin),
+			getAccountMeta("registryConfig", accounts.registryConfig),
+			getAccountMeta("systemProgram", accounts.systemProgram),
+		],
+		data: getInitializeInstructionDataEncoder().encode(
+			args as InitializeInstructionDataArgs,
+		),
+		programAddress,
+	} as InitializeInstruction<
+		TProgramAddress,
+		TAccountAdmin,
+		TAccountRegistryConfig,
+		TAccountSystemProgram
+	>);
 }
 
 export type InitializeInput<

--- a/codama/clients/js/role_registry_program/src/generated/programs/roleRegistryProgram.ts
+++ b/codama/clients/js/role_registry_program/src/generated/programs/roleRegistryProgram.ts
@@ -43,10 +43,10 @@ import {
 	type DeactivateRoleInput,
 	getAddRoleInstruction,
 	getDeactivateRoleInstruction,
-	getInitializeInstruction,
+	getInitializeInstructionAsync,
 	getRotateAdminInstruction,
 	getUpdateRoleInstruction,
-	type InitializeInput,
+	type InitializeAsyncInput,
 	parseAddRoleInstruction,
 	type ParsedAddRoleInstruction,
 	type ParsedDeactivateRoleInstruction,
@@ -205,8 +205,10 @@ export type RoleRegistryProgramPluginAccounts = {
 
 export type RoleRegistryProgramPluginInstructions = {
 	initialize: (
-		input: InitializeInput,
-	) => ReturnType<typeof getInitializeInstruction> & SelfPlanAndSendFunctions;
+		input: InitializeAsyncInput,
+	) =>
+		& ReturnType<typeof getInitializeInstructionAsync>
+		& SelfPlanAndSendFunctions;
 	addRole: (
 		input: AddRoleInput,
 	) => ReturnType<typeof getAddRoleInstruction> & SelfPlanAndSendFunctions;
@@ -249,7 +251,7 @@ export function roleRegistryProgramProgram() {
 					initialize: (input) =>
 						addSelfPlanAndSendFunctions(
 							client,
-							getInitializeInstruction(input),
+							getInitializeInstructionAsync(input),
 						),
 					addRole: (input) =>
 						addSelfPlanAndSendFunctions(client, getAddRoleInstruction(input)),

--- a/codama/clients/js/todo_program/src/generated/instructions/initialize.ts
+++ b/codama/clients/js/todo_program/src/generated/instructions/initialize.ts
@@ -35,8 +35,10 @@ import {
 } from "@solana/kit";
 import {
 	getAccountMetaFactory,
+	getAddressFromResolvedInstructionAccount,
 	type ResolvedInstructionAccount,
 } from "@solana/program-client-core";
+import { findTodoPda } from "../pdas";
 import { TODO_PROGRAM_PROGRAM_ADDRESS } from "../programs";
 
 export const INITIALIZE_DISCRIMINATOR = 0;
@@ -103,6 +105,90 @@ export function getInitializeInstructionDataCodec(): FixedSizeCodec<
 		getInitializeInstructionDataEncoder(),
 		getInitializeInstructionDataDecoder(),
 	);
+}
+
+export type InitializeAsyncInput<
+	TAccountOwner extends string = string,
+	TAccountTodo extends string = string,
+	TAccountSystemProgram extends string = string,
+> = {
+	owner: TransactionSigner<TAccountOwner>;
+	todo?: Address<TAccountTodo>;
+	systemProgram?: Address<TAccountSystemProgram>;
+	bump: InitializeInstructionDataArgs["bump"];
+	digest: InitializeInstructionDataArgs["digest"];
+};
+
+export async function getInitializeInstructionAsync<
+	TAccountOwner extends string,
+	TAccountTodo extends string,
+	TAccountSystemProgram extends string,
+	TProgramAddress extends Address = typeof TODO_PROGRAM_PROGRAM_ADDRESS,
+>(
+	input: InitializeAsyncInput<
+		TAccountOwner,
+		TAccountTodo,
+		TAccountSystemProgram
+	>,
+	config?: { programAddress?: TProgramAddress },
+): Promise<
+	InitializeInstruction<
+		TProgramAddress,
+		TAccountOwner,
+		TAccountTodo,
+		TAccountSystemProgram
+	>
+> {
+	// Program address.
+	const programAddress = config?.programAddress ?? TODO_PROGRAM_PROGRAM_ADDRESS;
+
+	// Original accounts.
+	const originalAccounts = {
+		owner: { value: input.owner ?? null, isWritable: false },
+		todo: { value: input.todo ?? null, isWritable: true },
+		systemProgram: { value: input.systemProgram ?? null, isWritable: false },
+	};
+	const accounts = originalAccounts as Record<
+		keyof typeof originalAccounts,
+		ResolvedInstructionAccount
+	>;
+
+	// Original args.
+	const args = { ...input };
+
+	// Resolve default values.
+	if (!accounts.todo.value) {
+		accounts.todo.value = await findTodoPda({
+			owner: getAddressFromResolvedInstructionAccount(
+				"owner",
+				accounts.owner.value,
+			),
+		});
+	}
+	if (!accounts.systemProgram.value) {
+		accounts.systemProgram.value =
+			"11111111111111111111111111111111" as Address<
+				"11111111111111111111111111111111"
+			>;
+	}
+
+	const getAccountMeta = getAccountMetaFactory(programAddress, "programId");
+	return Object.freeze({
+		accounts: [
+			getAccountMeta("owner", accounts.owner),
+			getAccountMeta("todo", accounts.todo),
+			getAccountMeta("systemProgram", accounts.systemProgram),
+		],
+		data: getInitializeInstructionDataEncoder().encode(
+			args as InitializeInstructionDataArgs,
+		),
+		programAddress,
+	} as InitializeInstruction<
+		TProgramAddress,
+		TAccountOwner,
+		TAccountTodo,
+		TAccountSystemProgram
+	>);
 }
 
 export type InitializeInput<

--- a/codama/clients/js/todo_program/src/generated/instructions/toggleCompleted.ts
+++ b/codama/clients/js/todo_program/src/generated/instructions/toggleCompleted.ts
@@ -21,8 +21,10 @@ import {
 } from "@solana/kit";
 import {
 	getAccountMetaFactory,
+	getAddressFromResolvedInstructionAccount,
 	type ResolvedInstructionAccount,
 } from "@solana/program-client-core";
+import { findTodoPda } from "../pdas";
 import { TODO_PROGRAM_PROGRAM_ADDRESS } from "../programs";
 
 export const TOGGLE_COMPLETED_DISCRIMINATOR = 1;
@@ -49,6 +51,63 @@ export type ToggleCompletedInstruction<
 			...TRemainingAccounts,
 		]
 	>;
+
+export type ToggleCompletedAsyncInput<
+	TAccountOwner extends string = string,
+	TAccountTodo extends string = string,
+> = {
+	owner: TransactionSigner<TAccountOwner>;
+	todo?: Address<TAccountTodo>;
+};
+
+export async function getToggleCompletedInstructionAsync<
+	TAccountOwner extends string,
+	TAccountTodo extends string,
+	TProgramAddress extends Address = typeof TODO_PROGRAM_PROGRAM_ADDRESS,
+>(
+	input: ToggleCompletedAsyncInput<TAccountOwner, TAccountTodo>,
+	config?: { programAddress?: TProgramAddress },
+): Promise<
+	ToggleCompletedInstruction<TProgramAddress, TAccountOwner, TAccountTodo>
+> {
+	// Program address.
+	const programAddress = config?.programAddress ?? TODO_PROGRAM_PROGRAM_ADDRESS;
+
+	// Original accounts.
+	const originalAccounts = {
+		owner: { value: input.owner ?? null, isWritable: false },
+		todo: { value: input.todo ?? null, isWritable: true },
+	};
+	const accounts = originalAccounts as Record<
+		keyof typeof originalAccounts,
+		ResolvedInstructionAccount
+	>;
+
+	// Resolve default values.
+	if (!accounts.todo.value) {
+		accounts.todo.value = await findTodoPda({
+			owner: getAddressFromResolvedInstructionAccount(
+				"owner",
+				accounts.owner.value,
+			),
+		});
+	}
+
+	const getAccountMeta = getAccountMetaFactory(programAddress, "programId");
+	return Object.freeze(
+		{
+			accounts: [
+				getAccountMeta("owner", accounts.owner),
+				getAccountMeta("todo", accounts.todo),
+			],
+			programAddress,
+		} as ToggleCompletedInstruction<
+			TProgramAddress,
+			TAccountOwner,
+			TAccountTodo
+		>,
+	);
+}
 
 export type ToggleCompletedInput<
 	TAccountOwner extends string = string,

--- a/codama/clients/js/todo_program/src/generated/instructions/updateDigest.ts
+++ b/codama/clients/js/todo_program/src/generated/instructions/updateDigest.ts
@@ -33,8 +33,10 @@ import {
 } from "@solana/kit";
 import {
 	getAccountMetaFactory,
+	getAddressFromResolvedInstructionAccount,
 	type ResolvedInstructionAccount,
 } from "@solana/program-client-core";
+import { findTodoPda } from "../pdas";
 import { TODO_PROGRAM_PROGRAM_ADDRESS } from "../programs";
 
 export const UPDATE_DIGEST_DISCRIMINATOR = 2;
@@ -87,6 +89,64 @@ export function getUpdateDigestInstructionDataCodec(): FixedSizeCodec<
 		getUpdateDigestInstructionDataEncoder(),
 		getUpdateDigestInstructionDataDecoder(),
 	);
+}
+
+export type UpdateDigestAsyncInput<
+	TAccountOwner extends string = string,
+	TAccountTodo extends string = string,
+> = {
+	owner: TransactionSigner<TAccountOwner>;
+	todo?: Address<TAccountTodo>;
+	digest: UpdateDigestInstructionDataArgs["digest"];
+};
+
+export async function getUpdateDigestInstructionAsync<
+	TAccountOwner extends string,
+	TAccountTodo extends string,
+	TProgramAddress extends Address = typeof TODO_PROGRAM_PROGRAM_ADDRESS,
+>(
+	input: UpdateDigestAsyncInput<TAccountOwner, TAccountTodo>,
+	config?: { programAddress?: TProgramAddress },
+): Promise<
+	UpdateDigestInstruction<TProgramAddress, TAccountOwner, TAccountTodo>
+> {
+	// Program address.
+	const programAddress = config?.programAddress ?? TODO_PROGRAM_PROGRAM_ADDRESS;
+
+	// Original accounts.
+	const originalAccounts = {
+		owner: { value: input.owner ?? null, isWritable: false },
+		todo: { value: input.todo ?? null, isWritable: true },
+	};
+	const accounts = originalAccounts as Record<
+		keyof typeof originalAccounts,
+		ResolvedInstructionAccount
+	>;
+
+	// Original args.
+	const args = { ...input };
+
+	// Resolve default values.
+	if (!accounts.todo.value) {
+		accounts.todo.value = await findTodoPda({
+			owner: getAddressFromResolvedInstructionAccount(
+				"owner",
+				accounts.owner.value,
+			),
+		});
+	}
+
+	const getAccountMeta = getAccountMetaFactory(programAddress, "programId");
+	return Object.freeze({
+		accounts: [
+			getAccountMeta("owner", accounts.owner),
+			getAccountMeta("todo", accounts.todo),
+		],
+		data: getUpdateDigestInstructionDataEncoder().encode(
+			args as UpdateDigestInstructionDataArgs,
+		),
+		programAddress,
+	} as UpdateDigestInstruction<TProgramAddress, TAccountOwner, TAccountTodo>);
 }
 
 export type UpdateDigestInput<

--- a/codama/clients/js/todo_program/src/generated/programs/todoProgram.ts
+++ b/codama/clients/js/todo_program/src/generated/programs/todoProgram.ts
@@ -36,18 +36,18 @@ import {
 	type TodoStateArgs,
 } from "../accounts";
 import {
-	getInitializeInstruction,
-	getToggleCompletedInstruction,
-	getUpdateDigestInstruction,
-	type InitializeInput,
+	getInitializeInstructionAsync,
+	getToggleCompletedInstructionAsync,
+	getUpdateDigestInstructionAsync,
+	type InitializeAsyncInput,
 	type ParsedInitializeInstruction,
 	type ParsedToggleCompletedInstruction,
 	type ParsedUpdateDigestInstruction,
 	parseInitializeInstruction,
 	parseToggleCompletedInstruction,
 	parseUpdateDigestInstruction,
-	type ToggleCompletedInput,
-	type UpdateDigestInput,
+	type ToggleCompletedAsyncInput,
+	type UpdateDigestAsyncInput,
 } from "../instructions";
 import { findTodoPda } from "../pdas";
 
@@ -161,16 +161,20 @@ export type TodoProgramPluginAccounts = {
 
 export type TodoProgramPluginInstructions = {
 	initialize: (
-		input: InitializeInput,
-	) => ReturnType<typeof getInitializeInstruction> & SelfPlanAndSendFunctions;
-	toggleCompleted: (
-		input: ToggleCompletedInput,
+		input: InitializeAsyncInput,
 	) =>
-		& ReturnType<typeof getToggleCompletedInstruction>
+		& ReturnType<typeof getInitializeInstructionAsync>
+		& SelfPlanAndSendFunctions;
+	toggleCompleted: (
+		input: ToggleCompletedAsyncInput,
+	) =>
+		& ReturnType<typeof getToggleCompletedInstructionAsync>
 		& SelfPlanAndSendFunctions;
 	updateDigest: (
-		input: UpdateDigestInput,
-	) => ReturnType<typeof getUpdateDigestInstruction> & SelfPlanAndSendFunctions;
+		input: UpdateDigestAsyncInput,
+	) =>
+		& ReturnType<typeof getUpdateDigestInstructionAsync>
+		& SelfPlanAndSendFunctions;
 };
 
 export type TodoProgramPluginPdas = { todo: typeof findTodoPda };
@@ -192,17 +196,17 @@ export function todoProgramProgram() {
 					initialize: (input) =>
 						addSelfPlanAndSendFunctions(
 							client,
-							getInitializeInstruction(input),
+							getInitializeInstructionAsync(input),
 						),
 					toggleCompleted: (input) =>
 						addSelfPlanAndSendFunctions(
 							client,
-							getToggleCompletedInstruction(input),
+							getToggleCompletedInstructionAsync(input),
 						),
 					updateDigest: (input) =>
 						addSelfPlanAndSendFunctions(
 							client,
-							getUpdateDigestInstruction(input),
+							getUpdateDigestInstructionAsync(input),
 						),
 				},
 				pdas: { todo: findTodoPda },

--- a/codama/clients/rust/anchor_declare_id/Cargo.toml
+++ b/codama/clients/rust/anchor_declare_id/Cargo.toml
@@ -13,5 +13,5 @@ solana-account-info = { workspace = true, default-features = true }
 solana-cpi = { workspace = true, default-features = true }
 solana-instruction = { workspace = true, default-features = true }
 solana-program-error = { workspace = true, default-features = true }
-solana-pubkey = { workspace = true, default-features = true }
+solana-pubkey = { workspace = true, default-features = true, features = ["curve25519"] }
 thiserror = { workspace = true, default-features = true }

--- a/codama/clients/rust/anchor_declare_program/Cargo.toml
+++ b/codama/clients/rust/anchor_declare_program/Cargo.toml
@@ -13,5 +13,5 @@ solana-account-info = { workspace = true, default-features = true }
 solana-cpi = { workspace = true, default-features = true }
 solana-instruction = { workspace = true, default-features = true }
 solana-program-error = { workspace = true, default-features = true }
-solana-pubkey = { workspace = true, default-features = true }
+solana-pubkey = { workspace = true, default-features = true, features = ["curve25519"] }
 thiserror = { workspace = true, default-features = true }

--- a/codama/clients/rust/anchor_duplicate_mutable_accounts/Cargo.toml
+++ b/codama/clients/rust/anchor_duplicate_mutable_accounts/Cargo.toml
@@ -13,5 +13,5 @@ solana-account-info = { workspace = true, default-features = true }
 solana-cpi = { workspace = true, default-features = true }
 solana-instruction = { workspace = true, default-features = true }
 solana-program-error = { workspace = true, default-features = true }
-solana-pubkey = { workspace = true, default-features = true }
+solana-pubkey = { workspace = true, default-features = true, features = ["curve25519"] }
 thiserror = { workspace = true, default-features = true }

--- a/codama/clients/rust/anchor_errors/Cargo.toml
+++ b/codama/clients/rust/anchor_errors/Cargo.toml
@@ -13,5 +13,5 @@ solana-account-info = { workspace = true, default-features = true }
 solana-cpi = { workspace = true, default-features = true }
 solana-instruction = { workspace = true, default-features = true }
 solana-program-error = { workspace = true, default-features = true }
-solana-pubkey = { workspace = true, default-features = true }
+solana-pubkey = { workspace = true, default-features = true, features = ["curve25519"] }
 thiserror = { workspace = true, default-features = true }

--- a/codama/clients/rust/anchor_events/Cargo.toml
+++ b/codama/clients/rust/anchor_events/Cargo.toml
@@ -13,5 +13,5 @@ solana-account-info = { workspace = true, default-features = true }
 solana-cpi = { workspace = true, default-features = true }
 solana-instruction = { workspace = true, default-features = true }
 solana-program-error = { workspace = true, default-features = true }
-solana-pubkey = { workspace = true, default-features = true }
+solana-pubkey = { workspace = true, default-features = true, features = ["curve25519"] }
 thiserror = { workspace = true, default-features = true }

--- a/codama/clients/rust/anchor_floats/Cargo.toml
+++ b/codama/clients/rust/anchor_floats/Cargo.toml
@@ -13,5 +13,5 @@ solana-account-info = { workspace = true, default-features = true }
 solana-cpi = { workspace = true, default-features = true }
 solana-instruction = { workspace = true, default-features = true }
 solana-program-error = { workspace = true, default-features = true }
-solana-pubkey = { workspace = true, default-features = true }
+solana-pubkey = { workspace = true, default-features = true, features = ["curve25519"] }
 thiserror = { workspace = true, default-features = true }

--- a/codama/clients/rust/anchor_realloc/Cargo.toml
+++ b/codama/clients/rust/anchor_realloc/Cargo.toml
@@ -13,5 +13,5 @@ solana-account-info = { workspace = true, default-features = true }
 solana-cpi = { workspace = true, default-features = true }
 solana-instruction = { workspace = true, default-features = true }
 solana-program-error = { workspace = true, default-features = true }
-solana-pubkey = { workspace = true, default-features = true }
+solana-pubkey = { workspace = true, default-features = true, features = ["curve25519"] }
 thiserror = { workspace = true, default-features = true }

--- a/codama/clients/rust/anchor_system_accounts/Cargo.toml
+++ b/codama/clients/rust/anchor_system_accounts/Cargo.toml
@@ -13,5 +13,5 @@ solana-account-info = { workspace = true, default-features = true }
 solana-cpi = { workspace = true, default-features = true }
 solana-instruction = { workspace = true, default-features = true }
 solana-program-error = { workspace = true, default-features = true }
-solana-pubkey = { workspace = true, default-features = true }
+solana-pubkey = { workspace = true, default-features = true, features = ["curve25519"] }
 thiserror = { workspace = true, default-features = true }

--- a/codama/clients/rust/anchor_sysvars/Cargo.toml
+++ b/codama/clients/rust/anchor_sysvars/Cargo.toml
@@ -13,5 +13,5 @@ solana-account-info = { workspace = true, default-features = true }
 solana-cpi = { workspace = true, default-features = true }
 solana-instruction = { workspace = true, default-features = true }
 solana-program-error = { workspace = true, default-features = true }
-solana-pubkey = { workspace = true, default-features = true }
+solana-pubkey = { workspace = true, default-features = true, features = ["curve25519"] }
 thiserror = { workspace = true, default-features = true }

--- a/codama/clients/rust/counter_program/Cargo.toml
+++ b/codama/clients/rust/counter_program/Cargo.toml
@@ -13,5 +13,5 @@ solana-account-info = { workspace = true, default-features = true }
 solana-cpi = { workspace = true, default-features = true }
 solana-instruction = { workspace = true, default-features = true }
 solana-program-error = { workspace = true, default-features = true }
-solana-pubkey = { workspace = true, default-features = true }
+solana-pubkey = { workspace = true, default-features = true, features = ["curve25519"] }
 thiserror = { workspace = true, default-features = true }

--- a/codama/clients/rust/counter_program/src/generated/instructions/increment.rs
+++ b/codama/clients/rust/counter_program/src/generated/instructions/increment.rs
@@ -22,8 +22,15 @@ pub struct Increment {
 }
 
 impl Increment {
-	pub fn new(authority: solana_pubkey::Pubkey, counter: solana_pubkey::Pubkey) -> Self {
-		Self { authority, counter }
+	pub fn new(authority: solana_pubkey::Pubkey) -> Self {
+		Self {
+			authority,
+			counter: solana_pubkey::Pubkey::find_program_address(
+				&["counter".as_bytes(), authority.as_ref()],
+				&crate::COUNTER_PROGRAM_ID,
+			)
+			.0,
+		}
 	}
 
 	pub fn instruction(&self, data: IncrementInstructionData) -> solana_instruction::Instruction {

--- a/codama/clients/rust/counter_program/src/generated/instructions/initialize.rs
+++ b/codama/clients/rust/counter_program/src/generated/instructions/initialize.rs
@@ -27,10 +27,14 @@ pub struct Initialize {
 }
 
 impl Initialize {
-	pub fn new(authority: solana_pubkey::Pubkey, counter: solana_pubkey::Pubkey) -> Self {
+	pub fn new(authority: solana_pubkey::Pubkey) -> Self {
 		Self {
 			authority,
-			counter,
+			counter: solana_pubkey::Pubkey::find_program_address(
+				&["counter".as_bytes(), authority.as_ref()],
+				&crate::COUNTER_PROGRAM_ID,
+			)
+			.0,
 			system_program: solana_pubkey::pubkey!("11111111111111111111111111111111"),
 		}
 	}

--- a/codama/clients/rust/escrow_program/Cargo.toml
+++ b/codama/clients/rust/escrow_program/Cargo.toml
@@ -13,5 +13,5 @@ solana-account-info = { workspace = true, default-features = true }
 solana-cpi = { workspace = true, default-features = true }
 solana-instruction = { workspace = true, default-features = true }
 solana-program-error = { workspace = true, default-features = true }
-solana-pubkey = { workspace = true, default-features = true }
+solana-pubkey = { workspace = true, default-features = true, features = ["curve25519"] }
 thiserror = { workspace = true, default-features = true }

--- a/codama/clients/rust/hello_solana/Cargo.toml
+++ b/codama/clients/rust/hello_solana/Cargo.toml
@@ -13,5 +13,5 @@ solana-account-info = { workspace = true, default-features = true }
 solana-cpi = { workspace = true, default-features = true }
 solana-instruction = { workspace = true, default-features = true }
 solana-program-error = { workspace = true, default-features = true }
-solana-pubkey = { workspace = true, default-features = true }
+solana-pubkey = { workspace = true, default-features = true, features = ["curve25519"] }
 thiserror = { workspace = true, default-features = true }

--- a/codama/clients/rust/pina_bpf/Cargo.toml
+++ b/codama/clients/rust/pina_bpf/Cargo.toml
@@ -13,5 +13,5 @@ solana-account-info = { workspace = true, default-features = true }
 solana-cpi = { workspace = true, default-features = true }
 solana-instruction = { workspace = true, default-features = true }
 solana-program-error = { workspace = true, default-features = true }
-solana-pubkey = { workspace = true, default-features = true }
+solana-pubkey = { workspace = true, default-features = true, features = ["curve25519"] }
 thiserror = { workspace = true, default-features = true }

--- a/codama/clients/rust/prop_amm_program/Cargo.toml
+++ b/codama/clients/rust/prop_amm_program/Cargo.toml
@@ -13,5 +13,5 @@ solana-account-info = { workspace = true, default-features = true }
 solana-cpi = { workspace = true, default-features = true }
 solana-instruction = { workspace = true, default-features = true }
 solana-program-error = { workspace = true, default-features = true }
-solana-pubkey = { workspace = true, default-features = true }
+solana-pubkey = { workspace = true, default-features = true, features = ["curve25519"] }
 thiserror = { workspace = true, default-features = true }

--- a/codama/clients/rust/role_registry_program/Cargo.toml
+++ b/codama/clients/rust/role_registry_program/Cargo.toml
@@ -13,5 +13,5 @@ solana-account-info = { workspace = true, default-features = true }
 solana-cpi = { workspace = true, default-features = true }
 solana-instruction = { workspace = true, default-features = true }
 solana-program-error = { workspace = true, default-features = true }
-solana-pubkey = { workspace = true, default-features = true }
+solana-pubkey = { workspace = true, default-features = true, features = ["curve25519"] }
 thiserror = { workspace = true, default-features = true }

--- a/codama/clients/rust/role_registry_program/src/generated/instructions/initialize.rs
+++ b/codama/clients/rust/role_registry_program/src/generated/instructions/initialize.rs
@@ -19,10 +19,14 @@ pub struct Initialize {
 }
 
 impl Initialize {
-	pub fn new(admin: solana_pubkey::Pubkey, registry_config: solana_pubkey::Pubkey) -> Self {
+	pub fn new(admin: solana_pubkey::Pubkey) -> Self {
 		Self {
 			admin,
-			registry_config,
+			registry_config: solana_pubkey::Pubkey::find_program_address(
+				&["registry".as_bytes(), admin.as_ref()],
+				&crate::ROLE_REGISTRY_PROGRAM_ID,
+			)
+			.0,
 			system_program: solana_pubkey::pubkey!("11111111111111111111111111111111"),
 		}
 	}

--- a/codama/clients/rust/role_registry_program/tests/contract.rs
+++ b/codama/clients/rust/role_registry_program/tests/contract.rs
@@ -36,10 +36,11 @@ fn role_registry_program_client_has_expected_contract_shape() {
 	let admin = Pubkey::new_unique();
 	let grantee = Pubkey::new_unique();
 	let new_admin = Pubkey::new_unique();
-	let registry_config = Pubkey::new_unique();
+	let registry_config =
+		Pubkey::find_program_address(&["registry".as_bytes(), admin.as_ref()], &program_id).0;
 	let role_entry = Pubkey::new_unique();
 
-	let initialize = Initialize::new(admin, registry_config);
+	let initialize = Initialize::new(admin);
 	let init_payload = InitializeInstructionData::new(7);
 	let init_ix = initialize.instruction(init_payload);
 	assert_eq!(init_ix.program_id, program_id);

--- a/codama/clients/rust/staking_rewards_program/Cargo.toml
+++ b/codama/clients/rust/staking_rewards_program/Cargo.toml
@@ -13,5 +13,5 @@ solana-account-info = { workspace = true, default-features = true }
 solana-cpi = { workspace = true, default-features = true }
 solana-instruction = { workspace = true, default-features = true }
 solana-program-error = { workspace = true, default-features = true }
-solana-pubkey = { workspace = true, default-features = true }
+solana-pubkey = { workspace = true, default-features = true, features = ["curve25519"] }
 thiserror = { workspace = true, default-features = true }

--- a/codama/clients/rust/todo_program/Cargo.toml
+++ b/codama/clients/rust/todo_program/Cargo.toml
@@ -13,5 +13,5 @@ solana-account-info = { workspace = true, default-features = true }
 solana-cpi = { workspace = true, default-features = true }
 solana-instruction = { workspace = true, default-features = true }
 solana-program-error = { workspace = true, default-features = true }
-solana-pubkey = { workspace = true, default-features = true }
+solana-pubkey = { workspace = true, default-features = true, features = ["curve25519"] }
 thiserror = { workspace = true, default-features = true }

--- a/codama/clients/rust/todo_program/src/generated/instructions/initialize.rs
+++ b/codama/clients/rust/todo_program/src/generated/instructions/initialize.rs
@@ -19,10 +19,14 @@ pub struct Initialize {
 }
 
 impl Initialize {
-	pub fn new(owner: solana_pubkey::Pubkey, todo: solana_pubkey::Pubkey) -> Self {
+	pub fn new(owner: solana_pubkey::Pubkey) -> Self {
 		Self {
 			owner,
-			todo,
+			todo: solana_pubkey::Pubkey::find_program_address(
+				&["todo".as_bytes(), owner.as_ref()],
+				&crate::TODO_PROGRAM_ID,
+			)
+			.0,
 			system_program: solana_pubkey::pubkey!("11111111111111111111111111111111"),
 		}
 	}

--- a/codama/clients/rust/todo_program/src/generated/instructions/toggle_completed.rs
+++ b/codama/clients/rust/todo_program/src/generated/instructions/toggle_completed.rs
@@ -18,8 +18,15 @@ pub struct ToggleCompleted {
 }
 
 impl ToggleCompleted {
-	pub fn new(owner: solana_pubkey::Pubkey, todo: solana_pubkey::Pubkey) -> Self {
-		Self { owner, todo }
+	pub fn new(owner: solana_pubkey::Pubkey) -> Self {
+		Self {
+			owner,
+			todo: solana_pubkey::Pubkey::find_program_address(
+				&["todo".as_bytes(), owner.as_ref()],
+				&crate::TODO_PROGRAM_ID,
+			)
+			.0,
+		}
 	}
 
 	pub fn instruction(

--- a/codama/clients/rust/todo_program/src/generated/instructions/update_digest.rs
+++ b/codama/clients/rust/todo_program/src/generated/instructions/update_digest.rs
@@ -18,8 +18,15 @@ pub struct UpdateDigest {
 }
 
 impl UpdateDigest {
-	pub fn new(owner: solana_pubkey::Pubkey, todo: solana_pubkey::Pubkey) -> Self {
-		Self { owner, todo }
+	pub fn new(owner: solana_pubkey::Pubkey) -> Self {
+		Self {
+			owner,
+			todo: solana_pubkey::Pubkey::find_program_address(
+				&["todo".as_bytes(), owner.as_ref()],
+				&crate::TODO_PROGRAM_ID,
+			)
+			.0,
+		}
 	}
 
 	pub fn instruction(

--- a/codama/clients/rust/transfer_sol/Cargo.toml
+++ b/codama/clients/rust/transfer_sol/Cargo.toml
@@ -13,5 +13,5 @@ solana-account-info = { workspace = true, default-features = true }
 solana-cpi = { workspace = true, default-features = true }
 solana-instruction = { workspace = true, default-features = true }
 solana-program-error = { workspace = true, default-features = true }
-solana-pubkey = { workspace = true, default-features = true }
+solana-pubkey = { workspace = true, default-features = true, features = ["curve25519"] }
 thiserror = { workspace = true, default-features = true }

--- a/codama/clients/rust/vesting_program/Cargo.toml
+++ b/codama/clients/rust/vesting_program/Cargo.toml
@@ -13,5 +13,5 @@ solana-account-info = { workspace = true, default-features = true }
 solana-cpi = { workspace = true, default-features = true }
 solana-instruction = { workspace = true, default-features = true }
 solana-program-error = { workspace = true, default-features = true }
-solana-pubkey = { workspace = true, default-features = true }
+solana-pubkey = { workspace = true, default-features = true, features = ["curve25519"] }
 thiserror = { workspace = true, default-features = true }

--- a/codama/idls/counter_program.json
+++ b/codama/idls/counter_program.json
@@ -109,7 +109,24 @@
 						"isSigner": false,
 						"docs": [
 							"The counter PDA account (must be empty — not yet created)."
-						]
+						],
+						"defaultValue": {
+							"kind": "pdaValueNode",
+							"pda": {
+								"kind": "pdaLinkNode",
+								"name": "counter"
+							},
+							"seeds": [
+								{
+									"kind": "pdaSeedValueNode",
+									"name": "authority",
+									"value": {
+										"kind": "accountValueNode",
+										"name": "authority"
+									}
+								}
+							]
+						}
 					},
 					{
 						"kind": "instructionAccountNode",
@@ -179,7 +196,24 @@
 						"isSigner": false,
 						"docs": [
 							"The counter PDA account (must already exist and be writable)."
-						]
+						],
+						"defaultValue": {
+							"kind": "pdaValueNode",
+							"pda": {
+								"kind": "pdaLinkNode",
+								"name": "counter"
+							},
+							"seeds": [
+								{
+									"kind": "pdaSeedValueNode",
+									"name": "authority",
+									"value": {
+										"kind": "accountValueNode",
+										"name": "authority"
+									}
+								}
+							]
+						}
 					}
 				],
 				"arguments": [],

--- a/codama/idls/role_registry_program.json
+++ b/codama/idls/role_registry_program.json
@@ -156,7 +156,24 @@
 						"kind": "instructionAccountNode",
 						"name": "registryConfig",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"defaultValue": {
+							"kind": "pdaValueNode",
+							"pda": {
+								"kind": "pdaLinkNode",
+								"name": "registryConfig"
+							},
+							"seeds": [
+								{
+									"kind": "pdaSeedValueNode",
+									"name": "admin",
+									"value": {
+										"kind": "accountValueNode",
+										"name": "admin"
+									}
+								}
+							]
+						}
 					},
 					{
 						"kind": "instructionAccountNode",

--- a/codama/idls/todo_program.json
+++ b/codama/idls/todo_program.json
@@ -90,7 +90,24 @@
 						"kind": "instructionAccountNode",
 						"name": "todo",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"defaultValue": {
+							"kind": "pdaValueNode",
+							"pda": {
+								"kind": "pdaLinkNode",
+								"name": "todo"
+							},
+							"seeds": [
+								{
+									"kind": "pdaSeedValueNode",
+									"name": "owner",
+									"value": {
+										"kind": "accountValueNode",
+										"name": "owner"
+									}
+								}
+							]
+						}
 					},
 					{
 						"kind": "instructionAccountNode",
@@ -158,7 +175,24 @@
 						"kind": "instructionAccountNode",
 						"name": "todo",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"defaultValue": {
+							"kind": "pdaValueNode",
+							"pda": {
+								"kind": "pdaLinkNode",
+								"name": "todo"
+							},
+							"seeds": [
+								{
+									"kind": "pdaSeedValueNode",
+									"name": "owner",
+									"value": {
+										"kind": "accountValueNode",
+										"name": "owner"
+									}
+								}
+							]
+						}
 					}
 				],
 				"arguments": [],
@@ -195,7 +229,24 @@
 						"kind": "instructionAccountNode",
 						"name": "todo",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"defaultValue": {
+							"kind": "pdaValueNode",
+							"pda": {
+								"kind": "pdaLinkNode",
+								"name": "todo"
+							},
+							"seeds": [
+								{
+									"kind": "pdaSeedValueNode",
+									"name": "owner",
+									"value": {
+										"kind": "accountValueNode",
+										"name": "owner"
+									}
+								}
+							]
+						}
 					}
 				],
 				"arguments": [

--- a/crates/pina_cli/src/codegen/mod.rs
+++ b/crates/pina_cli/src/codegen/mod.rs
@@ -1,4 +1,5 @@
 use codama_nodes::AccountNode;
+use codama_nodes::AccountValueNode;
 use codama_nodes::Base16;
 use codama_nodes::ConstantDiscriminatorNode;
 use codama_nodes::ConstantPdaSeedNode;
@@ -13,8 +14,11 @@ use codama_nodes::IsAccountSigner;
 use codama_nodes::NumberFormat;
 use codama_nodes::NumberTypeNode;
 use codama_nodes::NumberValueNode;
+use codama_nodes::PdaLinkNode;
 use codama_nodes::PdaNode;
 use codama_nodes::PdaSeedNode;
+use codama_nodes::PdaSeedValueNode;
+use codama_nodes::PdaValueNode;
 use codama_nodes::ProgramNode;
 use codama_nodes::PublicKeyValueNode;
 use codama_nodes::RootNode;
@@ -45,7 +49,7 @@ pub fn ir_to_root_node(ir: &ProgramIr) -> RootNode {
 	}
 
 	for instruction in &ir.instructions {
-		program = program.add_instruction(build_instruction_node(instruction));
+		program = program.add_instruction(build_instruction_node(instruction, &ir.pdas));
 	}
 
 	for pda in &ir.pdas {
@@ -73,11 +77,11 @@ fn build_account_node(account: &AccountIr) -> AccountNode {
 	node
 }
 
-fn build_instruction_node(instruction: &InstructionIr) -> InstructionNode {
+fn build_instruction_node(instruction: &InstructionIr, pdas: &[PdaIr]) -> InstructionNode {
 	let accounts: Vec<InstructionAccountNode> = instruction
 		.accounts
 		.iter()
-		.map(build_instruction_account_node)
+		.map(|account| build_instruction_account_node(account, instruction, pdas))
 		.collect();
 
 	let arguments: Vec<InstructionArgumentNode> = instruction
@@ -103,7 +107,11 @@ fn build_instruction_node(instruction: &InstructionIr) -> InstructionNode {
 	node
 }
 
-fn build_instruction_account_node(account: &InstructionAccountIr) -> InstructionAccountNode {
+fn build_instruction_account_node(
+	account: &InstructionAccountIr,
+	instruction: &InstructionIr,
+	pdas: &[PdaIr],
+) -> InstructionAccountNode {
 	let is_signer = if account.is_signer {
 		IsAccountSigner::True
 	} else {
@@ -120,9 +128,52 @@ fn build_instruction_account_node(account: &InstructionAccountIr) -> Instruction
 
 	if let Some(default_value) = &account.default_value {
 		node.default_value = Some(build_default_value(default_value));
+	} else if let Some(default_value) = build_pda_default_value(account, instruction, pdas) {
+		node.default_value = Some(default_value);
 	}
 
 	node
+}
+
+fn build_pda_default_value(
+	account: &InstructionAccountIr,
+	instruction: &InstructionIr,
+	pdas: &[PdaIr],
+) -> Option<InstructionInputValueNode> {
+	let pda_name = account.pda_name.as_ref()?;
+	let pda = pdas.iter().find(|pda| pda.name == *pda_name)?;
+	let mut seed_values = Vec::new();
+
+	for seed in &pda.seeds {
+		let PdaSeedIr::Variable { name, .. } = seed else {
+			continue;
+		};
+
+		let value = if let Some(seed_account) = instruction
+			.accounts
+			.iter()
+			.find(|account| account.name == *name)
+		{
+			if seed_account.name == account.name
+				|| seed_account.is_optional
+				|| seed_account.default_value.is_some()
+				|| seed_account.pda_name.is_some()
+			{
+				return None;
+			}
+
+			PdaSeedValueNode::new(name.as_str(), AccountValueNode::new(name.as_str()))
+		} else {
+			return None;
+		};
+
+		seed_values.push(value);
+	}
+
+	Some(InstructionInputValueNode::Pda(PdaValueNode::new(
+		PdaLinkNode::new(pda_name.as_str()),
+		seed_values,
+	)))
 }
 
 fn build_default_value(default_value: &DefaultValueIr) -> InstructionInputValueNode {
@@ -207,4 +258,81 @@ fn build_error_node(error: &ErrorIr) -> ErrorNode {
 	}
 
 	node
+}
+
+#[cfg(test)]
+mod tests {
+	use codama_nodes::InstructionInputValueNode;
+	use codama_nodes::PdaSeedValueValueNode;
+	use codama_nodes::PdaValue;
+
+	use super::*;
+
+	#[test]
+	fn lowers_pda_instruction_account_default_from_account_seed() {
+		let ir = ProgramIr {
+			name: "default_program".to_string(),
+			public_key: "11111111111111111111111111111111".to_string(),
+			accounts: vec![],
+			instructions: vec![InstructionIr {
+				name: "initialize".to_string(),
+				accounts: vec![
+					InstructionAccountIr {
+						name: "authority".to_string(),
+						is_writable: false,
+						is_signer: true,
+						is_optional: false,
+						default_value: None,
+						is_pda: false,
+						pda_name: None,
+						docs: vec![],
+					},
+					InstructionAccountIr {
+						name: "state".to_string(),
+						is_writable: true,
+						is_signer: false,
+						is_optional: false,
+						default_value: None,
+						is_pda: true,
+						pda_name: Some("state".to_string()),
+						docs: vec![],
+					},
+				],
+				arguments: vec![],
+				discriminator: DiscriminatorIr {
+					value: 1,
+					repr_size: 1,
+				},
+				docs: vec![],
+			}],
+			errors: vec![],
+			pdas: vec![PdaIr {
+				name: "state".to_string(),
+				seeds: vec![
+					PdaSeedIr::Constant {
+						value: b"state".to_vec(),
+					},
+					PdaSeedIr::Variable {
+						name: "authority".to_string(),
+						rust_type: "Pubkey".to_string(),
+					},
+				],
+			}],
+		};
+
+		let root = ir_to_root_node(&ir);
+		let account = &root.program.instructions[0].accounts[1];
+		let Some(InstructionInputValueNode::Pda(default_value)) = &account.default_value else {
+			panic!("expected PDA account default");
+		};
+
+		assert!(
+			matches!(&default_value.pda, PdaValue::Linked(link) if link.name.as_ref() == "state")
+		);
+		assert_eq!(default_value.seeds.len(), 1);
+		assert!(matches!(
+			&default_value.seeds[0].value,
+			PdaSeedValueValueNode::Account(account) if account.name.as_ref() == "authority"
+		));
+	}
 }

--- a/crates/pina_cli/src/codegen/mod.rs
+++ b/crates/pina_cli/src/codegen/mod.rs
@@ -157,7 +157,6 @@ fn build_pda_default_value(
 			if seed_account.name == account.name
 				|| seed_account.is_optional
 				|| seed_account.default_value.is_some()
-				|| seed_account.pda_name.is_some()
 			{
 				return None;
 			}

--- a/crates/pina_cli/tests/snapshots/examples__counter_program.snap
+++ b/crates/pina_cli/tests/snapshots/examples__counter_program.snap
@@ -113,7 +113,24 @@ expression: idl
             "isSigner": false,
             "docs": [
               "The counter PDA account (must be empty — not yet created)."
-            ]
+            ],
+            "defaultValue": {
+              "kind": "pdaValueNode",
+              "pda": {
+                "kind": "pdaLinkNode",
+                "name": "counter"
+              },
+              "seeds": [
+                {
+                  "kind": "pdaSeedValueNode",
+                  "name": "authority",
+                  "value": {
+                    "kind": "accountValueNode",
+                    "name": "authority"
+                  }
+                }
+              ]
+            }
           },
           {
             "kind": "instructionAccountNode",
@@ -183,7 +200,24 @@ expression: idl
             "isSigner": false,
             "docs": [
               "The counter PDA account (must already exist and be writable)."
-            ]
+            ],
+            "defaultValue": {
+              "kind": "pdaValueNode",
+              "pda": {
+                "kind": "pdaLinkNode",
+                "name": "counter"
+              },
+              "seeds": [
+                {
+                  "kind": "pdaSeedValueNode",
+                  "name": "authority",
+                  "value": {
+                    "kind": "accountValueNode",
+                    "name": "authority"
+                  }
+                }
+              ]
+            }
           }
         ],
         "arguments": [],

--- a/crates/pina_cli/tests/snapshots/examples__todo_program.snap
+++ b/crates/pina_cli/tests/snapshots/examples__todo_program.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/pina_cli/tests/examples.rs
-assertion_line: 55
 expression: idl
 ---
 {
@@ -95,7 +94,24 @@ expression: idl
             "kind": "instructionAccountNode",
             "name": "todo",
             "isWritable": true,
-            "isSigner": false
+            "isSigner": false,
+            "defaultValue": {
+              "kind": "pdaValueNode",
+              "pda": {
+                "kind": "pdaLinkNode",
+                "name": "todo"
+              },
+              "seeds": [
+                {
+                  "kind": "pdaSeedValueNode",
+                  "name": "owner",
+                  "value": {
+                    "kind": "accountValueNode",
+                    "name": "owner"
+                  }
+                }
+              ]
+            }
           },
           {
             "kind": "instructionAccountNode",
@@ -163,7 +179,24 @@ expression: idl
             "kind": "instructionAccountNode",
             "name": "todo",
             "isWritable": true,
-            "isSigner": false
+            "isSigner": false,
+            "defaultValue": {
+              "kind": "pdaValueNode",
+              "pda": {
+                "kind": "pdaLinkNode",
+                "name": "todo"
+              },
+              "seeds": [
+                {
+                  "kind": "pdaSeedValueNode",
+                  "name": "owner",
+                  "value": {
+                    "kind": "accountValueNode",
+                    "name": "owner"
+                  }
+                }
+              ]
+            }
           }
         ],
         "arguments": [],
@@ -200,7 +233,24 @@ expression: idl
             "kind": "instructionAccountNode",
             "name": "todo",
             "isWritable": true,
-            "isSigner": false
+            "isSigner": false,
+            "defaultValue": {
+              "kind": "pdaValueNode",
+              "pda": {
+                "kind": "pdaLinkNode",
+                "name": "todo"
+              },
+              "seeds": [
+                {
+                  "kind": "pdaSeedValueNode",
+                  "name": "owner",
+                  "value": {
+                    "kind": "accountValueNode",
+                    "name": "owner"
+                  }
+                }
+              ]
+            }
           }
         ],
         "arguments": [

--- a/crates/pina_cli/tests/snapshots/fixtures__pda_seeds.snap
+++ b/crates/pina_cli/tests/snapshots/fixtures__pda_seeds.snap
@@ -27,7 +27,24 @@ expression: idl
             "kind": "instructionAccountNode",
             "name": "counter",
             "isWritable": true,
-            "isSigner": false
+            "isSigner": false,
+            "defaultValue": {
+              "kind": "pdaValueNode",
+              "pda": {
+                "kind": "pdaLinkNode",
+                "name": "counter"
+              },
+              "seeds": [
+                {
+                  "kind": "pdaSeedValueNode",
+                  "name": "authority",
+                  "value": {
+                    "kind": "accountValueNode",
+                    "name": "authority"
+                  }
+                }
+              ]
+            }
           }
         ],
         "arguments": [

--- a/crates/pina_codama_renderer/src/__tests.rs
+++ b/crates/pina_codama_renderer/src/__tests.rs
@@ -5,6 +5,7 @@ use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
 use codama_nodes::AccountNode;
+use codama_nodes::AccountValueNode;
 use codama_nodes::BooleanTypeNode;
 use codama_nodes::ConstantDiscriminatorNode;
 use codama_nodes::ConstantPdaSeedNode;
@@ -14,6 +15,7 @@ use codama_nodes::DiscriminatorNode;
 use codama_nodes::Docs;
 use codama_nodes::Endian;
 use codama_nodes::InstructionAccountNode;
+use codama_nodes::InstructionInputValueNode;
 use codama_nodes::InstructionNode;
 use codama_nodes::InstructionOptionalAccountStrategy;
 use codama_nodes::IsAccountSigner;
@@ -23,7 +25,10 @@ use codama_nodes::NumberValueNode;
 use codama_nodes::PdaLinkNode;
 use codama_nodes::PdaNode;
 use codama_nodes::PdaSeedNode;
+use codama_nodes::PdaSeedValueNode;
+use codama_nodes::PdaValueNode;
 use codama_nodes::ProgramNode;
+use codama_nodes::PublicKeyTypeNode;
 use codama_nodes::RootNode;
 use codama_nodes::StringTypeNode;
 use codama_nodes::StringValueNode;
@@ -31,6 +36,7 @@ use codama_nodes::StructFieldTypeNode;
 use codama_nodes::StructTypeNode;
 use codama_nodes::TypeNode;
 use codama_nodes::U8;
+use codama_nodes::VariablePdaSeedNode;
 
 use super::render::seeds::render_variable_seed_parameter;
 use super::*;
@@ -153,6 +159,69 @@ fn renders_pda_helpers_for_linked_account() {
 	let content = read_generated_file(&crate_dir, "accounts/state.rs");
 
 	insta::assert_snapshot!("pda_helpers_for_linked_account", content);
+}
+
+#[test]
+fn renders_instruction_account_default_from_pda() {
+	let mut state = InstructionAccountNode::new("state", true, false);
+	state.default_value = Some(InstructionInputValueNode::Pda(PdaValueNode::new(
+		PdaLinkNode::new("statePda"),
+		vec![PdaSeedValueNode::new(
+			"authority",
+			AccountValueNode::new("authority"),
+		)],
+	)));
+
+	let program = ProgramNode {
+		name: "defaultProgram".into(),
+		public_key: "11111111111111111111111111111111".to_string(),
+		accounts: vec![],
+		instructions: vec![InstructionNode {
+			name: "initialize".into(),
+			docs: Docs::default(),
+			optional_account_strategy: InstructionOptionalAccountStrategy::ProgramId,
+			accounts: vec![InstructionAccountNode::new("authority", false, true), state],
+			arguments: vec![],
+			extra_arguments: vec![],
+			remaining_accounts: vec![],
+			byte_deltas: vec![],
+			discriminators: vec![DiscriminatorNode::Constant(ConstantDiscriminatorNode::new(
+				ConstantValueNode::new(NumberTypeNode::le(U8), NumberValueNode::new(7u8)),
+				0,
+			))],
+			status: None,
+			sub_instructions: vec![],
+		}],
+		defined_types: vec![],
+		pdas: vec![PdaNode::new(
+			"statePda",
+			vec![
+				PdaSeedNode::Constant(ConstantPdaSeedNode::new(
+					StringTypeNode::utf8(),
+					StringValueNode::new("state"),
+				)),
+				PdaSeedNode::Variable(VariablePdaSeedNode::new(
+					"authority",
+					PublicKeyTypeNode::new(),
+				)),
+			],
+		)],
+		errors: vec![],
+		version: String::new(),
+		origin: None,
+		docs: Docs::default(),
+	};
+	let output_dir = unique_temp_dir("pina-codama-render-pda-default");
+	let crate_dir = output_dir.join("default_program");
+	render_root_node(
+		&RootNode::new(program),
+		&crate_dir,
+		&RenderConfig::default(),
+	)
+	.unwrap_or_else(|e| panic!("render failed: {e}"));
+
+	let content = read_generated_file(&crate_dir, "instructions/initialize.rs");
+	insta::assert_snapshot!("instruction_account_default_from_pda", content);
 }
 
 #[test]

--- a/crates/pina_codama_renderer/src/__tests.rs
+++ b/crates/pina_codama_renderer/src/__tests.rs
@@ -172,6 +172,9 @@ fn renders_instruction_account_default_from_pda() {
 		)],
 	)));
 
+	let mut authority = InstructionAccountNode::new("authority", false, true);
+	authority.is_signer = IsAccountSigner::Either;
+
 	let program = ProgramNode {
 		name: "defaultProgram".into(),
 		public_key: "11111111111111111111111111111111".to_string(),
@@ -180,7 +183,7 @@ fn renders_instruction_account_default_from_pda() {
 			name: "initialize".into(),
 			docs: Docs::default(),
 			optional_account_strategy: InstructionOptionalAccountStrategy::ProgramId,
-			accounts: vec![InstructionAccountNode::new("authority", false, true), state],
+			accounts: vec![authority, state],
 			arguments: vec![],
 			extra_arguments: vec![],
 			remaining_accounts: vec![],

--- a/crates/pina_codama_renderer/src/render/instructions.rs
+++ b/crates/pina_codama_renderer/src/render/instructions.rs
@@ -4,6 +4,11 @@ use codama_nodes::InstructionInputValueNode;
 use codama_nodes::InstructionNode;
 use codama_nodes::InstructionOptionalAccountStrategy;
 use codama_nodes::IsAccountSigner;
+use codama_nodes::PdaNode;
+use codama_nodes::PdaSeedNode;
+use codama_nodes::PdaSeedValueValueNode;
+use codama_nodes::PdaValue;
+use codama_nodes::PdaValueNode;
 use codama_nodes::ProgramNode;
 
 use super::discriminator::render_constant_discriminator;
@@ -11,6 +16,7 @@ use super::helpers::pascal;
 use super::helpers::program_id_const_name;
 use super::helpers::render_docs;
 use super::helpers::snake;
+use super::seeds::render_constant_seed_expression;
 use super::types::render_type_for_pod;
 use crate::error::RenderError;
 use crate::error::Result;
@@ -95,6 +101,7 @@ pub(crate) fn render_instruction_page(
 		let (field_type, base_type) = render_instruction_account_field_type(account);
 		let default_value = render_instruction_account_default_value(
 			account,
+			instruction,
 			&base_type,
 			primary_program_const,
 			program,
@@ -274,8 +281,160 @@ fn render_instruction_account_field_type(account: &InstructionAccountNode) -> (S
 	}
 }
 
+fn render_pda_default_value(
+	pda_value: &PdaValueNode,
+	instruction: &InstructionNode,
+	primary_program_const: &str,
+	program: &ProgramNode,
+	account: &InstructionAccountNode,
+) -> Result<String> {
+	let pda = match &pda_value.pda {
+		PdaValue::Linked(link) => {
+			program
+				.pdas
+				.iter()
+				.find(|pda| pda.name == link.name)
+				.ok_or_else(|| {
+					RenderError::UnsupportedValue {
+						context: format!(
+							"instruction `{}` account `{}` default PDA",
+							pascal(instruction.name.as_ref()),
+							snake(account.name.as_ref())
+						),
+						kind: pda_value.kind(),
+						reason: format!("linked PDA `{}` was not found", link.name.as_ref()),
+					}
+				})?
+		}
+		PdaValue::Nested(pda) => pda,
+	};
+
+	let seed_expressions = render_pda_default_seed_expressions(
+		pda,
+		pda_value,
+		instruction,
+		primary_program_const,
+		account,
+	)?;
+
+	Ok(format!(
+		"solana_pubkey::Pubkey::find_program_address(\n\t\t\t\t&[{}],\n\t\t\t\t&\
+		 crate::{primary_program_const},\n\t\t\t).0",
+		seed_expressions.join(", ")
+	))
+}
+
+fn render_pda_default_seed_expressions(
+	pda: &PdaNode,
+	pda_value: &PdaValueNode,
+	instruction: &InstructionNode,
+	primary_program_const: &str,
+	account: &InstructionAccountNode,
+) -> Result<Vec<String>> {
+	let mut seed_expressions = Vec::new();
+
+	for seed in &pda.seeds {
+		match seed {
+			PdaSeedNode::Constant(constant) => {
+				seed_expressions.push(render_constant_seed_expression(
+					&constant.r#type,
+					&constant.value,
+					&pda_default_context(instruction, account),
+					primary_program_const,
+				)?);
+			}
+			PdaSeedNode::Variable(variable) => {
+				let Some(value) = pda_value
+					.seeds
+					.iter()
+					.find(|value| value.name == variable.name)
+				else {
+					return Err(RenderError::UnsupportedValue {
+						context: pda_default_context(instruction, account),
+						kind: pda_value.kind(),
+						reason: format!("missing value for PDA seed `{}`", variable.name.as_ref()),
+					});
+				};
+
+				seed_expressions.push(render_pda_default_seed_value(
+					value,
+					instruction,
+					account,
+					&pda_default_context(instruction, account),
+				)?);
+			}
+		}
+	}
+
+	Ok(seed_expressions)
+}
+
+fn render_pda_default_seed_value(
+	value: &codama_nodes::PdaSeedValueNode,
+	instruction: &InstructionNode,
+	default_account: &InstructionAccountNode,
+	context: &str,
+) -> Result<String> {
+	match &value.value {
+		PdaSeedValueValueNode::Account(account) => {
+			let name = account.name.as_ref();
+			let referenced_account = instruction
+				.accounts
+				.iter()
+				.find(|instruction_account| instruction_account.name.as_ref() == name)
+				.ok_or_else(|| {
+					RenderError::UnsupportedValue {
+						context: context.to_string(),
+						kind: value.value.kind(),
+						reason: format!("account PDA seed `{name}` was not found"),
+					}
+				})?;
+
+			if referenced_account.name == default_account.name
+				|| referenced_account.is_optional
+				|| referenced_account.default_value.is_some()
+			{
+				return Err(RenderError::UnsupportedValue {
+					context: context.to_string(),
+					kind: value.value.kind(),
+					reason: format!(
+						"account PDA seed `{name}` is not an explicit builder parameter"
+					),
+				});
+			}
+
+			Ok(format!("{}.as_ref()", snake(name)))
+		}
+		PdaSeedValueValueNode::Argument(_) => {
+			Err(RenderError::UnsupportedValue {
+				context: context.to_string(),
+				kind: value.value.kind(),
+				reason: "instruction argument PDA seed defaults are not supported by account \
+				         builders"
+					.to_string(),
+			})
+		}
+		other => {
+			Err(RenderError::UnsupportedValue {
+				context: context.to_string(),
+				kind: other.kind(),
+				reason: "only account and argument PDA seed values are supported".to_string(),
+			})
+		}
+	}
+}
+
+fn pda_default_context(instruction: &InstructionNode, account: &InstructionAccountNode) -> String {
+	format!(
+		"instruction `{}` account `{}` default PDA",
+		pascal(instruction.name.as_ref()),
+		snake(account.name.as_ref())
+	)
+}
+
 fn render_instruction_account_default_value(
 	account: &InstructionAccountNode,
+	instruction: &InstructionNode,
 	_base_type: &str,
 	primary_program_const: &str,
 	program: &ProgramNode,
@@ -300,6 +459,9 @@ fn render_instruction_account_default_value(
 				"crate::{}",
 				program_id_const_name(program_link.name.as_ref())
 			)
+		}
+		InstructionInputValueNode::Pda(pda) => {
+			render_pda_default_value(pda, instruction, primary_program_const, program, account)?
 		}
 		_ => {
 			return Err(RenderError::UnsupportedValue {

--- a/crates/pina_codama_renderer/src/render/instructions.rs
+++ b/crates/pina_codama_renderer/src/render/instructions.rs
@@ -403,7 +403,12 @@ fn render_pda_default_seed_value(
 				});
 			}
 
-			Ok(format!("{}.as_ref()", snake(name)))
+			let seed_name = snake(name);
+			if matches!(referenced_account.is_signer, IsAccountSigner::Either) {
+				Ok(format!("{seed_name}.0.as_ref()"))
+			} else {
+				Ok(format!("{seed_name}.as_ref()"))
+			}
 		}
 		PdaSeedValueValueNode::Argument(_) => {
 			Err(RenderError::UnsupportedValue {

--- a/crates/pina_codama_renderer/src/render/scaffold.rs
+++ b/crates/pina_codama_renderer/src/render/scaffold.rs
@@ -45,7 +45,7 @@ solana-account-info = {{ workspace = true, default-features = true }}
 solana-cpi = {{ workspace = true, default-features = true }}
 solana-instruction = {{ workspace = true, default-features = true }}
 solana-program-error = {{ workspace = true, default-features = true }}
-solana-pubkey = {{ workspace = true, default-features = true }}
+solana-pubkey = {{ workspace = true, default-features = true, features = ["curve25519"] }}
 thiserror = {{ workspace = true, default-features = true }}
 "#
 	);

--- a/crates/pina_codama_renderer/src/snapshots/pina_codama_renderer__tests__instruction_account_default_from_pda.snap
+++ b/crates/pina_codama_renderer/src/snapshots/pina_codama_renderer__tests__instruction_account_default_from_pda.snap
@@ -17,16 +17,16 @@ pub const INITIALIZE_DISCRIMINATOR: u8 = 7u8;
 /// Accounts.
 #[derive(Clone, Debug)]
 pub struct Initialize {
-	pub authority: solana_pubkey::Pubkey,
+	pub authority: (solana_pubkey::Pubkey, bool),
 	pub state: solana_pubkey::Pubkey,
 }
 
 impl Initialize {
-	pub fn new(authority: solana_pubkey::Pubkey) -> Self {
+	pub fn new(authority: (solana_pubkey::Pubkey, bool)) -> Self {
 		Self {
 			authority,
 			state: solana_pubkey::Pubkey::find_program_address(
-				&["state".as_bytes(), authority.as_ref()],
+				&["state".as_bytes(), authority.0.as_ref()],
 				&crate::DEFAULT_PROGRAM_ID,
 			).0,
 		}
@@ -43,7 +43,7 @@ impl Initialize {
 		remaining_accounts: &[solana_instruction::AccountMeta],
 	) -> solana_instruction::Instruction {
 		let mut accounts = Vec::with_capacity(2 + remaining_accounts.len());
-		accounts.push(solana_instruction::AccountMeta::new_readonly(self.authority, true));
+		accounts.push(solana_instruction::AccountMeta::new_readonly(self.authority.0, self.authority.1));
 		accounts.push(solana_instruction::AccountMeta::new(self.state, false));
 		accounts.extend_from_slice(remaining_accounts);
 		let data = bytemuck::bytes_of(&data).to_vec();

--- a/crates/pina_codama_renderer/src/snapshots/pina_codama_renderer__tests__instruction_account_default_from_pda.snap
+++ b/crates/pina_codama_renderer/src/snapshots/pina_codama_renderer__tests__instruction_account_default_from_pda.snap
@@ -12,25 +12,23 @@ expression: content
 	clippy::too_many_arguments
 )]
 
-pub const INITIALIZE_DISCRIMINATOR: u8 = 0u8;
+pub const INITIALIZE_DISCRIMINATOR: u8 = 7u8;
 
 /// Accounts.
 #[derive(Clone, Debug)]
 pub struct Initialize {
-	pub owner: solana_pubkey::Pubkey,
-	pub todo: solana_pubkey::Pubkey,
-	pub system_program: solana_pubkey::Pubkey,
+	pub authority: solana_pubkey::Pubkey,
+	pub state: solana_pubkey::Pubkey,
 }
 
 impl Initialize {
-	pub fn new(owner: solana_pubkey::Pubkey) -> Self {
+	pub fn new(authority: solana_pubkey::Pubkey) -> Self {
 		Self {
-			owner,
-			todo: solana_pubkey::Pubkey::find_program_address(
-				&["todo".as_bytes(), owner.as_ref()],
-				&crate::TODO_PROGRAM_ID,
+			authority,
+			state: solana_pubkey::Pubkey::find_program_address(
+				&["state".as_bytes(), authority.as_ref()],
+				&crate::DEFAULT_PROGRAM_ID,
 			).0,
-			system_program: solana_pubkey::pubkey!("11111111111111111111111111111111"),
 		}
 	}
 
@@ -44,15 +42,14 @@ impl Initialize {
 		data: InitializeInstructionData,
 		remaining_accounts: &[solana_instruction::AccountMeta],
 	) -> solana_instruction::Instruction {
-		let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
-		accounts.push(solana_instruction::AccountMeta::new_readonly(self.owner, true));
-		accounts.push(solana_instruction::AccountMeta::new(self.todo, false));
-		accounts.push(solana_instruction::AccountMeta::new_readonly(self.system_program, false));
+		let mut accounts = Vec::with_capacity(2 + remaining_accounts.len());
+		accounts.push(solana_instruction::AccountMeta::new_readonly(self.authority, true));
+		accounts.push(solana_instruction::AccountMeta::new(self.state, false));
 		accounts.extend_from_slice(remaining_accounts);
 		let data = bytemuck::bytes_of(&data).to_vec();
 
 		solana_instruction::Instruction {
-			program_id: crate::TODO_PROGRAM_ID,
+			program_id: crate::DEFAULT_PROGRAM_ID,
 			accounts,
 			data,
 		}
@@ -63,16 +60,12 @@ impl Initialize {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, bytemuck::Pod, bytemuck::Zeroable)]
 pub struct InitializeInstructionData {
 	pub discriminator: u8,
-	pub bump: u8,
-	pub digest: [u8; 32],
 }
 
 impl InitializeInstructionData {
-	pub const fn new(bump: u8, digest: [u8; 32]) -> Self {
+	pub const fn new() -> Self {
 		Self {
 			discriminator: INITIALIZE_DISCRIMINATOR,
-			bump,
-			digest,
 		}
 	}
 }

--- a/crates/pina_codama_renderer/src/snapshots/pina_codama_renderer__tests__instruction_account_metas_using_self_fields.snap
+++ b/crates/pina_codama_renderer/src/snapshots/pina_codama_renderer__tests__instruction_account_metas_using_self_fields.snap
@@ -31,10 +31,13 @@ pub struct Initialize {
 }
 
 impl Initialize {
-	pub fn new(authority: solana_pubkey::Pubkey, counter: solana_pubkey::Pubkey) -> Self {
+	pub fn new(authority: solana_pubkey::Pubkey) -> Self {
 		Self {
 			authority,
-			counter,
+			counter: solana_pubkey::Pubkey::find_program_address(
+				&["counter".as_bytes(), authority.as_ref()],
+				&crate::COUNTER_PROGRAM_ID,
+			).0,
 			system_program: solana_pubkey::pubkey!("11111111111111111111111111111111"),
 		}
 	}
@@ -105,10 +108,13 @@ pub struct Increment {
 }
 
 impl Increment {
-	pub fn new(authority: solana_pubkey::Pubkey, counter: solana_pubkey::Pubkey) -> Self {
+	pub fn new(authority: solana_pubkey::Pubkey) -> Self {
 		Self {
 			authority,
-			counter,
+			counter: solana_pubkey::Pubkey::find_program_address(
+				&["counter".as_bytes(), authority.as_ref()],
+				&crate::COUNTER_PROGRAM_ID,
+			).0,
 		}
 	}
 

--- a/crates/pina_codama_renderer/src/snapshots/pina_codama_renderer__tests__writes_scaffold_with_bytemuck_dependency.snap
+++ b/crates/pina_codama_renderer/src/snapshots/pina_codama_renderer__tests__writes_scaffold_with_bytemuck_dependency.snap
@@ -17,5 +17,5 @@ solana-account-info = { workspace = true, default-features = true }
 solana-cpi = { workspace = true, default-features = true }
 solana-instruction = { workspace = true, default-features = true }
 solana-program-error = { workspace = true, default-features = true }
-solana-pubkey = { workspace = true, default-features = true }
+solana-pubkey = { workspace = true, default-features = true, features = ["curve25519"] }
 thiserror = { workspace = true, default-features = true }


### PR DESCRIPTION
## Summary
- Lower PDA-derived instruction accounts into Codama PDA default values when all variable seeds come from explicit account parameters
- Render generated client account builders that derive those PDA accounts deterministically from linked PDA metadata
- Keep cyclic/default/optional seed accounts out of auto-resolution and update IDL/snapshot coverage

Closes #144

## Tests
- cargo test -p pina_cli -p pina_codama_renderer
- dprint check --config dprint.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Instruction accounts can now declare automatic PDA address derivation so generated clients auto-compute and populate those addresses across instructions.
* **Chores**
  * Generated project manifests and client crates now enable the curve25519 feature for the Solana pubkey dependency.
* **Tests**
  * Added rendering test coverage to validate instruction-account default PDA generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->