### PR TITLE
fix(macros): replace latent panic paths with spanned compile errors

### DIFF
--- a/.changeset/macro_panic_paths.md
+++ b/.changeset/macro_panic_paths.md
@@ -1,0 +1,5 @@
+---
+pina_macros: patch
+---
+
+Replace latent panic paths in the proc macros with spanned compile errors and explicit internal-error panics. `#[derive(Accounts)]` now reports a clear error instead of panicking if the input shape is ever accepted by `darling` without named fields, and the remaining `unwrap()` calls on provably-safe values carry explanatory messages. Add trybuild negative tests for `#[derive(Accounts)]` on enums and tuple structs.

--- a/.changeset/macro_panic_paths.md
+++ b/.changeset/macro_panic_paths.md
@@ -1,5 +1,5 @@
 ---
-pina_macros: patch
+pina_macros: fix
 ---
 
 Replace latent panic paths in the proc macros with spanned compile errors and explicit internal-error panics. `#[derive(Accounts)]` now reports a clear error instead of panicking if the input shape is ever accepted by `darling` without named fields, and the remaining `unwrap()` calls on provably-safe values carry explanatory messages. Add trybuild negative tests for `#[derive(Accounts)]` on enums and tuple structs.

--- a/crates/pina_macros/src/args.rs
+++ b/crates/pina_macros/src/args.rs
@@ -55,7 +55,8 @@ pub(crate) struct ErrorArgs {
 }
 
 fn default_crate_path() -> syn::Path {
-	syn::parse_str("::pina").unwrap()
+	syn::parse_str("::pina")
+		.unwrap_or_else(|e| panic!("internal error: failed to parse default crate path: {e}"))
 }
 
 /// Arguments for the `#[discriminator(...)]` attribute macro.

--- a/crates/pina_macros/src/lib.rs
+++ b/crates/pina_macros/src/lib.rs
@@ -6,6 +6,7 @@ use args::EventArgs;
 use darling::FromDeriveInput;
 use darling::FromMeta;
 use darling::ast::NestedMeta;
+use darling::ast::Style;
 use heck::ToShoutySnakeCase;
 use proc_macro::TokenStream;
 use quote::format_ident;
@@ -52,7 +53,17 @@ fn accounts_derive_impl(input: proc_macro2::TokenStream) -> proc_macro2::TokenSt
 	let struct_name = &args.ident;
 	let (impl_generics, ty_generics, where_clause) = args.generics.split_for_impl();
 	let crate_path = &args.crate_path;
