### PR TITLE
fix(pod_primitives): remove unsound Deref/AsRef<str> from PodString

### DIFF
--- a/.changeset/podstring_utf8_soundness.md
+++ b/.changeset/podstring_utf8_soundness.md
@@ -1,5 +1,5 @@
 ---
-pina_pod_primitives: minor
+pina_pod_primitives: fix
 ---
 
 Remove the unsound `Deref<Target = str>` and `AsRef<str>` impls from `PodString`. Because `PodString` is `bytemuck::Pod`, bytes loaded from untrusted account data may not be valid UTF-8, and the removed impls produced a `&str` via `from_utf8_unchecked` — undefined behavior. Use `try_as_str()` for validated access, or `as_str_unchecked()` (unsafe) for unchecked access.

--- a/.changeset/podstring_utf8_soundness.md
+++ b/.changeset/podstring_utf8_soundness.md
@@ -1,0 +1,5 @@
+---
+pina_pod_primitives: minor
+---
+
+Remove the unsound `Deref<Target = str>` and `AsRef<str>` impls from `PodString`. Because `PodString` is `bytemuck::Pod`, bytes loaded from untrusted account data may not be valid UTF-8, and the removed impls produced a `&str` via `from_utf8_unchecked` — undefined behavior. Use `try_as_str()` for validated access, or `as_str_unchecked()` (unsafe) for unchecked access.

--- a/crates/pina_pod_primitives/src/string.rs
+++ b/crates/pina_pod_primitives/src/string.rs
@@ -103,11 +103,16 @@ impl<const N: usize, const PFX: usize> PodString<N, PFX> {
 		N
 	}
 
-	/// Returns the string as a `&str`.
+	/// Returns the string as a `&str` without validating UTF-8.
+	///
+	/// This is the only way to obtain a `&str` view without validation —
+	/// `PodString` deliberately does not implement `Deref<Target = str>` or
+	/// `AsRef<str>`, because the stored bytes may be arbitrary when the value
+	/// is loaded from untrusted account data via `Pod`.
 	///
 	/// # Safety
-	/// This assumes the stored bytes are valid UTF-8. For untrusted account
-	/// data, use `try_as_str()` instead.
+	/// The stored bytes must be valid UTF-8. For untrusted account data, use
+	/// `try_as_str()` instead.
 	#[inline]
 	pub unsafe fn as_str_unchecked(&self) -> &str {
 		unsafe {
@@ -194,20 +199,6 @@ impl<const N: usize, const PFX: usize> Default for PodString<N, PFX> {
 			len: [0u8; PFX],
 			data: [MaybeUninit::uninit(); N],
 		}
-	}
-}
-
-impl<const N: usize, const PFX: usize> core::ops::Deref for PodString<N, PFX> {
-	type Target = str;
-
-	fn deref(&self) -> &str {
-		unsafe { self.as_str_unchecked() }
-	}
-}
-
-impl<const N: usize, const PFX: usize> AsRef<str> for PodString<N, PFX> {
-	fn as_ref(&self) -> &str {
-		unsafe { self.as_str_unchecked() }
 	}
 }
 

--- a/crates/pina_pod_primitives/src/tests/string.rs
+++ b/crates/pina_pod_primitives/src/tests/string.rs
@@ -56,3 +56,79 @@ fn pod_string_bytemuck_roundtrip() {
 	let restored = unsafe { &*(bytes.as_ptr() as *const PodString<32>) };
 	assert_eq!(restored.try_as_str().unwrap(), "test");
 }