-	let fields = args.data.take_struct().unwrap();
+	let fields = match args.data.take_struct() {
+		Some(fields) if fields.style == Style::Struct => fields,
+		Some(_) => {
+			return syn::Error::new_spanned(&args.ident, "Accounts structs must have named fields")
+				.to_compile_error();
+		}
+		None => {
+			return syn::Error::new_spanned(&args.ident, "Accounts derive only supports structs")
+				.to_compile_error();
+		}
+	};
 
 	// Get lifetime parameter
 	let lifetime = match args.generics.lifetimes().next() {
@@ -90,7 +101,10 @@ fn accounts_derive_impl(input: proc_macro2::TokenStream) -> proc_macro2::TokenSt
 	}
 
 	for (index, field) in fields.iter().enumerate() {
-		let ident = field.ident.as_ref().unwrap();
+		let ident = field
+			.ident
+			.as_ref()
+			.unwrap_or_else(|| panic!("internal error: `Accounts` field without an ident"));
 
 		if field.remaining.is_present() {
 			if index + 1 != field_count {
@@ -903,7 +917,10 @@ fn account_impl(
 	// Generate assertions
 	let assertions = if let Fields::Named(named_fields) = &item_struct.fields {
 		let field_assertions = named_fields.named.iter().map(|field| {
-			let field_name = field.ident.as_ref().unwrap();
+			let field_name = field
+				.ident
+				.as_ref()
+				.unwrap_or_else(|| panic!("internal error: named field without an ident"));
 			let field_name_str = field_name.to_string();
 			let field_type = &field.ty;
 			quote! {
@@ -1300,7 +1317,10 @@ fn instruction_impl(
 	// Generate assertions
 	let assertions = if let Fields::Named(named_fields) = &item_struct.fields {
 		let field_assertions = named_fields.named.iter().map(|field| {
-			let field_name = field.ident.as_ref().unwrap();
+			let field_name = field
+				.ident
+				.as_ref()
+				.unwrap_or_else(|| panic!("internal error: named field without an ident"));
 			let field_name_str = field_name.to_string();
 			let field_type = &field.ty;
 			quote! {
@@ -1605,7 +1625,10 @@ fn event_impl(
 	// Generate assertions
 	let assertions = if let Fields::Named(named_fields) = &item_struct.fields {
 		let field_assertions = named_fields.named.iter().map(|field| {
-			let field_name = field.ident.as_ref().unwrap();
+			let field_name = field
+				.ident
+				.as_ref()
+				.unwrap_or_else(|| panic!("internal error: named field without an ident"));
 			let field_name_str = field_name.to_string();
 			let field_type = &field.ty;
 			quote! {

--- a/crates/pina_macros/tests/ui/fail/accounts_enum.rs
+++ b/crates/pina_macros/tests/ui/fail/accounts_enum.rs
@@ -1,0 +1,8 @@
+use pina::*;
+
+#[derive(Accounts)]
+pub enum BadAccounts {
+	Variant,
+}
+
+fn main() {}

--- a/crates/pina_macros/tests/ui/fail/accounts_enum.stderr
+++ b/crates/pina_macros/tests/ui/fail/accounts_enum.stderr
@@ -1,0 +1,7 @@
+error: Unsupported shape `enum`. Expected struct with named fields.
+ --> tests/ui/fail/accounts_enum.rs:3:10
+  |
+3 | #[derive(Accounts)]
+  |          ^^^^^^^^
+  |
+  = note: this error originates in the derive macro `Accounts` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/pina_macros/tests/ui/fail/accounts_tuple_struct.rs
+++ b/crates/pina_macros/tests/ui/fail/accounts_tuple_struct.rs
@@ -1,0 +1,6 @@
+use pina::*;
+
+#[derive(Accounts)]
+pub struct TupleAccounts<'a>(&'a AccountView);
+
+fn main() {}

--- a/crates/pina_macros/tests/ui/fail/accounts_tuple_struct.stderr
+++ b/crates/pina_macros/tests/ui/fail/accounts_tuple_struct.stderr
@@ -1,0 +1,7 @@
+error: Unsupported shape `one unnamed field`. Expected named fields.
+ --> tests/ui/fail/accounts_tuple_struct.rs:3:10
+  |
+3 | #[derive(Accounts)]
+  |          ^^^^^^^^
+  |
+  = note: this error originates in the derive macro `Accounts` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
## Problem

`#[derive(Accounts)]` called `args.data.take_struct().unwrap()` and `field.ident.as_ref().unwrap()` on the parsed input. Today these are unreachable because `darling` rejects enums and tuple structs during `from_derive_input` with "Unsupported shape" errors — but they are **latent panic paths**: if darling's shape validation ever changes, a proc-macro panic surfaces as an ICE with no useful span, which is the worst possible UX for a derive macro.

The same class of issue exists in `args.rs` (`parse_str("::pina").unwrap()`) and in the account/instruction/event derives (`field.ident.as_ref().unwrap()` inside `Fields::Named` guards).

## Fix

- `take_struct().unwrap()` → a `match` that emits **spanned compile errors** for enums ("Accounts derive only supports structs") and non-named structs ("Accounts structs must have named fields")
- The remaining provably-safe `unwrap()` calls → `unwrap_or_else(|| panic!("internal error: ..."))` with explanatory messages, so a future invariant break fails loudly with context instead of a bare unwrap
- `parse_str("::pina").unwrap()` → `unwrap_or_else` with a message

The 8 `segments.last().unwrap()` calls in the derive-attribute merge logic are left as-is: `syn::Path` always has at least one segment, so they are provably safe, and converting them would add noise without changing behavior.

## Tests

Added trybuild negative tests locking in the current (non-panicking) behavior:

- `accounts_enum.rs` — `#[derive(Accounts)]` on an enum → compile error
- `accounts_tuple_struct.rs` — `#[derive(Accounts)]` on a tuple struct → compile error

Full `pina_macros` test suite passes (31 unit + trybuild UI + 10 integration); clippy and fmt clean.

---
Created on behalf of Ifiok Jr. (@ifiokjr) — model: claude, thinking level: high