+
+// ---------------------------------------------------------------------------
+// UTF-8 soundness: PodString loaded from untrusted bytes
+// ---------------------------------------------------------------------------
+
+/// A `PodString` loaded from arbitrary account data may contain invalid
+/// UTF-8. `try_as_str()` must reject it rather than producing a `&str`.
+#[test]
+fn pod_string_invalid_utf8_rejected_by_try_as_str() {
+	// Length prefix 2, data bytes [0xff, 0xfe] — invalid UTF-8.
+	let bytes = [2u8, 0xff, 0xfe];
+	let pod = try_from_bytes::<PodString<2>>(&bytes)
+		.unwrap_or_else(|e| panic!("try_from_bytes failed for {bytes:?}: {e}"));
+	assert_eq!(pod.len(), 2);
+	assert!(matches!(
+		pod.try_as_str(),
+		Err(PodCollectionError::InvalidUtf8)
+	));
+}
+
+/// A truncated multi-byte sequence is also invalid UTF-8.
+#[test]
+fn pod_string_incomplete_utf8_rejected_by_try_as_str() {
+	// Length prefix 1, data byte 0xc3 — a lead byte with no continuation.
+	let bytes = [1u8, 0xc3];
+	let pod = try_from_bytes::<PodString<1>>(&bytes)
+		.unwrap_or_else(|e| panic!("try_from_bytes failed for {bytes:?}: {e}"));
+	assert!(matches!(
+		pod.try_as_str(),
+		Err(PodCollectionError::InvalidUtf8)
+	));
+}
+
+/// Safe traits must never panic or produce a `&str` from invalid UTF-8.
+#[test]
+fn pod_string_invalid_utf8_safe_traits_do_not_panic() {
+	let bytes = [2u8, 0xff, 0xfe];
+	let pod = try_from_bytes::<PodString<2>>(&bytes)
+		.unwrap_or_else(|e| panic!("try_from_bytes failed for {bytes:?}: {e}"));
+
+	// Debug and Display fall back to a placeholder.
+	assert_eq!(std::format!("{pod:?}"), "PodString { len: 2 }");
+	assert_eq!(std::format!("{pod}"), "<invalid utf8>");
+
+	// Byte access and byte-based comparison remain total and safe.
+	assert_eq!(pod.as_bytes(), &[0xff, 0xfe]);
+	assert_eq!(<PodString<2> as AsRef<[u8]>>::as_ref(&pod), &[0xff, 0xfe]);
+	assert_eq!(pod, pod);
+	assert_ne!(pod, "valid");
+}
+
+/// Valid multi-byte UTF-8 survives a Pod round-trip.
+#[test]
+fn pod_string_valid_utf8_roundtrip_via_pod() {
+	let mut s = PodString::<32>::default();
+	s.set("héllo wörld");
+	let bytes = bytemuck::bytes_of(&s);
+	let restored = try_from_bytes::<PodString<32>>(bytes)
+		.unwrap_or_else(|e| panic!("try_from_bytes failed: {e}"));
+	assert_eq!(
+		restored
+			.try_as_str()
+			.unwrap_or_else(|e| panic!("invalid UTF-8: {e}")),
+		"héllo wörld"
+	);
+}
+
+/// `as_str_unchecked` remains available as an explicit unsafe escape hatch.
+#[test]
+fn pod_string_as_str_unchecked_valid() {
+	let mut s = PodString::<32>::default();
+	s.set("hello");
+	// SAFETY: "hello" is valid UTF-8.
+	let s = unsafe { s.as_str_unchecked() };
+	assert_eq!(s, "hello");
+}


### PR DESCRIPTION
## Problem

`PodString<N, PFX>` implements `bytemuck::Pod` + `Zeroable`, so any byte pattern can be reinterpreted as a `PodString` via `try_from_bytes` — including bytes loaded directly from untrusted account data.

The `Deref<Target = str>` and `AsRef<str>` impls called `as_str_unchecked()`, which uses `core::str::from_utf8_unchecked` on the stored bytes. When those bytes are not valid UTF-8 (e.g. a corrupted or malicious account), this is **undefined behavior reachable from safe code** — the compiler may assume the `&str` is valid and miscompile downstream code, and the transaction may succeed with garbage string data instead of failing.

## Fix

Remove both impls. This makes the unsound path a **compile error** instead of a runtime hazard:

- `try_as_str()` remains the validated accessor (returns `Err(PodCollectionError::InvalidUtf8)` on invalid data).
- `as_str_unchecked()` remains as an explicit `unsafe` escape hatch for performance-critical paths, with its `# Safety` contract documented.
- `AsRef<[u8]>`, `PartialEq` (byte comparison), `Debug`, and `Display` (fallback placeholder) all remain — they are total and safe on arbitrary bytes.

`PodString` has zero usage outside this crate, so no workspace code is affected. The changeset marks this as a breaking change (`minor` bump, 0.x).

## Tests

Added 5 tests covering the soundness boundary:

- Invalid UTF-8 (`[0xff, 0xfe]`) loaded via `Pod::try_from_bytes` → `try_as_str()` returns `Err(InvalidUtf8)`
- Truncated multi-byte sequence (`0xc3` lead byte) → rejected
- Safe traits (`Debug`, `Display`, `AsRef<[u8]>`, `PartialEq`) never panic on invalid data
- Valid multi-byte UTF-8 survives a Pod round-trip
- `as_str_unchecked` still works on valid data

Full workspace test suite passes; clippy and fmt clean.

---
Created on behalf of Ifiok Jr. (@ifiokjr) — model: claude, thinking level: high

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UTF-8 safety when handling raw `PodString` data.
  * Removed implicit string conversions that could expose invalid UTF-8.
  * Byte-slice access remains available for raw data.

* **Documentation**
  * Clarified safe and unchecked string access options.
  * Use `try_as_str()` for validated UTF-8 or `as_str_unchecked()` only when validity is guaranteed.

* **Tests**
  * Added coverage for invalid, truncated, and valid multi-byte UTF-8 inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->