### PR TITLE
chore(deps): refresh workspace dependencies to latest compatible versions

### DIFF
--- a/.changeset/dependency_refresh.md
+++ b/.changeset/dependency_refresh.md
@@ -1,0 +1,17 @@
+---
+pina: patch
+pina_cli: patch
+pina_codama_renderer: patch
+pina_macros: patch
+pina_pod_primitives: patch
+pina_profile: patch
+pina_sdk_ids: patch
+---
+
+Refresh workspace dependencies to their latest compatible versions.
+
+- Bump `pinocchio-token` to `0.7` and `pinocchio-token-2022` to `0.4` (drops the `token_program` field from `TransferChecked`/`CloseAccount`; examples now use the `new()` constructors).
+- Bump `codama-nodes` to `0.11` (spec `1.8.0`), `mollusk-svm` to `0.15`, `solana-account` to `4`, `solana-system-interface` to `3`, `insta-cmd` to `0.7`, and `object` to `0.40`.
+- Bump the JS Codama toolchain (`codama` to `1.10`, `@codama/renderers-js` to `2.3`) and regenerate all IDLs and Rust/JS clients.
+- Keep `syn` at `2` by pinning `clap` `4.6.3`, `thiserror` `2.0.18`, `serde` `1.0.228`, `tokio-macros` `2.7.1`, `bytemuck_derive` `1.11.0`, and `enum-ordinalize-derive` `4.4.1` (newer releases of these derive crates require `syn` 3).
+- Resolves `RUSTSEC-2026-0204` (crossbeam-epoch) and drops the unmaintained `proc-macro-error2` and unsound `rand 0.7.3` from the dependency tree.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,70 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "agave-feature-set"
-version = "3.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe79fc4c114c51ea8461d829bb49853a21a76c7c8ef20e9041b071558f628ce"
-dependencies = [
- "ahash",
- "solana-epoch-schedule",
- "solana-hash 3.1.0",
- "solana-pubkey 3.0.0",
- "solana-sha256-hasher",
- "solana-svm-feature-set",
-]
-
-[[package]]
-name = "agave-syscalls"
-version = "3.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98807b80e4367cc38c2b24ea30d6d16466553982aeedb0b0cb2c70bbae8ba5b0"
-dependencies = [
- "bincode",
- "libsecp256k1",
- "num-traits",
- "solana-account",
- "solana-account-info",
- "solana-big-mod-exp",
- "solana-blake3-hasher",
- "solana-bn254",
- "solana-clock",
- "solana-cpi",
- "solana-curve25519",
- "solana-hash 3.1.0",
- "solana-instruction",
- "solana-keccak-hasher",
- "solana-loader-v3-interface",
- "solana-poseidon",
- "solana-program-entrypoint",
- "solana-program-runtime",
- "solana-pubkey 3.0.0",
- "solana-sbpf",
- "solana-sdk-ids",
- "solana-secp256k1-recover",
- "solana-sha256-hasher",
- "solana-stable-layout",
- "solana-stake-interface",
- "solana-svm-callback",
- "solana-svm-feature-set",
- "solana-svm-log-collector",
- "solana-svm-measure",
- "solana-svm-timings",
- "solana-svm-type-overrides",
- "solana-sysvar",
- "solana-sysvar-id",
- "solana-transaction-context",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -105,7 +47,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.3.0",
+ "solana-pubkey",
  "thiserror 2.0.18",
 ]
 
@@ -121,7 +63,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.3.0",
+ "solana-pubkey",
  "thiserror 2.0.18",
 ]
 
@@ -137,7 +79,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.3.0",
+ "solana-pubkey",
  "thiserror 2.0.18",
 ]
 
@@ -153,7 +95,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.3.0",
+ "solana-pubkey",
  "thiserror 2.0.18",
 ]
 
@@ -169,7 +111,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.3.0",
+ "solana-pubkey",
  "thiserror 2.0.18",
 ]
 
@@ -185,7 +127,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.3.0",
+ "solana-pubkey",
  "thiserror 2.0.18",
 ]
 
@@ -201,7 +143,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.3.0",
+ "solana-pubkey",
  "thiserror 2.0.18",
 ]
 
@@ -217,7 +159,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.3.0",
+ "solana-pubkey",
  "thiserror 2.0.18",
 ]
 
@@ -233,7 +175,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.3.0",
+ "solana-pubkey",
  "thiserror 2.0.18",
 ]
 
@@ -623,12 +565,6 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -676,6 +612,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "blake3"
 version = "1.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,6 +653,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blst"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20659f9bbee16cbbd2f7393e40ab6309f5a98f76a2eb57a995ec508b72387fe"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
+]
+
+[[package]]
+name = "blstrs"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a8a8ed6fefbeef4a8c7b460e4110e12c5e22a5b7cf32621aae6ad650c4dcf29"
+dependencies = [
+ "blst",
+ "byte-slice-cast",
+ "ff",
+ "group",
+ "pairing",
+ "rand_core 0.6.4",
+ "serde",
+ "subtle",
 ]
 
 [[package]]
@@ -749,6 +725,12 @@ dependencies = [
  "feature-probe",
  "serde",
 ]
+
+[[package]]
+name = "byte-slice-cast"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "bytemuck"
@@ -856,9 +838,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codama-errors"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dce85c51b425a9e4195b35f5b739103e9ac5c44a0f7bfc34bab7456e90d32c4"
+checksum = "9c4e65ee3ef3464d660567139bc313368c3d13c1f4a84f455f4b20ba90ba0320"
 dependencies = [
  "cargo_toml",
  "proc-macro2",
@@ -869,9 +851,9 @@ dependencies = [
 
 [[package]]
 name = "codama-nodes"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06cb005634ded4ba8771a30b7f8fd66c508e1de27a99e1a18e9b8dcdf87ab646"
+checksum = "4c233b476fe665182fde18ca7afc43b5385622367ac6d98661c0c6748f93a9b0"
 dependencies = [
  "codama-errors",
  "codama-nodes-derive",
@@ -882,9 +864,9 @@ dependencies = [
 
 [[package]]
 name = "codama-nodes-derive"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebb3a0ea01bd4f08e4d6b30f7f8958fa636b957da605d626e9d3598c0572d6c"
+checksum = "86315bc36007da03157be9657e24f3235e5cf53b384f15a4b03c484a2b087487"
 dependencies = [
  "codama-errors",
  "codama-syn-helpers",
@@ -896,9 +878,9 @@ dependencies = [
 
 [[package]]
 name = "codama-syn-helpers"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312c524f114086719fb16a5a2f76ff5f11df0f493479a699ce354d1864e79a58"
+checksum = "0c32b8d72d636d82ffe8cb2e614fbc5c84d897b5969eb27dfac226d944efe361"
 dependencies = [
  "codama-errors",
  "derive_more 1.0.0",
@@ -990,7 +972,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.3.0",
+ "solana-pubkey",
  "thiserror 2.0.18",
 ]
 
@@ -1002,7 +984,7 @@ dependencies = [
  "pina",
  "solana-account",
  "solana-instruction",
- "solana-pubkey 4.3.0",
+ "solana-pubkey",
  "solana-sdk-ids",
  "solana-system-interface",
 ]
@@ -1423,9 +1405,9 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "enum-iterator"
-version = "1.5.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd242f399be1da0a5354aa462d57b4ab2b4ee0683cc552f7c007d2d12d36e94"
+checksum = "a4549325971814bda7a44061bf3fe7e487d447cba01e4220a4b454d630d7a016"
 dependencies = [
  "enum-iterator-derive",
 ]
@@ -1512,7 +1494,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.3.0",
+ "solana-pubkey",
  "thiserror 2.0.18",
 ]
 
@@ -1543,6 +1525,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
+ "bitvec",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -1606,6 +1589,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1618,24 +1607,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -1674,7 +1652,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
+ "rand 0.8.7",
  "rand_core 0.6.4",
+ "rand_xorshift 0.3.0",
  "subtle",
 ]
 
@@ -1732,7 +1712,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.3.0",
+ "solana-pubkey",
  "thiserror 2.0.18",
 ]
 
@@ -1742,6 +1722,12 @@ version = "0.0.0"
 dependencies = [
  "pina",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hmac"
@@ -1783,9 +1769,9 @@ dependencies = [
 
 [[package]]
 name = "insta-cmd"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffeeefa927925cced49ccb01bf3e57c9d4cd132df21e576eb9415baeab2d3de6"
+checksum = "bffdf4af1db390cf0401535d7c1303cd079a074d28d8473b026fdb6559c41403"
 dependencies = [
  "insta",
  "serde",
@@ -1809,18 +1795,18 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -1927,26 +1913,26 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libsecp256k1"
-version = "0.6.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9d220bc1feda2ac231cb78c3d26f27676b8cf82c96971f7aeef3d0cf2797c73"
+checksum = "e79019718125edc905a079a70cfa5f3820bc76139fc91d6f9abc27ea2a887139"
 dependencies = [
  "arrayref",
- "base64 0.12.3",
+ "base64",
  "digest 0.9.0",
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
- "rand 0.7.3",
+ "rand 0.8.7",
  "serde",
  "sha2 0.9.9",
 ]
 
 [[package]]
 name = "libsecp256k1-core"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f6ab710cec28cef759c5f18671a27dae2a5f952cdaaee1d8e2908cb2478a80"
+checksum = "5be9b9bb642d8522a44d533eab56c16c738301965504753b03ad1de3425d5451"
 dependencies = [
  "crunchy",
  "digest 0.9.0",
@@ -1955,18 +1941,18 @@ dependencies = [
 
 [[package]]
 name = "libsecp256k1-gen-ecmult"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccab96b584d38fac86a83f07e659f0deafd0253dc096dab5a36d53efe653c5c3"
+checksum = "3038c808c55c87e8a172643a7d87187fc6c4174468159cb3090659d55bcb4809"
 dependencies = [
  "libsecp256k1-core",
 ]
 
 [[package]]
 name = "libsecp256k1-gen-genmult"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67abfe149395e3aa1c48a2beb32b068e2334402df8181f818d3aee2b304c4f5d"
+checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
 dependencies = [
  "libsecp256k1-core",
 ]
@@ -2055,18 +2041,16 @@ checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys",
 ]
 
 [[package]]
 name = "mollusk-svm"
-version = "0.11.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a3cac3aca9ffb1e97c0b60ac4fca70f1ef2cbe532010e62cfdcdf2a2a2a2ef"
+checksum = "7926024cefb20fe555c34ccf66ab3e9e8fd407e8399149ce386b86999c967253"
 dependencies = [
- "agave-feature-set",
- "agave-syscalls",
  "bincode",
  "mollusk-svm-error",
  "mollusk-svm-result",
@@ -2076,26 +2060,26 @@ dependencies = [
  "solana-compute-budget",
  "solana-epoch-rewards",
  "solana-epoch-schedule",
- "solana-hash 3.1.0",
+ "solana-hash",
  "solana-instruction",
  "solana-instruction-error",
- "solana-instructions-sysvar",
+ "solana-instructions-sysvar 3.0.1",
  "solana-loader-v3-interface",
- "solana-loader-v4-interface",
  "solana-logger",
  "solana-message",
  "solana-precompile-error",
  "solana-program-error",
  "solana-program-runtime",
- "solana-pubkey 4.3.0",
+ "solana-pubkey",
  "solana-rent",
  "solana-sdk-ids",
  "solana-slot-hashes",
- "solana-stake-interface",
+ "solana-stake-history",
  "solana-svm-callback",
+ "solana-svm-feature-set",
  "solana-svm-log-collector",
  "solana-svm-timings",
- "solana-svm-transaction",
+ "solana-syscalls",
  "solana-system-program",
  "solana-sysvar",
  "solana-sysvar-id",
@@ -2105,24 +2089,24 @@ dependencies = [
 
 [[package]]
 name = "mollusk-svm-error"
-version = "0.11.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e315980684803972f443b2d8dd765e3def7e4e20bb67d5125bb80639e858a040"
+checksum = "2566d4c2c6c4aa51b95d70d71fdd2a2d8519d2bb790356d11f2d13608c2f2a0e"
 dependencies = [
- "solana-pubkey 4.3.0",
- "thiserror 1.0.69",
+ "solana-pubkey",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "mollusk-svm-result"
-version = "0.11.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d5087302293e891db8627166c41a8cded1d74d1ba6c5b7b3a823bf4d7503e37"
+checksum = "d466fd9a244ca531289a707ae68e9720b1fbbb87989ee4e859f3e848c3561806"
 dependencies = [
  "solana-account",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.3.0",
+ "solana-pubkey",
  "solana-rent",
  "solana-transaction-error",
 ]
@@ -2224,10 +2208,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.39.1"
+name = "num_cpus"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd229a0361b9d0d4396176e02d65897f487eebeab7caa6d443855ee152ca0b9c"
 dependencies = [
  "crc32fast",
  "flate2",
@@ -2260,6 +2254,15 @@ name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+
+[[package]]
+name = "pairing"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
+dependencies = [
+ "group",
+]
 
 [[package]]
 name = "parking_lot"
@@ -2326,7 +2329,7 @@ dependencies = [
  "pinocchio-token",
  "pinocchio-token-2022",
  "proptest",
- "solana-address 2.7.0",
+ "solana-address",
  "solana-program-log",
  "typed-builder",
 ]
@@ -2343,7 +2346,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.3.0",
+ "solana-pubkey",
  "thiserror 2.0.18",
 ]
 
@@ -2430,7 +2433,7 @@ name = "pina_sdk_ids"
 version = "0.8.0"
 dependencies = [
  "proptest",
- "solana-address 2.7.0",
+ "solana-address",
 ]
 
 [[package]]
@@ -2440,7 +2443,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cababcb62a2e739c7078ae16eda02789a6e3edd21bbdded864e85c38a7914d"
 dependencies = [
  "solana-account-view",
- "solana-address 2.7.0",
+ "solana-address",
  "solana-define-syscall 5.2.0",
  "solana-instruction-view",
  "solana-program-error",
@@ -2453,7 +2456,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c552da2a965b33511ac54494e434e69be0ae12da1619a72594b76703c3dca211"
 dependencies = [
  "solana-account-view",
- "solana-address 2.7.0",
+ "solana-address",
  "solana-instruction-view",
  "solana-program-error",
 ]
@@ -2465,7 +2468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87cd9e3e3c3c315d5c7d974929b74cd074ac280e3ab09111e736e9de47f3ce38"
 dependencies = [
  "solana-account-view",
- "solana-address 2.7.0",
+ "solana-address",
  "solana-instruction-view",
  "solana-program-error",
 ]
@@ -2477,7 +2480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3ae2ee67b42e2ac797dd88312da473c895660e270d8093e0ba2749b885b5778"
 dependencies = [
  "pinocchio",
- "solana-address 2.7.0",
+ "solana-address",
 ]
 
 [[package]]
@@ -2487,7 +2490,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217e3259f93a1520e4692b18653dad4d29af54ffc8b3a09819808be85dada074"
 dependencies = [
  "solana-account-view",
- "solana-address 2.7.0",
+ "solana-address",
  "solana-instruction-view",
  "solana-program-error",
 ]
@@ -2500,7 +2503,7 @@ checksum = "3a3c164973916f044bebff3c8cb4467088bafb13cbdb818522b9ca8782940d06"
 dependencies = [
  "pinocchio-token",
  "solana-account-view",
- "solana-address 2.7.0",
+ "solana-address",
  "solana-instruction-view",
  "solana-nullable",
  "solana-program-error",
@@ -2581,7 +2584,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.3.0",
+ "solana-pubkey",
  "thiserror 2.0.18",
 ]
 
@@ -2593,7 +2596,7 @@ dependencies = [
  "pina",
  "solana-account",
  "solana-instruction",
- "solana-pubkey 4.3.0",
+ "solana-pubkey",
  "solana-sdk-ids",
 ]
 
@@ -2609,7 +2612,7 @@ dependencies = [
  "num-traits",
  "rand 0.9.5",
  "rand_chacha 0.9.0",
- "rand_xorshift",
+ "rand_xorshift 0.4.0",
  "regex-syntax",
  "rusty-fork",
  "tempfile",
@@ -2655,17 +2658,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "rand"
-version = "0.7.3"
+name = "radium"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -2690,16 +2686,6 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
@@ -2716,15 +2702,6 @@ checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -2746,12 +2723,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_hc"
-version = "0.2.0"
+name = "rand_xorshift"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core 0.5.1",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2843,7 +2820,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.3.0",
+ "solana-pubkey",
  "thiserror 2.0.18",
 ]
 
@@ -2855,7 +2832,7 @@ dependencies = [
  "pina",
  "solana-account",
  "solana-instruction",
- "solana-pubkey 4.3.0",
+ "solana-pubkey",
  "solana-sdk-ids",
 ]
 
@@ -2901,9 +2878,9 @@ dependencies = [
 
 [[package]]
 name = "ruzstd"
-version = "0.8.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
+checksum = "a252f5e20f038fe7b4ea53e073e65398d652c864cc162fc77c56c2f13717b888"
 dependencies = [
  "twox-hash",
 ]
@@ -3208,9 +3185,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account"
-version = "3.4.0"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efc0ed36decb689413b9da5d57f2be49eea5bebb3cf7897015167b0c4336e731"
+checksum = "26788ba0d7eb5b250edda3e1d393739bafd5daf94882f2261d14f5ab0d6a25e0"
 dependencies = [
  "bincode",
  "qualifier_attr",
@@ -3220,7 +3197,7 @@ dependencies = [
  "solana-account-info",
  "solana-clock",
  "solana-instruction-error",
- "solana-pubkey 4.3.0",
+ "solana-pubkey",
  "solana-sdk-ids",
  "solana-sysvar",
 ]
@@ -3231,7 +3208,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9cf16495d9eb53e3d04e72366a33bb1c20c24e78c171d8b8f5978357b63ae95"
 dependencies = [
- "solana-address 2.7.0",
+ "solana-address",
  "solana-program-error",
  "solana-program-memory",
 ]
@@ -3242,24 +3219,15 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc141b940560430425ebaadb7645496c45f6a10fad9911d719bd03eab7f4d422"
 dependencies = [
- "solana-address 2.7.0",
+ "solana-address",
  "solana-program-error",
 ]
 
 [[package]]
 name = "solana-address"
-version = "1.1.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ecac8e1b7f74c2baa9e774c42817e3e75b20787134b76cc4d45e8a604488f5"
-dependencies = [
- "solana-address 2.7.0",
-]
-
-[[package]]
-name = "solana-address"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01332a01c0a3098404d55a724c8d9a92aed4a50fe40a7dd0c7a51e29274c14de"
+checksum = "39c93e262f671bf402e1040e4a7e40b05d81da5956c7681948c975a0997517bb"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -3289,17 +3257,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-big-mod-exp"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30c80fb6d791b3925d5ec4bf23a7c169ef5090c013059ec3ed7d0b2c04efa085"
-dependencies = [
- "num-bigint 0.4.8",
- "num-traits",
- "solana-define-syscall 3.0.0",
-]
-
-[[package]]
 name = "solana-bincode"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3318,7 +3275,20 @@ checksum = "7116e1d942a2432ca3f514625104757ab8a56233787e95144c93950029e31176"
 dependencies = [
  "blake3",
  "solana-define-syscall 4.0.1",
- "solana-hash 4.6.0",
+ "solana-hash",
+]
+
+[[package]]
+name = "solana-bls12-381-syscall"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e8256fda0542709fd1320a96d81c3c66e10ac5f680cca9b991d7d3b0e3fe86"
+dependencies = [
+ "blst",
+ "blstrs",
+ "bytemuck",
+ "bytemuck_derive",
+ "pairing",
 ]
 
 [[package]]
@@ -3338,11 +3308,10 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "3.1.14"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb423db3faa08533a122f867456bb5b7aab211818af004552ea6df5f3c43ef49"
+checksum = "fba6be8c60af6076de7e40e54a0ad9d88ad5f7004ecf9be5e93d296dd9b0cbe3"
 dependencies = [
- "agave-syscalls",
  "bincode",
  "qualifier_attr",
  "solana-account",
@@ -3350,26 +3319,25 @@ dependencies = [
  "solana-clock",
  "solana-instruction",
  "solana-loader-v3-interface",
- "solana-loader-v4-interface",
  "solana-packet",
- "solana-program-entrypoint",
  "solana-program-runtime",
- "solana-pubkey 3.0.0",
+ "solana-pubkey",
  "solana-sbpf",
  "solana-sdk-ids",
  "solana-svm-feature-set",
  "solana-svm-log-collector",
  "solana-svm-measure",
  "solana-svm-type-overrides",
+ "solana-syscalls",
  "solana-system-interface",
  "solana-transaction-context",
 ]
 
 [[package]]
 name = "solana-clock"
-version = "3.2.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7708bdb262fd9c257c3a56d4289297b10a3e821b8cba3f7cf42b49c40201ab9"
+checksum = "f0acdace90d96e2c9e70d681465b4fe888b6bcf27c354ae9774e9f8a3b72923d"
 dependencies = [
  "serde",
  "serde_derive",
@@ -3381,9 +3349,9 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget"
-version = "3.1.14"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de86231371bf26dbcf473a0ea7ca424184db0c7720fafbb899d2fca2eaf1ac2"
+checksum = "508ef8407ce095d146830943bab8dccbbc6d581615e1de8d449565d16eae3aff"
 dependencies = [
  "solana-fee-structure",
  "solana-program-runtime",
@@ -3399,29 +3367,23 @@ dependencies = [
  "solana-define-syscall 4.0.1",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.3.0",
+ "solana-pubkey",
  "solana-stable-layout",
 ]
 
 [[package]]
 name = "solana-curve25519"
-version = "3.1.14"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aff7432cdf2ec6a44ac06b4d64d2ee006f6c0066d6456e032a7fe25be40cd5c"
+checksum = "14b4d2a4bf0d0b0a86c22111917e86e8bd39a7b31420fb2c7d73eb83761fc7af"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
  "curve25519-dalek",
- "solana-define-syscall 3.0.0",
+ "solana-define-syscall 5.2.0",
  "subtle",
  "thiserror 2.0.18",
 ]
-
-[[package]]
-name = "solana-define-syscall"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9697086a4e102d28a156b8d6b521730335d6951bd39a5e766512bbe09007cee"
 
 [[package]]
 name = "solana-define-syscall"
@@ -3437,14 +3399,14 @@ checksum = "bf8209ece2bd9f1450e672858ffc0e5c8c786ff6916d2a862b126dd0128f380f"
 
 [[package]]
 name = "solana-epoch-rewards"
-version = "3.2.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0788d74ee15778deecaa15ed1a1e37727ba954f86cbc35225450a1f2b5012969"
+checksum = "daf7eb4986b0b1d6f562b21f75a836f1a6df6e00c275efcef50aab5c144dc59e"
 dependencies = [
  "serde",
  "serde_derive",
  "solana-get-sysvar",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
@@ -3452,9 +3414,9 @@ dependencies = [
 
 [[package]]
 name = "solana-epoch-schedule"
-version = "3.3.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1633cfd10cde127f2caf8f12021b4f8e9a425e7e4eea4326e428c422376d6fd"
+checksum = "8116e6ffa6002237d5ab5edcbda17f9ba66b6742c45a89c9fb40a94dbacd4c1d"
 dependencies = [
  "serde",
  "serde_derive",
@@ -3467,13 +3429,14 @@ dependencies = [
 
 [[package]]
 name = "solana-fee-calculator"
-version = "3.3.0"
+version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4bf4f4afb4704212ef1d994ee65bef7293441721639dfd16f0e60996f37be51"
+checksum = "ef67f01cc6a0c72e99a08d0d484683f995de4c80e9568728fa77d1537f9b7e09"
 dependencies = [
  "log",
  "serde",
  "serde_derive",
+ "wincode",
 ]
 
 [[package]]
@@ -3488,54 +3451,52 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef3bc859fc036ed490146793557386cbfae614ebba4adc704c37d94350824ed4"
 dependencies = [
- "solana-address 2.7.0",
+ "solana-address",
  "solana-define-syscall 5.2.0",
  "solana-program-error",
 ]
 
 [[package]]
 name = "solana-hash"
-version = "3.1.0"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "337c246447142f660f778cf6cb582beba8e28deb05b3b24bfb9ffd7c562e5f41"
-dependencies = [
- "solana-hash 4.6.0",
-]
-
-[[package]]
-name = "solana-hash"
-version = "4.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df9b01495ed31100aca97a7f5862d5e19ab1636d60d1a9f02391408dd9dec84"
+checksum = "6f4c847893a2ea50b4ae3ca723b124e07cd0544fecea3598f785168f9b78333f"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
  "five8",
  "serde",
  "serde_derive",
- "solana-atomic-u64",
  "solana-sanitize",
+ "wincode",
 ]
 
 [[package]]
-name = "solana-instruction"
-version = "3.5.0"
+name = "solana-hash-512"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d70cf6ece1070a66d25e68274f338f29664794669c175223940a298645ef3495"
+checksum = "7ce934b02bab639341f2fd62c3e7e3c39dcceb47f0196b7630ed1f82ecb704bd"
+
+[[package]]
+name = "solana-instruction"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3957ca1d31107efd9a6bb88b25c348ca5e3b4b6683e3d08adb86d3d17aa01f1"
 dependencies = [
  "bincode",
  "serde",
  "serde_derive",
  "solana-define-syscall 5.2.0",
  "solana-instruction-error",
- "solana-pubkey 4.3.0",
+ "solana-pubkey",
+ "wincode",
 ]
 
 [[package]]
 name = "solana-instruction-error"
-version = "2.5.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e7db78c122d02189619490b1fef04a2a042c389662920617c0e6381fdf8fdd"
+checksum = "3b7d34343838343a3755b7dfb1e438d94c6db2263b519cfe3c2257af932b6e93"
 dependencies = [
  "num-traits",
  "serde",
@@ -3550,7 +3511,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ab7a27d0c4214b9f7389c3dd00b68c93093a67f1dcc5b7893aebe299bbcbb47"
 dependencies = [
  "solana-account-view",
- "solana-address 2.7.0",
+ "solana-address",
  "solana-define-syscall 5.2.0",
  "solana-program-error",
 ]
@@ -3573,6 +3534,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-instructions-sysvar"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e38363a181313d607f7a118df2b401bb27b477a0104b09283cbf504f5f0f00cc"
+dependencies = [
+ "bitflags 2.13.1",
+ "solana-account-info",
+ "solana-instruction",
+ "solana-instruction-error",
+ "solana-program-error",
+ "solana-sanitize",
+ "solana-sdk-ids",
+ "solana-serialize-utils",
+ "solana-sysvar-id",
+]
+
+[[package]]
 name = "solana-keccak-hasher"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3580,14 +3558,14 @@ checksum = "ed1c0d16d6fdeba12291a1f068cdf0d479d9bff1141bf44afd7aa9d485f65ef8"
 dependencies = [
  "sha3",
  "solana-define-syscall 4.0.1",
- "solana-hash 4.6.0",
+ "solana-hash",
 ]
 
 [[package]]
 name = "solana-last-restart-slot"
-version = "3.2.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5099e736c3c06c451b307a60637d69eb65b3144143ebeed899e2fd1134f4fc35"
+checksum = "c22474b83d3c7c318e1c3a725784fc2d1d03b728e36369e58ce48769a61ed85e"
 dependencies = [
  "serde",
  "serde_derive",
@@ -3599,31 +3577,16 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v3-interface"
-version = "6.1.1"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0538d4dbc9022e01616f1c58f2db98ece739c5d5ed4a2ef8737a953e76a2d4"
+checksum = "68029ab11d9c891d4ce23ada75745e40f983c5674af366f447b672569634231b"
 dependencies = [
  "serde",
  "serde_bytes",
  "serde_derive",
  "solana-instruction",
- "solana-pubkey 4.3.0",
+ "solana-pubkey",
  "solana-sdk-ids",
-]
-
-[[package]]
-name = "solana-loader-v4-interface"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c948b33ff81fa89699911b207059e493defdba9647eaf18f23abdf3674e0fb"
-dependencies = [
- "serde",
- "serde_bytes",
- "serde_derive",
- "solana-instruction",
- "solana-pubkey 3.0.0",
- "solana-sdk-ids",
- "solana-system-interface",
 ]
 
 [[package]]
@@ -3641,13 +3604,12 @@ dependencies = [
 
 [[package]]
 name = "solana-message"
-version = "3.1.0"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0448b1fd891c5f46491e5dc7d9986385ba3c852c340db2911dd29faa01d2b08d"
+checksum = "7e29e655f222a3a64145fedceacdca3e696ba7aded1dbd5391aa09d5fbfba53c"
 dependencies = [
- "lazy_static",
- "solana-address 2.7.0",
- "solana-hash 4.6.0",
+ "solana-address",
+ "solana-hash",
  "solana-instruction",
  "solana-sanitize",
  "solana-sdk-ids",
@@ -3665,28 +3627,30 @@ dependencies = [
 
 [[package]]
 name = "solana-nonce"
-version = "3.3.0"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f13b7ec92de6dd4ef713ed763d22585efa0042cd244bce81997e52077885c47"
+checksum = "c4172d5b33a0a38fcdb2af8f84406570dd51567267da96c28ad0f31fc11621c0"
 dependencies = [
  "serde",
  "serde_derive",
  "solana-fee-calculator",
- "solana-hash 4.6.0",
- "solana-pubkey 4.3.0",
+ "solana-hash",
+ "solana-pubkey",
  "solana-sha256-hasher",
+ "wincode",
 ]
 
 [[package]]
 name = "solana-nonce-account"
-version = "3.0.0"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "805fd25b29e5a1a0e6c3dd6320c9da80f275fbe4ff6e392617c303a2085c435e"
+checksum = "b81bf7e2aa8c443724051507c1007d0b6d9c34b70925d3232dc78f5ca485209e"
 dependencies = [
  "solana-account",
- "solana-hash 3.1.0",
+ "solana-hash",
  "solana-nonce",
  "solana-sdk-ids",
+ "wincode",
 ]
 
 [[package]]
@@ -3697,24 +3661,25 @@ checksum = "889194d8c5faec648f2f6fadddb60566249921ebb074e2707e7095458d5864e2"
 
 [[package]]
 name = "solana-packet"
-version = "3.0.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6edf2f25743c95229ac0fdc32f8f5893ef738dbf332c669e9861d33ddb0f469d"
+checksum = "43a2a582d7863548f047f49aa3745c076cfa9e1364baa080ef0c1210f0e4ebda"
 dependencies = [
  "bitflags 2.13.1",
+ "solana-pubkey",
 ]
 
 [[package]]
 name = "solana-poseidon"
-version = "3.1.14"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ac13134287d7af80717353a8136e3c515d7f34d88e6f116b47350bd623e338"
+checksum = "737b8ab25bf4cc8e618f80f1fe40709b2ace708bc764a36b8a4c81eea8c07034"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-bn254 0.5.0",
  "light-poseidon 0.2.0",
  "light-poseidon 0.4.0",
- "solana-define-syscall 3.0.0",
+ "solana-define-syscall 4.0.1",
  "thiserror 2.0.18",
 ]
 
@@ -3736,7 +3701,7 @@ dependencies = [
  "solana-account-info",
  "solana-define-syscall 4.0.1",
  "solana-program-error",
- "solana-pubkey 4.3.0",
+ "solana-pubkey",
 ]
 
 [[package]]
@@ -3777,16 +3742,17 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "3.1.14"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c03c5100c43bf28fd03a11b66345ccdc28c1b7e5a7d49dbcff64e6442595627"
+checksum = "99a3895314c34396758131a8af156944453ebe18e70d2a5cde67eec899df48a1"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bincode",
- "itertools 0.12.1",
+ "cfg-if",
+ "itertools 0.14.0",
  "log",
  "percentage",
- "rand 0.8.7",
+ "rand 0.9.5",
  "serde",
  "solana-account",
  "solana-account-info",
@@ -3794,12 +3760,12 @@ dependencies = [
  "solana-epoch-rewards",
  "solana-epoch-schedule",
  "solana-fee-structure",
- "solana-hash 3.1.0",
+ "solana-hash",
  "solana-instruction",
  "solana-last-restart-slot",
  "solana-loader-v3-interface",
  "solana-program-entrypoint",
- "solana-pubkey 3.0.0",
+ "solana-pubkey",
  "solana-rent",
  "solana-sbpf",
  "solana-sdk-ids",
@@ -3818,34 +3784,27 @@ dependencies = [
  "solana-sysvar-id",
  "solana-transaction-context",
  "thiserror 2.0.18",
+ "wincode",
 ]
 
 [[package]]
 name = "solana-pubkey"
-version = "3.0.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8909d399deb0851aa524420beeb5646b115fd253ef446e35fe4504c904da3941"
+checksum = "6ab5a422939ca3b81180f79c87f43600728e4c5513d6034902675f96df25d033"
 dependencies = [
- "solana-address 1.1.0",
-]
-
-[[package]]
-name = "solana-pubkey"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f71b7a414de2ced1071f015834e9be581592d013432adbd06d02e4af11eba9"
-dependencies = [
- "solana-address 2.7.0",
+ "solana-address",
 ]
 
 [[package]]
 name = "solana-rent"
-version = "3.1.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e860d5499a705369778647e97d760f7670adfb6fc8419dd3d568deccd46d5487"
+checksum = "39f0d780bf8e8a1fe8b5b5fce1acad6b209485b86dec246e7523d5e4a8b7c7fc"
 dependencies = [
  "serde",
  "serde_derive",
+ "solana-get-sysvar",
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
@@ -3859,9 +3818,9 @@ checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
 
 [[package]]
 name = "solana-sbpf"
-version = "0.13.1"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15b079e08471a9dbfe1e48b2c7439c85aa2a055cbd54eddd8bd257b0a7dbb29"
+checksum = "d777d7a89267dd133e985113c7e7f820fb7cfd9123a4a350cf8b39ebae1920bc"
 dependencies = [
  "byteorder",
  "combine",
@@ -3880,7 +3839,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "def234c1956ff616d46c9dd953f251fa7096ddbaa6d52b165218de97882b7280"
 dependencies = [
- "solana-address 2.7.0",
+ "solana-address",
 ]
 
 [[package]]
@@ -3913,7 +3872,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "761357b0853c9623bf12c1d2314b3d6160a85b087b84c45224fb85766d22616b"
 dependencies = [
  "solana-instruction-error",
- "solana-pubkey 4.3.0",
+ "solana-pubkey",
  "solana-sanitize",
 ]
 
@@ -3925,7 +3884,18 @@ checksum = "db7dc3011ea4c0334aaaa7e7128cb390ecf546b28d412e9bf2064680f57f588f"
 dependencies = [
  "sha2 0.10.9",
  "solana-define-syscall 4.0.1",
- "solana-hash 4.6.0",
+ "solana-hash",
+]
+
+[[package]]
+name = "solana-sha512-hasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11e10e103ab5bd52af341e7bc2f4123a2f4e66bb7ba4e6ca40f1e00cd6314e02"
+dependencies = [
+ "sha2 0.10.9",
+ "solana-define-syscall 5.2.0",
+ "solana-hash-512",
 ]
 
 [[package]]
@@ -3940,16 +3910,17 @@ dependencies = [
 
 [[package]]
 name = "solana-slot-hashes"
-version = "3.2.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "007d6bc909599eea325c9d09f7ff16ef6166c134876ff47a6a122d693d058dad"
+checksum = "5c7ce2b4b8911bf2db3de7b6266e67bfc21a6a9f8c566fb096d9782ca2ad16ee"
 dependencies = [
  "serde",
  "serde_derive",
  "solana-get-sysvar",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-sdk-ids",
  "solana-sysvar-id",
+ "wincode",
 ]
 
 [[package]]
@@ -3973,14 +3944,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9f6a291ba063a37780af29e7db14bdd3dc447584d8ba5b3fc4b88e2bbc982fa"
 dependencies = [
  "solana-instruction",
- "solana-pubkey 4.3.0",
+ "solana-pubkey",
+]
+
+[[package]]
+name = "solana-stake-history"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c736a6aa0e53b9d264d90b06589fc0996f49f882f3e71842ed754fc57ffc1a43"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-clock",
+ "solana-get-sysvar",
+ "solana-sdk-ids",
+ "solana-sysvar-id",
 ]
 
 [[package]]
 name = "solana-stake-interface"
-version = "2.0.2"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9bc26191b533f9a6e5a14cca05174119819ced680a80febff2f5051a713f0db"
+checksum = "252b4291eb25a5a356149ed4d4a940d5f655186210fa84b5d0d8d55c3dd42a81"
 dependencies = [
  "num-traits",
  "serde",
@@ -3989,7 +3974,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 3.0.0",
+ "solana-pubkey",
  "solana-system-interface",
  "solana-sysvar",
  "solana-sysvar-id",
@@ -3997,57 +3982,57 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-callback"
-version = "3.1.14"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "012617d16d2994673d98792f7f6d93f612dea00b1b747a3c4aec24c12547875b"
+checksum = "3603ca4c273926155ace95887b30cd1e3918835737687bffa8a5d8749dcf0e91"
 dependencies = [
  "solana-account",
  "solana-clock",
  "solana-precompile-error",
- "solana-pubkey 3.0.0",
+ "solana-pubkey",
 ]
 
 [[package]]
 name = "solana-svm-feature-set"
-version = "3.1.14"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc2e2fdebd77159b7a14ee45c9dbb3f1d202e8e7ccc14e4cda78c006a7a78a9"
+checksum = "bda42b13c4748e47af89010e16a4391e1901be860beb93eedc0ccab66795fe50"
 
 [[package]]
 name = "solana-svm-log-collector"
-version = "3.1.14"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce188c2c438ced63a975af79f06db2ff5accaf1a4027a26e35783be566f6070"
+checksum = "eec82e47b4ee1628f6f453f8ce8de5473458470fe60965e4d3be31fa82afdbea"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "solana-svm-measure"
-version = "3.1.14"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea64909ba06fa651c95c4db35614430b1a0bc722e51996e97b5b779e3528bad"
+checksum = "6b309b60870dc1821d363807cdd40097d52db1529aae04344f361995bb88b084"
 
 [[package]]
 name = "solana-svm-timings"
-version = "3.1.14"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a05b09e2caac9b4d7c35c5997d754433e15ee5f506509117eb77032e1718ac"
+checksum = "44b30b0c61db8d711327c49ab2171984d564a93835ed77acb6aa2da0ecf434ba"
 dependencies = [
  "eager",
  "enum-iterator",
- "solana-pubkey 3.0.0",
+ "solana-pubkey",
 ]
 
 [[package]]
 name = "solana-svm-transaction"
-version = "3.1.14"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be3250a278a769ba59059e13d0f16c2aba0ca1de7595fb0e02556091751560c8"
+checksum = "736d2cec944c6f8f298a7bd8ada5eb318cca9ab859281b1300842fa0e9a25afa"
 dependencies = [
- "solana-hash 3.1.0",
+ "solana-hash",
  "solana-message",
- "solana-pubkey 3.0.0",
+ "solana-pubkey",
  "solana-sdk-ids",
  "solana-signature",
  "solana-transaction",
@@ -4055,37 +4040,79 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-type-overrides"
-version = "3.1.14"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b78cd0bfb102d4197ce8c590f800a119ba0d358369ca57b0f66e94d1317fd0e"
+checksum = "9b6cc834d4a01719767e68b9d30c33c4162b2d818afc084cf310715ea087e64f"
 dependencies = [
- "rand 0.8.7",
+ "rand 0.9.5",
+]
+
+[[package]]
+name = "solana-syscalls"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6976ef46df8e2fd9ce7cc6396a6cf29bcc37c882def849e7d6bc48bd621c88f8"
+dependencies = [
+ "bincode",
+ "libsecp256k1",
+ "num-traits",
+ "solana-account",
+ "solana-account-info",
+ "solana-blake3-hasher",
+ "solana-bls12-381-syscall",
+ "solana-bn254",
+ "solana-clock",
+ "solana-cpi",
+ "solana-curve25519",
+ "solana-hash",
+ "solana-hash-512",
+ "solana-instruction",
+ "solana-keccak-hasher",
+ "solana-poseidon",
+ "solana-program-entrypoint",
+ "solana-program-runtime",
+ "solana-pubkey",
+ "solana-sbpf",
+ "solana-sdk-ids",
+ "solana-secp256k1-recover",
+ "solana-sha256-hasher",
+ "solana-sha512-hasher",
+ "solana-stable-layout",
+ "solana-stake-interface",
+ "solana-svm-feature-set",
+ "solana-svm-log-collector",
+ "solana-svm-type-overrides",
+ "solana-sysvar",
+ "solana-sysvar-id",
+ "solana-transaction-context",
+ "thiserror 2.0.18",
+ "wincode",
 ]
 
 [[package]]
 name = "solana-system-interface"
-version = "2.0.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e1790547bfc3061f1ee68ea9d8dc6c973c02a163697b24263a8e9f2e6d4afa2"
+checksum = "55b54965bf0b76fa8e2b35376583efddd4d916618cfe595bf48c7d7b55a9e628"
 dependencies = [
  "num-traits",
  "serde",
  "serde_derive",
+ "solana-address",
  "solana-instruction",
  "solana-msg",
  "solana-program-error",
- "solana-pubkey 3.0.0",
+ "wincode",
 ]
 
 [[package]]
 name = "solana-system-program"
-version = "3.1.14"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b4b6faeddf5a62c06991a9a077fd1097da6867060f884595a659b3b24dc3a4a"
+checksum = "ba583e7a473426fab4c0b17fde848a6bb798b1ede5a14c4f13a3494a2e748fc6"
 dependencies = [
  "bincode",
  "log",
- "serde",
  "solana-account",
  "solana-bincode",
  "solana-fee-calculator",
@@ -4094,10 +4121,9 @@ dependencies = [
  "solana-nonce-account",
  "solana-packet",
  "solana-program-runtime",
- "solana-pubkey 3.0.0",
+ "solana-pubkey",
  "solana-sdk-ids",
  "solana-svm-log-collector",
- "solana-svm-type-overrides",
  "solana-system-interface",
  "solana-sysvar",
  "solana-transaction-context",
@@ -4105,33 +4131,35 @@ dependencies = [
 
 [[package]]
 name = "solana-sysvar"
-version = "3.1.1"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6690d3dd88f15c21edff68eb391ef8800df7a1f5cec84ee3e8d1abf05affdf74"
+checksum = "ada7045bbfdd802af08fbc9c7e2b56ddabb20599d22e4c3840fcef5e7afb8324"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bincode",
  "lazy_static",
  "serde",
  "serde_derive",
  "solana-account-info",
  "solana-clock",
- "solana-define-syscall 4.0.1",
+ "solana-define-syscall 5.2.0",
  "solana-epoch-rewards",
  "solana-epoch-schedule",
  "solana-fee-calculator",
- "solana-hash 4.6.0",
+ "solana-get-sysvar",
+ "solana-hash",
  "solana-instruction",
  "solana-last-restart-slot",
  "solana-program-entrypoint",
  "solana-program-error",
  "solana-program-memory",
- "solana-pubkey 4.3.0",
+ "solana-pubkey",
  "solana-rent",
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-slot-hashes",
  "solana-slot-history",
+ "solana-stake-history",
  "solana-sysvar-id",
 ]
 
@@ -4141,18 +4169,18 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17358d1e9a13e5b9c2264d301102126cf11a47fd394cdf3dec174fe7bc96e1de"
 dependencies = [
- "solana-address 2.7.0",
+ "solana-address",
  "solana-sdk-ids",
 ]
 
 [[package]]
 name = "solana-transaction"
-version = "3.1.0"
+version = "4.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96697cff5075a028265324255efed226099f6d761ca67342b230d09f72cc48d2"
+checksum = "6aa9b0f8543b99e1cb7db16a7c1a392139d82db57a90d262fb0a394807337bec"
 dependencies = [
- "solana-address 2.7.0",
- "solana-hash 4.6.0",
+ "solana-address",
+ "solana-hash",
  "solana-instruction",
  "solana-instruction-error",
  "solana-message",
@@ -4164,17 +4192,17 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-context"
-version = "3.1.14"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a3c3a69688293a195b02c60a5384d855b8de19981f404c71ccb9e7f139b98f"
+checksum = "855e7e2bf38f3a8e18c9dc1f2a4d2fd947f52c81f4e3b73077a3827582be6e03"
 dependencies = [
  "bincode",
  "qualifier_attr",
  "serde",
  "solana-account",
  "solana-instruction",
- "solana-instructions-sysvar",
- "solana-pubkey 3.0.0",
+ "solana-instructions-sysvar 4.0.0",
+ "solana-pubkey",
  "solana-rent",
  "solana-sbpf",
  "solana-sdk-ids",
@@ -4182,9 +4210,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-error"
-version = "3.4.0"
+version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a37cf28c58b03878d38c38411f0414d3a99a9e3b7e5ebb0f83f3317b2796d18"
+checksum = "054e54d15164b0c34cb744600a1a0330e9fd97a12d979f2eb95904c807a07713"
 dependencies = [
  "solana-instruction-error",
  "solana-sanitize",
@@ -4218,7 +4246,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.3.0",
+ "solana-pubkey",
  "thiserror 2.0.18",
 ]
 
@@ -4230,7 +4258,7 @@ dependencies = [
  "pina",
  "solana-account",
  "solana-instruction",
- "solana-pubkey 4.3.0",
+ "solana-pubkey",
  "solana-sdk-ids",
 ]
 
@@ -4273,6 +4301,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-triple"
@@ -4359,6 +4393,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4385,7 +4428,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.3.0",
+ "solana-pubkey",
  "thiserror 2.0.18",
 ]
 
@@ -4528,7 +4571,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.3.0",
+ "solana-pubkey",
  "thiserror 2.0.18",
 ]
 
@@ -4649,7 +4692,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.3.0",
+ "solana-pubkey",
  "thiserror 2.0.18",
 ]
 
@@ -4661,7 +4704,7 @@ dependencies = [
  "pina",
  "solana-account",
  "solana-instruction",
- "solana-pubkey 4.3.0",
+ "solana-pubkey",
  "solana-sdk-ids",
  "solana-system-interface",
 ]
@@ -4690,12 +4733,6 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -4745,9 +4782,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "wincode"
-version = "0.6.1"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfc6339f1ba427bf7ad7c42403b28e524832ba2ddb5eef1bb2cc3b85db6b7b75"
+checksum = "66d967db7705dc29120bb6e8ce5b5a2e27734ed5976d1c904e95bd238d1c3c5a"
 dependencies = [
  "pastey",
  "proc-macro2",
@@ -4758,9 +4795,9 @@ dependencies = [
 
 [[package]]
 name = "wincode-derive"
-version = "0.5.1"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d582d9fc9d813264407a9e16bfa16846ccf15ef032f9bbcd700741bdc00255"
+checksum = "15ab90b719560d0fda79c74550ad1c948d17b118765942838055ebaf34d67071"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -4806,6 +4843,15 @@ name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2473,9 +2473,9 @@ dependencies = [
 
 [[package]]
 name = "pinocchio-token"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825f59c8348e5c2d3fd56432ef927f5819542b3b05fae4f5b6869801113e775e"
+checksum = "217e3259f93a1520e4692b18653dad4d29af54ffc8b3a09819808be85dada074"
 dependencies = [
  "solana-account-view",
  "solana-address 2.6.1",
@@ -2485,14 +2485,17 @@ dependencies = [
 
 [[package]]
 name = "pinocchio-token-2022"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57dbab5718ab6ae446b2217c47598fabd29173a09bd32b05344f031739db92b8"
+checksum = "3a3c164973916f044bebff3c8cb4467088bafb13cbdb818522b9ca8782940d06"
 dependencies = [
+ "pinocchio-token",
  "solana-account-view",
  "solana-address 2.6.1",
  "solana-instruction-view",
+ "solana-nullable",
  "solana-program-error",
+ "solana-zero-copy",
 ]
 
 [[package]]
@@ -3282,6 +3285,7 @@ dependencies = [
  "sha2-const-stable",
  "solana-atomic-u64",
  "solana-define-syscall 5.1.0",
+ "solana-nullable",
  "solana-program-error",
  "solana-sanitize",
  "solana-sha256-hasher",
@@ -3681,6 +3685,12 @@ dependencies = [
  "solana-nonce",
  "solana-sdk-ids",
 ]
+
+[[package]]
+name = "solana-nullable"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "889194d8c5faec648f2f6fadddb60566249921ebb074e2707e7095458d5864e2"
 
 [[package]]
 name = "solana-packet"
@@ -4174,6 +4184,12 @@ dependencies = [
  "solana-instruction-error",
  "solana-sanitize",
 ]
+
+[[package]]
+name = "solana-zero-copy"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd3183a7934dd7e6490ae86732616cd70361f5ab9401b9a375ab62f7fa17b112"
 
 [[package]]
 name = "spki"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,9 +80,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -105,7 +105,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.2.0",
+ "solana-pubkey 4.3.0",
  "thiserror 2.0.18",
 ]
 
@@ -121,7 +121,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.2.0",
+ "solana-pubkey 4.3.0",
  "thiserror 2.0.18",
 ]
 
@@ -137,7 +137,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.2.0",
+ "solana-pubkey 4.3.0",
  "thiserror 2.0.18",
 ]
 
@@ -153,7 +153,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.2.0",
+ "solana-pubkey 4.3.0",
  "thiserror 2.0.18",
 ]
 
@@ -169,7 +169,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.2.0",
+ "solana-pubkey 4.3.0",
  "thiserror 2.0.18",
 ]
 
@@ -185,7 +185,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.2.0",
+ "solana-pubkey 4.3.0",
  "thiserror 2.0.18",
 ]
 
@@ -201,7 +201,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.2.0",
+ "solana-pubkey 4.3.0",
  "thiserror 2.0.18",
 ]
 
@@ -217,7 +217,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.2.0",
+ "solana-pubkey 4.3.0",
  "thiserror 2.0.18",
 ]
 
@@ -233,7 +233,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.2.0",
+ "solana-pubkey 4.3.0",
  "thiserror 2.0.18",
 ]
 
@@ -404,7 +404,7 @@ dependencies = [
  "fnv",
  "hashbrown 0.15.5",
  "itertools 0.13.0",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
  "zeroize",
@@ -423,7 +423,7 @@ dependencies = [
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-traits",
  "paste",
  "rustc_version",
@@ -444,7 +444,7 @@ dependencies = [
  "digest 0.10.7",
  "educe",
  "itertools 0.13.0",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-traits",
  "paste",
  "zeroize",
@@ -467,7 +467,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -476,7 +476,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -489,11 +489,11 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -533,7 +533,7 @@ dependencies = [
  "ark-serialize-derive 0.4.2",
  "ark-std 0.4.0",
  "digest 0.10.7",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
 ]
 
 [[package]]
@@ -546,7 +546,7 @@ dependencies = [
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
 ]
 
 [[package]]
@@ -568,7 +568,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -578,7 +578,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -588,7 +588,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -599,9 +599,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "ascii"
@@ -671,15 +671,15 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "blake3"
-version = "1.8.5"
+version = "1.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+checksum = "76ae7bad254120e9e4c63bafc385310756f90c484eac0e36b8317cf09cb92a77"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -709,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
+checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
 dependencies = [
  "borsh-derive",
  "bytes",
@@ -720,15 +720,15 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8fb4fb5740e4b2c4884ff95f5f32f5e8479db1e8fd8eb49ddbe09eb09bb7c"
+checksum = "d8f347189c62a579b8cd5f80714efa178f52e461dc2e6d701d264f5ff22e566c"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -752,22 +752,22 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.10.2"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -778,9 +778,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cargo_toml"
@@ -794,9 +794,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -810,15 +810,15 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -826,9 +826,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -838,14 +838,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -863,7 +863,7 @@ dependencies = [
  "cargo_toml",
  "proc-macro2",
  "serde_json",
- "syn 2.0.118",
+ "syn 2.0.119",
  "thiserror 2.0.18",
 ]
 
@@ -891,7 +891,7 @@ dependencies = [
  "derive_more 1.0.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -904,7 +904,7 @@ dependencies = [
  "derive_more 1.0.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -939,9 +939,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -990,7 +990,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.2.0",
+ "solana-pubkey 4.3.0",
  "thiserror 2.0.18",
 ]
 
@@ -1002,7 +1002,7 @@ dependencies = [
  "pina",
  "solana-account",
  "solana-instruction",
- "solana-pubkey 4.2.0",
+ "solana-pubkey 4.3.0",
  "solana-sdk-ids",
  "solana-system-interface",
 ]
@@ -1036,9 +1036,9 @@ dependencies = [
 
 [[package]]
 name = "crokey"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04a63daf06a168535c74ab97cdba3ed4fa5d4f32cb36e437dcceb83d66854b7c"
+checksum = "074bc31bff1084f74e5a145ad5f6ac74469fa312159faa5144f0b1c4506b8d80"
 dependencies = [
  "crokey-proc_macros",
  "crossterm",
@@ -1049,15 +1049,15 @@ dependencies = [
 
 [[package]]
 name = "crokey-proc_macros"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "847f11a14855fc490bd5d059821895c53e77eeb3c2b73ee3dded7ce77c93b231"
+checksum = "b88c4ff2d5717616c3bb4a31d06b0b241ed811c7c0c41d077d77631bee7caad0"
 dependencies = [
  "crossterm",
  "proc-macro2",
  "quote",
  "strict",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1075,18 +1075,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -1103,18 +1103,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crossterm"
@@ -1122,7 +1122,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "crossterm_winapi",
  "derive_more 2.1.1",
  "document-features",
@@ -1197,7 +1197,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1220,7 +1220,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1231,14 +1231,14 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "defmt"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
 dependencies = [
  "bitflags 1.3.2",
  "defmt-macros",
@@ -1246,15 +1246,14 @@ dependencies = [
 
 [[package]]
 name = "defmt-macros"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
 dependencies = [
  "defmt-parser",
- "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1313,7 +1312,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1326,7 +1325,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1388,14 +1387,14 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "elliptic-curve"
@@ -1439,34 +1438,34 @@ checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "enum-ordinalize"
-version = "4.3.2"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
+checksum = "89dd01549b09589510cf0647475075d12071456586d70f5c75c98ae2a5537677"
 dependencies = [
  "enum-ordinalize-derive",
 ]
 
 [[package]]
 name = "enum-ordinalize-derive"
-version = "4.3.2"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
+checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "env_filter"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
  "regex",
@@ -1474,9 +1473,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1513,7 +1512,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.2.0",
+ "solana-pubkey 4.3.0",
  "thiserror 2.0.18",
 ]
 
@@ -1528,9 +1527,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "feature-probe"
@@ -1556,9 +1555,9 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "five8"
@@ -1664,9 +1663,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "group"
@@ -1733,7 +1732,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.2.0",
+ "solana-pubkey 4.3.0",
  "thiserror 2.0.18",
 ]
 
@@ -1834,11 +1833,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.29"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
  "defmt",
+ "jiff-core",
  "jiff-static",
  "log",
  "portable-atomic",
@@ -1847,14 +1847,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "jiff-static"
-version = "0.2.29"
+name = "jiff-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
 dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1882,9 +1892,9 @@ dependencies = [
 
 [[package]]
 name = "lazy-regex"
-version = "3.6.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bae91019476d3ec7147de9aa291cadb6d870abf2f3015d2da73a90325ac1496"
+checksum = "4994ba703f78b083e2f7946dac9251abd83fd43a0365f030e99b69be5b4b9ef9"
 dependencies = [
  "lazy-regex-proc_macros",
  "once_cell",
@@ -1893,14 +1903,14 @@ dependencies = [
 
 [[package]]
 name = "lazy-regex-proc_macros"
-version = "3.6.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4de9c1e1439d8b7b3061b2d209809f447ca33241733d9a3c01eabf2dc8d94358"
+checksum = "fd97232314824e6dbef1918a871bb93f51070455e3715bf26e19a6d01aa977a0"
 dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1911,9 +1921,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libsecp256k1"
@@ -1969,7 +1979,7 @@ checksum = "3c9a85a9752c549ceb7578064b4ed891179d20acd85f27318573b64d2d7ee7ee"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-ff 0.4.2",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "thiserror 1.0.69",
 ]
 
@@ -1981,7 +1991,7 @@ checksum = "47a1ccadd0bb5a32c196da536fd72c59183de24a055f6bf0513bf845fefab862"
 dependencies = [
  "ark-bn254 0.5.0",
  "ark-ff 0.5.0",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "thiserror 1.0.69",
 ]
 
@@ -2014,9 +2024,9 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "minimad"
@@ -2039,9 +2049,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "log",
@@ -2077,7 +2087,7 @@ dependencies = [
  "solana-precompile-error",
  "solana-program-error",
  "solana-program-runtime",
- "solana-pubkey 4.2.0",
+ "solana-pubkey 4.3.0",
  "solana-rent",
  "solana-sdk-ids",
  "solana-slot-hashes",
@@ -2099,7 +2109,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e315980684803972f443b2d8dd765e3def7e4e20bb67d5125bb80639e858a040"
 dependencies = [
- "solana-pubkey 4.2.0",
+ "solana-pubkey 4.3.0",
  "thiserror 1.0.69",
 ]
 
@@ -2112,7 +2122,7 @@ dependencies = [
  "solana-account",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.2.0",
+ "solana-pubkey 4.3.0",
  "solana-rent",
  "solana-transaction-error",
 ]
@@ -2144,9 +2154,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -2170,25 +2180,24 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "num-iter"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -2317,7 +2326,7 @@ dependencies = [
  "pinocchio-token",
  "pinocchio-token-2022",
  "proptest",
- "solana-address 2.6.1",
+ "solana-address 2.7.0",
  "solana-program-log",
  "typed-builder",
 ]
@@ -2334,7 +2343,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.2.0",
+ "solana-pubkey 4.3.0",
  "thiserror 2.0.18",
 ]
 
@@ -2363,7 +2372,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "syn 2.0.118",
+ "syn 2.0.119",
  "tempfile",
  "termimad",
  "thiserror 2.0.18",
@@ -2393,7 +2402,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "trybuild",
 ]
 
@@ -2421,7 +2430,7 @@ name = "pina_sdk_ids"
 version = "0.8.0"
 dependencies = [
  "proptest",
- "solana-address 2.6.1",
+ "solana-address 2.7.0",
 ]
 
 [[package]]
@@ -2431,8 +2440,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cababcb62a2e739c7078ae16eda02789a6e3edd21bbdded864e85c38a7914d"
 dependencies = [
  "solana-account-view",
- "solana-address 2.6.1",
- "solana-define-syscall 5.1.0",
+ "solana-address 2.7.0",
+ "solana-define-syscall 5.2.0",
  "solana-instruction-view",
  "solana-program-error",
 ]
@@ -2444,7 +2453,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c552da2a965b33511ac54494e434e69be0ae12da1619a72594b76703c3dca211"
 dependencies = [
  "solana-account-view",
- "solana-address 2.6.1",
+ "solana-address 2.7.0",
  "solana-instruction-view",
  "solana-program-error",
 ]
@@ -2456,7 +2465,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87cd9e3e3c3c315d5c7d974929b74cd074ac280e3ab09111e736e9de47f3ce38"
 dependencies = [
  "solana-account-view",
- "solana-address 2.6.1",
+ "solana-address 2.7.0",
  "solana-instruction-view",
  "solana-program-error",
 ]
@@ -2468,7 +2477,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3ae2ee67b42e2ac797dd88312da473c895660e270d8093e0ba2749b885b5778"
 dependencies = [
  "pinocchio",
- "solana-address 2.6.1",
+ "solana-address 2.7.0",
 ]
 
 [[package]]
@@ -2478,7 +2487,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217e3259f93a1520e4692b18653dad4d29af54ffc8b3a09819808be85dada074"
 dependencies = [
  "solana-account-view",
- "solana-address 2.6.1",
+ "solana-address 2.7.0",
  "solana-instruction-view",
  "solana-program-error",
 ]
@@ -2491,7 +2500,7 @@ checksum = "3a3c164973916f044bebff3c8cb4467088bafb13cbdb818522b9ca8782940d06"
 dependencies = [
  "pinocchio-token",
  "solana-account-view",
- "solana-address 2.6.1",
+ "solana-address 2.7.0",
  "solana-instruction-view",
  "solana-nullable",
  "solana-program-error",
@@ -2510,9 +2519,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
@@ -2539,7 +2548,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2548,36 +2557,14 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.12+spec-1.1.0",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
+ "toml_edit 0.25.13+spec-1.1.0",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -2594,7 +2581,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.2.0",
+ "solana-pubkey 4.3.0",
  "thiserror 2.0.18",
 ]
 
@@ -2606,7 +2593,7 @@ dependencies = [
  "pina",
  "solana-account",
  "solana-instruction",
- "solana-pubkey 4.2.0",
+ "solana-pubkey 4.3.0",
  "solana-sdk-ids",
 ]
 
@@ -2618,9 +2605,9 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "num-traits",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -2637,7 +2624,7 @@ checksum = "9e2e25ee72f5b24d773cae88422baddefff7714f97aab68d96fe2b6fc4a28fb2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2648,9 +2635,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -2682,9 +2669,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2693,9 +2680,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2802,14 +2789,14 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2819,9 +2806,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2856,7 +2843,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.2.0",
+ "solana-pubkey 4.3.0",
  "thiserror 2.0.18",
 ]
 
@@ -2868,15 +2855,15 @@ dependencies = [
  "pina",
  "solana-account",
  "solana-instruction",
- "solana-pubkey 4.2.0",
+ "solana-pubkey 4.3.0",
  "solana-sdk-ids",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc_version"
@@ -2893,7 +2880,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3070,14 +3057,14 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -3193,9 +3180,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "similar"
@@ -3211,9 +3198,9 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys",
@@ -3233,7 +3220,7 @@ dependencies = [
  "solana-account-info",
  "solana-clock",
  "solana-instruction-error",
- "solana-pubkey 4.2.0",
+ "solana-pubkey 4.3.0",
  "solana-sdk-ids",
  "solana-sysvar",
 ]
@@ -3244,7 +3231,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9cf16495d9eb53e3d04e72366a33bb1c20c24e78c171d8b8f5978357b63ae95"
 dependencies = [
- "solana-address 2.6.1",
+ "solana-address 2.7.0",
  "solana-program-error",
  "solana-program-memory",
 ]
@@ -3255,7 +3242,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc141b940560430425ebaadb7645496c45f6a10fad9911d719bd03eab7f4d422"
 dependencies = [
- "solana-address 2.6.1",
+ "solana-address 2.7.0",
  "solana-program-error",
 ]
 
@@ -3265,14 +3252,14 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2ecac8e1b7f74c2baa9e774c42817e3e75b20787134b76cc4d45e8a604488f5"
 dependencies = [
- "solana-address 2.6.1",
+ "solana-address 2.7.0",
 ]
 
 [[package]]
 name = "solana-address"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c93e262f671bf402e1040e4a7e40b05d81da5956c7681948c975a0997517bb"
+checksum = "01332a01c0a3098404d55a724c8d9a92aed4a50fe40a7dd0c7a51e29274c14de"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -3284,7 +3271,7 @@ dependencies = [
  "serde_derive",
  "sha2-const-stable",
  "solana-atomic-u64",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "solana-nullable",
  "solana-program-error",
  "solana-sanitize",
@@ -3307,7 +3294,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30c80fb6d791b3925d5ec4bf23a7c169ef5090c013059ec3ed7d0b2c04efa085"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-traits",
  "solana-define-syscall 3.0.0",
 ]
@@ -3331,7 +3318,7 @@ checksum = "7116e1d942a2432ca3f514625104757ab8a56233787e95144c93950029e31176"
 dependencies = [
  "blake3",
  "solana-define-syscall 4.0.1",
- "solana-hash 4.4.0",
+ "solana-hash 4.6.0",
 ]
 
 [[package]]
@@ -3345,7 +3332,7 @@ dependencies = [
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
  "bytemuck",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "thiserror 2.0.18",
 ]
 
@@ -3380,12 +3367,13 @@ dependencies = [
 
 [[package]]
 name = "solana-clock"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea35d8f69b67daddb921a9da7f78ca591b533cf5e98833cd9ae62fdc2e4652c"
+checksum = "a7708bdb262fd9c257c3a56d4289297b10a3e821b8cba3f7cf42b49c40201ab9"
 dependencies = [
  "serde",
  "serde_derive",
+ "solana-get-sysvar",
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
@@ -3411,7 +3399,7 @@ dependencies = [
  "solana-define-syscall 4.0.1",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.2.0",
+ "solana-pubkey 4.3.0",
  "solana-stable-layout",
 ]
 
@@ -3443,19 +3431,20 @@ checksum = "57e5b1c0bc1d4a4d10c88a4100499d954c09d3fecfae4912c1a074dff68b1738"
 
 [[package]]
 name = "solana-define-syscall"
-version = "5.1.0"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e14a4f604117f379840956a8fc8695e4c84f5b0ebed192f31f60d9b85d581d"
+checksum = "bf8209ece2bd9f1450e672858ffc0e5c8c786ff6916d2a862b126dd0128f380f"
 
 [[package]]
 name = "solana-epoch-rewards"
-version = "3.0.2"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cddf2388b28291210d9aa60690740733cab527531f06ed153c4d388951e407c"
+checksum = "0788d74ee15778deecaa15ed1a1e37727ba954f86cbc35225450a1f2b5012969"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-hash 4.4.0",
+ "solana-get-sysvar",
+ "solana-hash 4.6.0",
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
@@ -3463,12 +3452,14 @@ dependencies = [
 
 [[package]]
 name = "solana-epoch-schedule"
-version = "3.1.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ad280b1ed803853f7b453cb3ea9a57e600ca5599a63e69f7be199b486c0ec93"
+checksum = "a1633cfd10cde127f2caf8f12021b4f8e9a425e7e4eea4326e428c422376d6fd"
 dependencies = [
  "serde",
  "serde_derive",
+ "solana-get-sysvar",
+ "solana-program-error",
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
@@ -3476,9 +3467,9 @@ dependencies = [
 
 [[package]]
 name = "solana-fee-calculator"
-version = "3.2.2"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef67f01cc6a0c72e99a08d0d484683f995de4c80e9568728fa77d1537f9b7e09"
+checksum = "d4bf4f4afb4704212ef1d994ee65bef7293441721639dfd16f0e60996f37be51"
 dependencies = [
  "log",
  "serde",
@@ -3492,19 +3483,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e2abdb1223eea8ec64136f39cb1ffcf257e00f915c957c35c0dd9e3f4e700b0"
 
 [[package]]
+name = "solana-get-sysvar"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef3bc859fc036ed490146793557386cbfae614ebba4adc704c37d94350824ed4"
+dependencies = [
+ "solana-address 2.7.0",
+ "solana-define-syscall 5.2.0",
+ "solana-program-error",
+]
+
+[[package]]
 name = "solana-hash"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "337c246447142f660f778cf6cb582beba8e28deb05b3b24bfb9ffd7c562e5f41"
 dependencies = [
- "solana-hash 4.4.0",
+ "solana-hash 4.6.0",
 ]
 
 [[package]]
 name = "solana-hash"
-version = "4.4.0"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe51db00ac3aa9f950d1e6201a126acfa26e6d81bc4a183ba64ec02effcad883"
+checksum = "0df9b01495ed31100aca97a7f5862d5e19ab1636d60d1a9f02391408dd9dec84"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -3517,23 +3519,23 @@ dependencies = [
 
 [[package]]
 name = "solana-instruction"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ebb0ffd19263051bc3f683fcc086134b8ff23af894dcb63f7563c7137b42f1"
+checksum = "d70cf6ece1070a66d25e68274f338f29664794669c175223940a298645ef3495"
 dependencies = [
  "bincode",
  "serde",
  "serde_derive",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "solana-instruction-error",
- "solana-pubkey 4.2.0",
+ "solana-pubkey 4.3.0",
 ]
 
 [[package]]
 name = "solana-instruction-error"
-version = "2.3.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b188842592fdf6cb96f55263ae1bf11713ab5114401d1d5a881ed7cc41bef6"
+checksum = "e8e7db78c122d02189619490b1fef04a2a042c389662920617c0e6381fdf8fdd"
 dependencies = [
  "num-traits",
  "serde",
@@ -3548,8 +3550,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ab7a27d0c4214b9f7389c3dd00b68c93093a67f1dcc5b7893aebe299bbcbb47"
 dependencies = [
  "solana-account-view",
- "solana-address 2.6.1",
- "solana-define-syscall 5.1.0",
+ "solana-address 2.7.0",
+ "solana-define-syscall 5.2.0",
  "solana-program-error",
 ]
 
@@ -3559,7 +3561,7 @@ version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e0732294560e88ecdb2bbc656e67383e9f88c78ec09469cef172f0d28cd1bcd"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "solana-account-info",
  "solana-instruction",
  "solana-instruction-error",
@@ -3578,17 +3580,18 @@ checksum = "ed1c0d16d6fdeba12291a1f068cdf0d479d9bff1141bf44afd7aa9d485f65ef8"
 dependencies = [
  "sha3",
  "solana-define-syscall 4.0.1",
- "solana-hash 4.4.0",
+ "solana-hash 4.6.0",
 ]
 
 [[package]]
 name = "solana-last-restart-slot"
-version = "3.0.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "426711c6564b790026e45cabec3c64b971864c48b6b2d83c0ebf52a118bb4cda"
+checksum = "5099e736c3c06c451b307a60637d69eb65b3144143ebeed899e2fd1134f4fc35"
 dependencies = [
  "serde",
  "serde_derive",
+ "solana-get-sysvar",
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
@@ -3604,7 +3607,7 @@ dependencies = [
  "serde_bytes",
  "serde_derive",
  "solana-instruction",
- "solana-pubkey 4.2.0",
+ "solana-pubkey 4.3.0",
  "solana-sdk-ids",
 ]
 
@@ -3643,8 +3646,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0448b1fd891c5f46491e5dc7d9986385ba3c852c340db2911dd29faa01d2b08d"
 dependencies = [
  "lazy_static",
- "solana-address 2.6.1",
- "solana-hash 4.4.0",
+ "solana-address 2.7.0",
+ "solana-hash 4.6.0",
  "solana-instruction",
  "solana-sanitize",
  "solana-sdk-ids",
@@ -3657,20 +3660,20 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726b7cbbc6be6f1c6f29146ac824343b9415133eee8cce156452ad1db93f8008"
 dependencies = [
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
 ]
 
 [[package]]
 name = "solana-nonce"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95dbc9f2e33b6c10e231df15cb2a3bff9ea7eab6347f9e316fe75c97fd67bbb"
+checksum = "1f13b7ec92de6dd4ef713ed763d22585efa0042cd244bce81997e52077885c47"
 dependencies = [
  "serde",
  "serde_derive",
  "solana-fee-calculator",
- "solana-hash 4.4.0",
- "solana-pubkey 4.2.0",
+ "solana-hash 4.6.0",
+ "solana-pubkey 4.3.0",
  "solana-sha256-hasher",
 ]
 
@@ -3698,7 +3701,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6edf2f25743c95229ac0fdc32f8f5893ef738dbf332c669e9861d33ddb0f469d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -3733,7 +3736,7 @@ dependencies = [
  "solana-account-info",
  "solana-define-syscall 4.0.1",
  "solana-program-error",
- "solana-pubkey 4.2.0",
+ "solana-pubkey 4.3.0",
 ]
 
 [[package]]
@@ -3748,7 +3751,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffd48ddef444e6db138fb11bdb9ab8117bb830a78cef051a453454de5613039b"
 dependencies = [
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "solana-program-log-macro",
 ]
 
@@ -3760,7 +3763,7 @@ checksum = "73b234f83b71ba6b5d3236b69ba42ccb639907cb724bf58e94ce8398b51ac87c"
 dependencies = [
  "quote",
  "regex",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3783,7 +3786,7 @@ dependencies = [
  "itertools 0.12.1",
  "log",
  "percentage",
- "rand 0.8.6",
+ "rand 0.8.7",
  "serde",
  "solana-account",
  "solana-account-info",
@@ -3828,11 +3831,11 @@ dependencies = [
 
 [[package]]
 name = "solana-pubkey"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7db719574990de7e8b0f55a8593ac92a5ccb42c8ce67b3e4bf05b139d5d9ee71"
+checksum = "10f71b7a414de2ced1071f015834e9be581592d013432adbd06d02e4af11eba9"
 dependencies = [
- "solana-address 2.6.1",
+ "solana-address 2.7.0",
 ]
 
 [[package]]
@@ -3865,7 +3868,7 @@ dependencies = [
  "hash32",
  "libc",
  "log",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rustc-demangle",
  "thiserror 2.0.18",
  "winapi",
@@ -3877,7 +3880,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "def234c1956ff616d46c9dd953f251fa7096ddbaa6d52b165218de97882b7280"
 dependencies = [
- "solana-address 2.6.1",
+ "solana-address 2.7.0",
 ]
 
 [[package]]
@@ -3889,17 +3892,17 @@ dependencies = [
  "bs58",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "solana-secp256k1-recover"
-version = "3.1.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c5f18893d62e6c73117dcba48f8f5e3266d90e5ec3d0a0a90f9785adac36c1"
+checksum = "ce0d2e8d53946f04e789476d6c407e4997b7fb412483df5fc10c075c65cb2edf"
 dependencies = [
  "k256",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "thiserror 2.0.18",
 ]
 
@@ -3910,7 +3913,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "761357b0853c9623bf12c1d2314b3d6160a85b087b84c45224fb85766d22616b"
 dependencies = [
  "solana-instruction-error",
- "solana-pubkey 4.2.0",
+ "solana-pubkey 4.3.0",
  "solana-sanitize",
 ]
 
@@ -3922,14 +3925,14 @@ checksum = "db7dc3011ea4c0334aaaa7e7128cb390ecf546b28d412e9bf2064680f57f588f"
 dependencies = [
  "sha2 0.10.9",
  "solana-define-syscall 4.0.1",
- "solana-hash 4.4.0",
+ "solana-hash 4.6.0",
 ]
 
 [[package]]
 name = "solana-signature"
-version = "3.4.1"
+version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0364c7577c3c82a693ce28a1febc8d1b5d1b0a175fdc2114ae6186b69effe1e"
+checksum = "fe45ce95700ac8045e422344b88e273843d70185873cc1cc880ba06dd9fa9002"
 dependencies = [
  "five8",
  "solana-sanitize",
@@ -3937,26 +3940,28 @@ dependencies = [
 
 [[package]]
 name = "solana-slot-hashes"
-version = "3.0.2"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a57c158c35629f9e302ab385f16b15813f4927a31c27dda72f3df828bb08d93"
+checksum = "007d6bc909599eea325c9d09f7ff16ef6166c134876ff47a6a122d693d058dad"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-hash 4.4.0",
+ "solana-get-sysvar",
+ "solana-hash 4.6.0",
  "solana-sdk-ids",
  "solana-sysvar-id",
 ]
 
 [[package]]
 name = "solana-slot-history"
-version = "3.0.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0622d03a823770f7763afd866e012b296d5a3cbbbe51e110b5bd9ab3441efdca"
+checksum = "4560fde841a6f2001aedc33b74fe99840ee3d56a71fe9b98ee332303b8597900"
 dependencies = [
  "bv",
  "serde",
  "serde_derive",
+ "solana-get-sysvar",
  "solana-sdk-ids",
  "solana-sysvar-id",
 ]
@@ -3968,7 +3973,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9f6a291ba063a37780af29e7db14bdd3dc447584d8ba5b3fc4b88e2bbc982fa"
 dependencies = [
  "solana-instruction",
- "solana-pubkey 4.2.0",
+ "solana-pubkey 4.3.0",
 ]
 
 [[package]]
@@ -4054,7 +4059,7 @@ version = "3.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b78cd0bfb102d4197ce8c590f800a119ba0d358369ca57b0f66e94d1317fd0e"
 dependencies = [
- "rand 0.8.6",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -4115,13 +4120,13 @@ dependencies = [
  "solana-epoch-rewards",
  "solana-epoch-schedule",
  "solana-fee-calculator",
- "solana-hash 4.4.0",
+ "solana-hash 4.6.0",
  "solana-instruction",
  "solana-last-restart-slot",
  "solana-program-entrypoint",
  "solana-program-error",
  "solana-program-memory",
- "solana-pubkey 4.2.0",
+ "solana-pubkey 4.3.0",
  "solana-rent",
  "solana-sdk-ids",
  "solana-sdk-macro",
@@ -4136,7 +4141,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17358d1e9a13e5b9c2264d301102126cf11a47fd394cdf3dec174fe7bc96e1de"
 dependencies = [
- "solana-address 2.6.1",
+ "solana-address 2.7.0",
  "solana-sdk-ids",
 ]
 
@@ -4146,8 +4151,8 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96697cff5075a028265324255efed226099f6d761ca67342b230d09f72cc48d2"
 dependencies = [
- "solana-address 2.6.1",
- "solana-hash 4.4.0",
+ "solana-address 2.7.0",
+ "solana-hash 4.6.0",
  "solana-instruction",
  "solana-instruction-error",
  "solana-message",
@@ -4177,9 +4182,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-error"
-version = "3.2.1"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2441d6dcd51100e7d97c3fb3b723e08aa701066ff7afc00026fd8d8e222cb95b"
+checksum = "8a37cf28c58b03878d38c38411f0414d3a99a9e3b7e5ebb0f83f3317b2796d18"
 dependencies = [
  "solana-instruction-error",
  "solana-sanitize",
@@ -4213,7 +4218,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.2.0",
+ "solana-pubkey 4.3.0",
  "thiserror 2.0.18",
 ]
 
@@ -4225,7 +4230,7 @@ dependencies = [
  "pina",
  "solana-account",
  "solana-instruction",
- "solana-pubkey 4.2.0",
+ "solana-pubkey 4.3.0",
  "solana-sdk-ids",
 ]
 
@@ -4260,9 +4265,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4271,9 +4276,9 @@ dependencies = [
 
 [[package]]
 name = "target-triple"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+checksum = "c3a6bfce3d99adfa72d24750a61f782f3036a81e7f86d8841ee1326deaebd171"
 
 [[package]]
 name = "tempfile"
@@ -4339,7 +4344,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4350,14 +4355,14 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4380,7 +4385,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.2.0",
+ "solana-pubkey 4.3.0",
  "thiserror 2.0.18",
 ]
 
@@ -4393,9 +4398,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -4410,13 +4415,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4433,9 +4438,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -4443,7 +4448,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -4480,23 +4485,23 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -4507,9 +4512,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "transfer-sol-client"
@@ -4523,7 +4528,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.2.0",
+ "solana-pubkey 4.3.0",
  "thiserror 2.0.18",
 ]
 
@@ -4536,9 +4541,9 @@ dependencies = [
 
 [[package]]
 name = "trybuild"
-version = "1.0.117"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0710d4dfbeae4f9c390baa784c49858a7468fa433f3fe5d0ec5ebef651cf59f9"
+checksum = "1e605bf6b39357663d8ba4e984f8be8da8df6bb32e81031d6889024ea8fd68e4"
 dependencies = [
  "glob",
  "serde",
@@ -4546,14 +4551,14 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
 ]
 
 [[package]]
 name = "twox-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
 
 [[package]]
 name = "typed-builder"
@@ -4572,7 +4577,7 @@ checksum = "076a02dc54dd46795c2e9c8282ed40bcfb1e22747e955de9389a1de28190fb26"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4644,7 +4649,7 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.2.0",
+ "solana-pubkey 4.3.0",
  "thiserror 2.0.18",
 ]
 
@@ -4656,7 +4661,7 @@ dependencies = [
  "pina",
  "solana-account",
  "solana-instruction",
- "solana-pubkey 4.2.0",
+ "solana-pubkey 4.3.0",
  "solana-sdk-ids",
  "solana-system-interface",
 ]
@@ -4740,9 +4745,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "wincode"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d967db7705dc29120bb6e8ce5b5a2e27734ed5976d1c904e95bd238d1c3c5a"
+checksum = "bfc6339f1ba427bf7ad7c42403b28e524832ba2ddb5eef1bb2cc3b85db6b7b75"
 dependencies = [
  "pastey",
  "proc-macro2",
@@ -4753,14 +4758,14 @@ dependencies = [
 
 [[package]]
 name = "wincode-derive"
-version = "0.4.6"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15ab90b719560d0fda79c74550ad1c948d17b118765942838055ebaf34d67071"
+checksum = "11d582d9fc9d813264407a9e16bfa16846ccf15ef032f9bbcd700741bdc00255"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4789,9 +4794,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -4804,22 +4809,22 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4839,11 +4844,11 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,7 +48,7 @@ dependencies = [
  "solana-instruction",
  "solana-program-error",
  "solana-pubkey",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -64,7 +64,7 @@ dependencies = [
  "solana-instruction",
  "solana-program-error",
  "solana-pubkey",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -80,7 +80,7 @@ dependencies = [
  "solana-instruction",
  "solana-program-error",
  "solana-pubkey",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -96,7 +96,7 @@ dependencies = [
  "solana-instruction",
  "solana-program-error",
  "solana-pubkey",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -112,7 +112,7 @@ dependencies = [
  "solana-instruction",
  "solana-program-error",
  "solana-pubkey",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -128,7 +128,7 @@ dependencies = [
  "solana-instruction",
  "solana-program-error",
  "solana-pubkey",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -144,7 +144,7 @@ dependencies = [
  "solana-instruction",
  "solana-program-error",
  "solana-pubkey",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -160,7 +160,7 @@ dependencies = [
  "solana-instruction",
  "solana-program-error",
  "solana-pubkey",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -176,7 +176,7 @@ dependencies = [
  "solana-instruction",
  "solana-program-error",
  "solana-pubkey",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -743,13 +743,13 @@ dependencies = [
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
+checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -798,9 +798,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "clap"
-version = "4.6.3"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -808,9 +808,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -820,14 +820,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -846,7 +846,7 @@ dependencies = [
  "proc-macro2",
  "serde_json",
  "syn 2.0.119",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -973,7 +973,7 @@ dependencies = [
  "solana-instruction",
  "solana-program-error",
  "solana-pubkey",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1188,8 +1188,18 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
+dependencies = [
+ "darling_core 0.24.0",
+ "darling_macro 0.24.0",
 ]
 
 [[package]]
@@ -1206,14 +1216,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
+dependencies = [
+ "darling_core 0.24.0",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1244,7 +1278,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1434,13 +1468,13 @@ dependencies = [
 
 [[package]]
 name = "enum-ordinalize-derive"
-version = "4.4.1"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
+checksum = "a65863d15a4ce2888bd2f0f543cc963d3879c3a022c8ee43f6141d479a3ac815"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1495,7 +1529,7 @@ dependencies = [
  "solana-instruction",
  "solana-program-error",
  "solana-pubkey",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1713,7 +1747,7 @@ dependencies = [
  "solana-instruction",
  "solana-program-error",
  "solana-pubkey",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2094,7 +2128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2566d4c2c6c4aa51b95d70d71fdd2a2d8519d2bb790356d11f2d13608c2f2a0e"
 dependencies = [
  "solana-pubkey",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2158,13 +2192,13 @@ dependencies = [
 
 [[package]]
 name = "num-derive"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+checksum = "e4e98dc3b890f6c23a0f9d3d491a2823d0dea0fa656302a13dd225fa924112a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2347,7 +2381,7 @@ dependencies = [
  "solana-instruction",
  "solana-program-error",
  "solana-pubkey",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2375,10 +2409,10 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "syn 2.0.119",
+ "syn 3.0.3",
  "tempfile",
  "termimad",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "walkdir",
 ]
 
@@ -2391,21 +2425,21 @@ dependencies = [
  "heck",
  "insta",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "pina_macros"
 version = "0.8.0"
 dependencies = [
- "darling",
+ "darling 0.24.0",
  "heck",
  "insta",
  "pina",
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
  "trybuild",
 ]
 
@@ -2425,7 +2459,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2546,12 +2580,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.37"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+checksum = "2bfe0f4c752e450fc2faf62654f1c134747922825d5b04ca717b8874f41a40c0"
 dependencies = [
  "proc-macro2",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2585,7 +2619,7 @@ dependencies = [
  "solana-instruction",
  "solana-program-error",
  "solana-pubkey",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2821,7 +2855,7 @@ dependencies = [
  "solana-instruction",
  "solana-program-error",
  "solana-pubkey",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2999,9 +3033,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -3019,22 +3053,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3303,7 +3337,7 @@ dependencies = [
  "ark-serialize 0.5.0",
  "bytemuck",
  "solana-define-syscall 5.2.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -3382,7 +3416,7 @@ dependencies = [
  "curve25519-dalek",
  "solana-define-syscall 5.2.0",
  "subtle",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -3680,7 +3714,7 @@ dependencies = [
  "light-poseidon 0.2.0",
  "light-poseidon 0.4.0",
  "solana-define-syscall 4.0.1",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -3783,7 +3817,7 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-transaction-context",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "wincode",
 ]
 
@@ -3829,7 +3863,7 @@ dependencies = [
  "log",
  "rand 0.8.7",
  "rustc-demangle",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "winapi",
 ]
 
@@ -3862,7 +3896,7 @@ checksum = "ce0d2e8d53946f04e789476d6c407e4997b7fb412483df5fc10c075c65cb2edf"
 dependencies = [
  "k256",
  "solana-define-syscall 5.2.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -4085,7 +4119,7 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-transaction-context",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "wincode",
 ]
 
@@ -4247,7 +4281,7 @@ dependencies = [
  "solana-instruction",
  "solana-program-error",
  "solana-pubkey",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -4303,6 +4337,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4348,7 +4393,7 @@ dependencies = [
  "lazy-regex",
  "minimad",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "unicode-width 0.1.14",
 ]
 
@@ -4363,11 +4408,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -4383,13 +4428,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4429,7 +4474,7 @@ dependencies = [
  "solana-instruction",
  "solana-program-error",
  "solana-pubkey",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -4458,13 +4503,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4572,7 +4617,7 @@ dependencies = [
  "solana-instruction",
  "solana-program-error",
  "solana-pubkey",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -4693,7 +4738,7 @@ dependencies = [
  "solana-instruction",
  "solana-program-error",
  "solana-pubkey",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -4789,7 +4834,7 @@ dependencies = [
  "pastey",
  "proc-macro2",
  "quote",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "wincode-derive",
 ]
 
@@ -4799,7 +4844,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15ab90b719560d0fda79c74550ad1c948d17b118765942838055ebaf34d67071"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,12 +89,12 @@ rust-version = "1.89.0"
 bytemuck = { default-features = false, version = "^1" }
 clap = { default-features = false, version = "^4", features = ["derive", "std"] }
 codama-nodes = { default-features = false, version = "0.11.0" }
-darling = { default-features = false, version = "0.23.0" }
+darling = { default-features = false, version = "0.24.0" }
 heck = { default-features = false, version = "^0.5" }
 insta = { default-features = false, version = "^1" }
 insta-cmd = { default-features = false, version = "^0.7.0" }
 mollusk-svm = { default-features = false, version = "0.15.0" }
-num-derive = { version = "^0.4", default-features = false }
+num-derive = { version = "^0.5", default-features = false }
 num-traits = { version = "^0.2", default-features = false }
 pastey = { default-features = false, version = "^0.2" }
 pinocchio = { default-features = false, version = "^0.11", features = ["cpi"] }
@@ -103,7 +103,7 @@ pinocchio-memo = { default-features = false, version = "^0.4" }
 pinocchio-system = { default-features = false, version = "^0.6" }
 pinocchio-token = { default-features = false, version = "^0.7" }
 pinocchio-token-2022 = { default-features = false, version = "^0.4" }
-prettyplease = { default-features = false, version = "^0.2" }
+prettyplease = { default-features = false, version = "^0.3" }
 proc-macro2 = { default-features = false, version = "^1" }
 proptest = { default-features = false, version = "^1", features = ["std"] }
 quote = { default-features = false, version = "^1" }
@@ -119,7 +119,7 @@ solana-program-log = { default-features = false, version = "^1.1" }
 solana-pubkey = { version = "^4", features = ["bytemuck"], default-features = false }
 solana-sdk-ids = { version = "^3", default-features = false }
 solana-system-interface = { version = "^3", default-features = false }
-syn = { default-features = false, version = "^2", features = ["full"] }
+syn = { default-features = false, version = "^3", features = ["full"] }
 tempfile = { default-features = false, version = "^3" }
 thiserror = { default-features = false, version = "^2" }
 tokio = { default-features = false, version = "^1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,12 +88,12 @@ rust-version = "1.89.0"
 [workspace.dependencies]
 bytemuck = { default-features = false, version = "^1" }
 clap = { default-features = false, version = "^4", features = ["derive", "std"] }
-codama-nodes = { default-features = false, version = "0.8.0" }
+codama-nodes = { default-features = false, version = "0.11.0" }
 darling = { default-features = false, version = "0.23.0" }
 heck = { default-features = false, version = "^0.5" }
 insta = { default-features = false, version = "^1" }
-insta-cmd = { default-features = false, version = "^0.6.0" }
-mollusk-svm = { default-features = false, version = "0.11.0" }
+insta-cmd = { default-features = false, version = "^0.7.0" }
+mollusk-svm = { default-features = false, version = "0.15.0" }
 num-derive = { version = "^0.4", default-features = false }
 num-traits = { version = "^0.2", default-features = false }
 pastey = { default-features = false, version = "^0.2" }
@@ -109,7 +109,7 @@ proptest = { default-features = false, version = "^1", features = ["std"] }
 quote = { default-features = false, version = "^1" }
 serde = { default-features = false, version = "^1" }
 serde_json = { default-features = false, version = "^1", features = ["std"] }
-solana-account = { version = "^3", default-features = false }
+solana-account = { version = "^4", default-features = false }
 solana-account-info = { version = "^3", default-features = false }
 solana-address = { default-features = false, version = "^2.0", features = ["bytemuck", "curve25519", "decode"] }
 solana-cpi = { version = "^3", default-features = false }
@@ -118,7 +118,7 @@ solana-program-error = { version = "^3", default-features = false }
 solana-program-log = { default-features = false, version = "^1.1" }
 solana-pubkey = { version = "^4", features = ["bytemuck"], default-features = false }
 solana-sdk-ids = { version = "^3", default-features = false }
-solana-system-interface = { version = "^2", default-features = false }
+solana-system-interface = { version = "^3", default-features = false }
 syn = { default-features = false, version = "^2", features = ["full"] }
 tempfile = { default-features = false, version = "^3" }
 thiserror = { default-features = false, version = "^2" }
@@ -128,7 +128,7 @@ typed-builder = { default-features = false, version = "^0.23" }
 walkdir = { default-features = false, version = "^2" }
 
 # publishable crates
-object = { default-features = false, version = "^0.39.0" }
+object = { default-features = false, version = "^0.40.0" }
 pina = { default-features = false, path = "crates/pina", version = "0.8.0" }
 pina_cli = { default-features = false, path = "crates/pina_cli", version = "0.8.0" }
 pina_codama_renderer = { default-features = false, path = "crates/pina_codama_renderer", version = "0.8.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,8 +101,8 @@ pinocchio = { default-features = false, version = "^0.11", features = ["cpi"] }
 pinocchio-associated-token-account = { default-features = false, version = "^0.4" }
 pinocchio-memo = { default-features = false, version = "^0.4" }
 pinocchio-system = { default-features = false, version = "^0.6" }
-pinocchio-token = { default-features = false, version = "^0.6" }
-pinocchio-token-2022 = { default-features = false, version = "^0.3" }
+pinocchio-token = { default-features = false, version = "^0.7" }
+pinocchio-token-2022 = { default-features = false, version = "^0.4" }
 prettyplease = { default-features = false, version = "^0.2" }
 proc-macro2 = { default-features = false, version = "^1" }
 proptest = { default-features = false, version = "^1", features = ["std"] }

--- a/codama/clients/js/anchor_declare_id/package.json
+++ b/codama/clients/js/anchor_declare_id/package.json
@@ -9,9 +9,9 @@
 	"keywords": [],
 	"author": "",
 	"peerDependencies": {
-		"@solana/kit": "^6.1.0"
+		"@solana/kit": "^6.10.0"
 	},
 	"dependencies": {
-		"@solana/program-client-core": "^6.1.0"
+		"@solana/program-client-core": "^6.10.0"
 	}
 }

--- a/codama/clients/js/anchor_declare_id/src/generated/instructions/initialize.ts
+++ b/codama/clients/js/anchor_declare_id/src/generated/instructions/initialize.ts
@@ -12,12 +12,13 @@ import {
 	getU8Encoder,
 	type Instruction,
 	type InstructionWithAccounts,
+	type ReadonlyUint8Array,
 } from "@solana/kit";
 import { ANCHOR_DECLARE_ID_PROGRAM_ADDRESS } from "../programs";
 
 export const INITIALIZE_DISCRIMINATOR = 0;
 
-export function getInitializeDiscriminatorBytes() {
+export function getInitializeDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(INITIALIZE_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/anchor_declare_id/src/generated/programs/anchorDeclareId.ts
+++ b/codama/clients/js/anchor_declare_id/src/generated/programs/anchorDeclareId.ts
@@ -11,6 +11,8 @@ import {
 	type ClientWithTransactionPlanning,
 	type ClientWithTransactionSending,
 	containsBytes,
+	extendClient,
+	type ExtendedClient,
 	getU8Encoder,
 	type Instruction,
 	type InstructionWithData,
@@ -84,6 +86,8 @@ export function parseAnchorDeclareIdInstruction<TProgram extends string>(
 
 export type AnchorDeclareIdPlugin = {
 	instructions: AnchorDeclareIdPluginInstructions;
+	identifyInstruction: typeof identifyAnchorDeclareIdInstruction;
+	parseInstruction: typeof parseAnchorDeclareIdInstruction;
 };
 
 export type AnchorDeclareIdPluginInstructions = {
@@ -97,9 +101,10 @@ export type AnchorDeclareIdPluginRequirements =
 	& ClientWithTransactionSending;
 
 export function anchorDeclareIdProgram() {
-	return <T extends AnchorDeclareIdPluginRequirements>(client: T) => {
-		return {
-			...client,
+	return <T extends AnchorDeclareIdPluginRequirements>(
+		client: T,
+	): ExtendedClient<T, { anchorDeclareId: AnchorDeclareIdPlugin }> => {
+		return extendClient(client, {
 			anchorDeclareId: <AnchorDeclareIdPlugin> {
 				instructions: {
 					initialize: (input) =>
@@ -108,7 +113,9 @@ export function anchorDeclareIdProgram() {
 							getInitializeInstruction(input),
 						),
 				},
+				identifyInstruction: identifyAnchorDeclareIdInstruction,
+				parseInstruction: parseAnchorDeclareIdInstruction,
 			},
-		};
+		});
 	};
 }

--- a/codama/clients/js/anchor_declare_program/package.json
+++ b/codama/clients/js/anchor_declare_program/package.json
@@ -9,9 +9,9 @@
 	"keywords": [],
 	"author": "",
 	"peerDependencies": {
-		"@solana/kit": "^6.1.0"
+		"@solana/kit": "^6.10.0"
 	},
 	"dependencies": {
-		"@solana/program-client-core": "^6.1.0"
+		"@solana/program-client-core": "^6.10.0"
 	}
 }

--- a/codama/clients/js/anchor_declare_program/src/generated/instructions/validateExternalProgram.ts
+++ b/codama/clients/js/anchor_declare_program/src/generated/instructions/validateExternalProgram.ts
@@ -15,6 +15,7 @@ import {
 	type InstructionWithAccounts,
 	type ReadonlyAccount,
 	type ReadonlySignerAccount,
+	type ReadonlyUint8Array,
 	SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
 	SolanaError,
 	type TransactionSigner,
@@ -27,7 +28,7 @@ import { ANCHOR_DECLARE_PROGRAM_PROGRAM_ADDRESS } from "../programs";
 
 export const VALIDATE_EXTERNAL_PROGRAM_DISCRIMINATOR = 0;
 
-export function getValidateExternalProgramDiscriminatorBytes() {
+export function getValidateExternalProgramDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(VALIDATE_EXTERNAL_PROGRAM_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/anchor_declare_program/src/generated/programs/anchorDeclareProgram.ts
+++ b/codama/clients/js/anchor_declare_program/src/generated/programs/anchorDeclareProgram.ts
@@ -12,6 +12,8 @@ import {
 	type ClientWithTransactionPlanning,
 	type ClientWithTransactionSending,
 	containsBytes,
+	extendClient,
+	type ExtendedClient,
 	getU8Encoder,
 	type Instruction,
 	type InstructionWithData,
@@ -87,6 +89,8 @@ export function parseAnchorDeclareProgramInstruction<TProgram extends string>(
 
 export type AnchorDeclareProgramPlugin = {
 	instructions: AnchorDeclareProgramPluginInstructions;
+	identifyInstruction: typeof identifyAnchorDeclareProgramInstruction;
+	parseInstruction: typeof parseAnchorDeclareProgramInstruction;
 };
 
 export type AnchorDeclareProgramPluginInstructions = {
@@ -102,9 +106,13 @@ export type AnchorDeclareProgramPluginRequirements =
 	& ClientWithTransactionSending;
 
 export function anchorDeclareProgramProgram() {
-	return <T extends AnchorDeclareProgramPluginRequirements>(client: T) => {
-		return {
-			...client,
+	return <T extends AnchorDeclareProgramPluginRequirements>(
+		client: T,
+	): ExtendedClient<
+		T,
+		{ anchorDeclareProgram: AnchorDeclareProgramPlugin }
+	> => {
+		return extendClient(client, {
 			anchorDeclareProgram: <AnchorDeclareProgramPlugin> {
 				instructions: {
 					validateExternalProgram: (input) =>
@@ -113,7 +121,9 @@ export function anchorDeclareProgramProgram() {
 							getValidateExternalProgramInstruction(input),
 						),
 				},
+				identifyInstruction: identifyAnchorDeclareProgramInstruction,
+				parseInstruction: parseAnchorDeclareProgramInstruction,
 			},
-		};
+		});
 	};
 }

--- a/codama/clients/js/anchor_duplicate_mutable_accounts/package.json
+++ b/codama/clients/js/anchor_duplicate_mutable_accounts/package.json
@@ -9,9 +9,9 @@
 	"keywords": [],
 	"author": "",
 	"peerDependencies": {
-		"@solana/kit": "^6.1.0"
+		"@solana/kit": "^6.10.0"
 	},
 	"dependencies": {
-		"@solana/program-client-core": "^6.1.0"
+		"@solana/program-client-core": "^6.10.0"
 	}
 }

--- a/codama/clients/js/anchor_duplicate_mutable_accounts/src/generated/errors/anchorDuplicateMutableAccounts.ts
+++ b/codama/clients/js/anchor_duplicate_mutable_accounts/src/generated/errors/anchorDuplicateMutableAccounts.ts
@@ -23,7 +23,7 @@ export type AnchorDuplicateMutableAccountsError =
 let anchorDuplicateMutableAccountsErrorMessages:
 	| Record<AnchorDuplicateMutableAccountsError, string>
 	| undefined;
-if (process.env.NODE_ENV !== "production") {
+if (process.env["NODE_ENV"] !== "production") {
 	anchorDuplicateMutableAccountsErrorMessages = {
 		[ANCHOR_DUPLICATE_MUTABLE_ACCOUNTS_ERROR__CONSTRAINT_DUPLICATE_MUTABLE_ACCOUNT]:
 			``,
@@ -33,7 +33,7 @@ if (process.env.NODE_ENV !== "production") {
 export function getAnchorDuplicateMutableAccountsErrorMessage(
 	code: AnchorDuplicateMutableAccountsError,
 ): string {
-	if (process.env.NODE_ENV !== "production") {
+	if (process.env["NODE_ENV"] !== "production") {
 		return (anchorDuplicateMutableAccountsErrorMessages as Record<
 			AnchorDuplicateMutableAccountsError,
 			string

--- a/codama/clients/js/anchor_duplicate_mutable_accounts/src/generated/instructions/allowsDuplicateMutable.ts
+++ b/codama/clients/js/anchor_duplicate_mutable_accounts/src/generated/instructions/allowsDuplicateMutable.ts
@@ -12,12 +12,13 @@ import {
 	getU8Encoder,
 	type Instruction,
 	type InstructionWithAccounts,
+	type ReadonlyUint8Array,
 } from "@solana/kit";
 import { ANCHOR_DUPLICATE_MUTABLE_ACCOUNTS_PROGRAM_ADDRESS } from "../programs";
 
 export const ALLOWS_DUPLICATE_MUTABLE_DISCRIMINATOR = 1;
 
-export function getAllowsDuplicateMutableDiscriminatorBytes() {
+export function getAllowsDuplicateMutableDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(ALLOWS_DUPLICATE_MUTABLE_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/anchor_duplicate_mutable_accounts/src/generated/instructions/allowsDuplicateReadonly.ts
+++ b/codama/clients/js/anchor_duplicate_mutable_accounts/src/generated/instructions/allowsDuplicateReadonly.ts
@@ -13,6 +13,7 @@ import {
 	type Instruction,
 	type InstructionWithAccounts,
 	type ReadonlyAccount,
+	type ReadonlyUint8Array,
 	SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
 	SolanaError,
 } from "@solana/kit";
@@ -24,7 +25,7 @@ import { ANCHOR_DUPLICATE_MUTABLE_ACCOUNTS_PROGRAM_ADDRESS } from "../programs";
 
 export const ALLOWS_DUPLICATE_READONLY_DISCRIMINATOR = 2;
 
-export function getAllowsDuplicateReadonlyDiscriminatorBytes() {
+export function getAllowsDuplicateReadonlyDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(ALLOWS_DUPLICATE_READONLY_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/anchor_duplicate_mutable_accounts/src/generated/instructions/failsDuplicateMutable.ts
+++ b/codama/clients/js/anchor_duplicate_mutable_accounts/src/generated/instructions/failsDuplicateMutable.ts
@@ -12,6 +12,7 @@ import {
 	getU8Encoder,
 	type Instruction,
 	type InstructionWithAccounts,
+	type ReadonlyUint8Array,
 	SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
 	SolanaError,
 	type WritableAccount,
@@ -24,7 +25,7 @@ import { ANCHOR_DUPLICATE_MUTABLE_ACCOUNTS_PROGRAM_ADDRESS } from "../programs";
 
 export const FAILS_DUPLICATE_MUTABLE_DISCRIMINATOR = 0;
 
-export function getFailsDuplicateMutableDiscriminatorBytes() {
+export function getFailsDuplicateMutableDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(FAILS_DUPLICATE_MUTABLE_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/anchor_duplicate_mutable_accounts/src/generated/programs/anchorDuplicateMutableAccounts.ts
+++ b/codama/clients/js/anchor_duplicate_mutable_accounts/src/generated/programs/anchorDuplicateMutableAccounts.ts
@@ -12,6 +12,8 @@ import {
 	type ClientWithTransactionPlanning,
 	type ClientWithTransactionSending,
 	containsBytes,
+	extendClient,
+	type ExtendedClient,
 	getU8Encoder,
 	type Instruction,
 	type InstructionWithData,
@@ -132,6 +134,8 @@ export function parseAnchorDuplicateMutableAccountsInstruction<
 
 export type AnchorDuplicateMutableAccountsPlugin = {
 	instructions: AnchorDuplicateMutableAccountsPluginInstructions;
+	identifyInstruction: typeof identifyAnchorDuplicateMutableAccountsInstruction;
+	parseInstruction: typeof parseAnchorDuplicateMutableAccountsInstruction;
 };
 
 export type AnchorDuplicateMutableAccountsPluginInstructions = {
@@ -159,9 +163,11 @@ export type AnchorDuplicateMutableAccountsPluginRequirements =
 export function anchorDuplicateMutableAccountsProgram() {
 	return <T extends AnchorDuplicateMutableAccountsPluginRequirements>(
 		client: T,
-	) => {
-		return {
-			...client,
+	): ExtendedClient<
+		T,
+		{ anchorDuplicateMutableAccounts: AnchorDuplicateMutableAccountsPlugin }
+	> => {
+		return extendClient(client, {
 			anchorDuplicateMutableAccounts: <AnchorDuplicateMutableAccountsPlugin> {
 				instructions: {
 					failsDuplicateMutable: (input) =>
@@ -180,7 +186,9 @@ export function anchorDuplicateMutableAccountsProgram() {
 							getAllowsDuplicateReadonlyInstruction(input),
 						),
 				},
+				identifyInstruction: identifyAnchorDuplicateMutableAccountsInstruction,
+				parseInstruction: parseAnchorDuplicateMutableAccountsInstruction,
 			},
-		};
+		});
 	};
 }

--- a/codama/clients/js/anchor_errors/package.json
+++ b/codama/clients/js/anchor_errors/package.json
@@ -9,9 +9,9 @@
 	"keywords": [],
 	"author": "",
 	"peerDependencies": {
-		"@solana/kit": "^6.1.0"
+		"@solana/kit": "^6.10.0"
 	},
 	"dependencies": {
-		"@solana/program-client-core": "^6.1.0"
+		"@solana/program-client-core": "^6.10.0"
 	}
 }

--- a/codama/clients/js/anchor_errors/src/generated/errors/anchorErrors.ts
+++ b/codama/clients/js/anchor_errors/src/generated/errors/anchorErrors.ts
@@ -34,7 +34,7 @@ export type AnchorErrorsError =
 	| typeof ANCHOR_ERRORS_ERROR__VALUE_MISMATCH;
 
 let anchorErrorsErrorMessages: Record<AnchorErrorsError, string> | undefined;
-if (process.env.NODE_ENV !== "production") {
+if (process.env["NODE_ENV"] !== "production") {
 	anchorErrorsErrorMessages = {
 		[ANCHOR_ERRORS_ERROR__HELLO]: ``,
 		[ANCHOR_ERRORS_ERROR__HELLO_CUSTOM]: ``,
@@ -48,7 +48,7 @@ if (process.env.NODE_ENV !== "production") {
 }
 
 export function getAnchorErrorsErrorMessage(code: AnchorErrorsError): string {
-	if (process.env.NODE_ENV !== "production") {
+	if (process.env["NODE_ENV"] !== "production") {
 		return (anchorErrorsErrorMessages as Record<AnchorErrorsError, string>)[
 			code
 		];

--- a/codama/clients/js/anchor_errors/src/generated/instructions/hello.ts
+++ b/codama/clients/js/anchor_errors/src/generated/instructions/hello.ts
@@ -12,12 +12,13 @@ import {
 	getU8Encoder,
 	type Instruction,
 	type InstructionWithAccounts,
+	type ReadonlyUint8Array,
 } from "@solana/kit";
 import { ANCHOR_ERRORS_PROGRAM_ADDRESS } from "../programs";
 
 export const HELLO_DISCRIMINATOR = 0;
 
-export function getHelloDiscriminatorBytes() {
+export function getHelloDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(HELLO_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/anchor_errors/src/generated/instructions/helloNext.ts
+++ b/codama/clients/js/anchor_errors/src/generated/instructions/helloNext.ts
@@ -12,12 +12,13 @@ import {
 	getU8Encoder,
 	type Instruction,
 	type InstructionWithAccounts,
+	type ReadonlyUint8Array,
 } from "@solana/kit";
 import { ANCHOR_ERRORS_PROGRAM_ADDRESS } from "../programs";
 
 export const HELLO_NEXT_DISCRIMINATOR = 2;
 
-export function getHelloNextDiscriminatorBytes() {
+export function getHelloNextDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(HELLO_NEXT_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/anchor_errors/src/generated/instructions/helloNoMsg.ts
+++ b/codama/clients/js/anchor_errors/src/generated/instructions/helloNoMsg.ts
@@ -12,12 +12,13 @@ import {
 	getU8Encoder,
 	type Instruction,
 	type InstructionWithAccounts,
+	type ReadonlyUint8Array,
 } from "@solana/kit";
 import { ANCHOR_ERRORS_PROGRAM_ADDRESS } from "../programs";
 
 export const HELLO_NO_MSG_DISCRIMINATOR = 1;
 
-export function getHelloNoMsgDiscriminatorBytes() {
+export function getHelloNoMsgDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(HELLO_NO_MSG_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/anchor_errors/src/generated/instructions/requireEq.ts
+++ b/codama/clients/js/anchor_errors/src/generated/instructions/requireEq.ts
@@ -12,12 +12,13 @@ import {
 	getU8Encoder,
 	type Instruction,
 	type InstructionWithAccounts,
+	type ReadonlyUint8Array,
 } from "@solana/kit";
 import { ANCHOR_ERRORS_PROGRAM_ADDRESS } from "../programs";
 
 export const REQUIRE_EQ_DISCRIMINATOR = 3;
 
-export function getRequireEqDiscriminatorBytes() {
+export function getRequireEqDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(REQUIRE_EQ_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/anchor_errors/src/generated/instructions/requireGt.ts
+++ b/codama/clients/js/anchor_errors/src/generated/instructions/requireGt.ts
@@ -12,12 +12,13 @@ import {
 	getU8Encoder,
 	type Instruction,
 	type InstructionWithAccounts,
+	type ReadonlyUint8Array,
 } from "@solana/kit";
 import { ANCHOR_ERRORS_PROGRAM_ADDRESS } from "../programs";
 
 export const REQUIRE_GT_DISCRIMINATOR = 5;
 
-export function getRequireGtDiscriminatorBytes() {
+export function getRequireGtDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(REQUIRE_GT_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/anchor_errors/src/generated/instructions/requireGte.ts
+++ b/codama/clients/js/anchor_errors/src/generated/instructions/requireGte.ts
@@ -12,12 +12,13 @@ import {
 	getU8Encoder,
 	type Instruction,
 	type InstructionWithAccounts,
+	type ReadonlyUint8Array,
 } from "@solana/kit";
 import { ANCHOR_ERRORS_PROGRAM_ADDRESS } from "../programs";
 
 export const REQUIRE_GTE_DISCRIMINATOR = 6;
 
-export function getRequireGteDiscriminatorBytes() {
+export function getRequireGteDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(REQUIRE_GTE_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/anchor_errors/src/generated/instructions/requireNeq.ts
+++ b/codama/clients/js/anchor_errors/src/generated/instructions/requireNeq.ts
@@ -12,12 +12,13 @@ import {
 	getU8Encoder,
 	type Instruction,
 	type InstructionWithAccounts,
+	type ReadonlyUint8Array,
 } from "@solana/kit";
 import { ANCHOR_ERRORS_PROGRAM_ADDRESS } from "../programs";
 
 export const REQUIRE_NEQ_DISCRIMINATOR = 4;
 
-export function getRequireNeqDiscriminatorBytes() {
+export function getRequireNeqDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(REQUIRE_NEQ_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/anchor_errors/src/generated/programs/anchorErrors.ts
+++ b/codama/clients/js/anchor_errors/src/generated/programs/anchorErrors.ts
@@ -11,6 +11,8 @@ import {
 	type ClientWithTransactionPlanning,
 	type ClientWithTransactionSending,
 	containsBytes,
+	extendClient,
+	type ExtendedClient,
 	getU8Encoder,
 	type Instruction,
 	type InstructionWithData,
@@ -180,6 +182,8 @@ export function parseAnchorErrorsInstruction<TProgram extends string>(
 
 export type AnchorErrorsPlugin = {
 	instructions: AnchorErrorsPluginInstructions;
+	identifyInstruction: typeof identifyAnchorErrorsInstruction;
+	parseInstruction: typeof parseAnchorErrorsInstruction;
 };
 
 export type AnchorErrorsPluginInstructions = {
@@ -211,9 +215,10 @@ export type AnchorErrorsPluginRequirements =
 	& ClientWithTransactionSending;
 
 export function anchorErrorsProgram() {
-	return <T extends AnchorErrorsPluginRequirements>(client: T) => {
-		return {
-			...client,
+	return <T extends AnchorErrorsPluginRequirements>(
+		client: T,
+	): ExtendedClient<T, { anchorErrors: AnchorErrorsPlugin }> => {
+		return extendClient(client, {
 			anchorErrors: <AnchorErrorsPlugin> {
 				instructions: {
 					hello: (input) =>
@@ -240,7 +245,9 @@ export function anchorErrorsProgram() {
 							getRequireGteInstruction(input),
 						),
 				},
+				identifyInstruction: identifyAnchorErrorsInstruction,
+				parseInstruction: parseAnchorErrorsInstruction,
 			},
-		};
+		});
 	};
 }

--- a/codama/clients/js/anchor_events/package.json
+++ b/codama/clients/js/anchor_events/package.json
@@ -9,9 +9,9 @@
 	"keywords": [],
 	"author": "",
 	"peerDependencies": {
-		"@solana/kit": "^6.1.0"
+		"@solana/kit": "^6.10.0"
 	},
 	"dependencies": {
-		"@solana/program-client-core": "^6.1.0"
+		"@solana/program-client-core": "^6.10.0"
 	}
 }

--- a/codama/clients/js/anchor_events/src/generated/instructions/initialize.ts
+++ b/codama/clients/js/anchor_events/src/generated/instructions/initialize.ts
@@ -12,12 +12,13 @@ import {
 	getU8Encoder,
 	type Instruction,
 	type InstructionWithAccounts,
+	type ReadonlyUint8Array,
 } from "@solana/kit";
 import { ANCHOR_EVENTS_PROGRAM_ADDRESS } from "../programs";
 
 export const INITIALIZE_DISCRIMINATOR = 0;
 
-export function getInitializeDiscriminatorBytes() {
+export function getInitializeDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(INITIALIZE_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/anchor_events/src/generated/instructions/testEvent.ts
+++ b/codama/clients/js/anchor_events/src/generated/instructions/testEvent.ts
@@ -12,12 +12,13 @@ import {
 	getU8Encoder,
 	type Instruction,
 	type InstructionWithAccounts,
+	type ReadonlyUint8Array,
 } from "@solana/kit";
 import { ANCHOR_EVENTS_PROGRAM_ADDRESS } from "../programs";
 
 export const TEST_EVENT_DISCRIMINATOR = 1;
 
-export function getTestEventDiscriminatorBytes() {
+export function getTestEventDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(TEST_EVENT_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/anchor_events/src/generated/instructions/testEventCpi.ts
+++ b/codama/clients/js/anchor_events/src/generated/instructions/testEventCpi.ts
@@ -12,12 +12,13 @@ import {
 	getU8Encoder,
 	type Instruction,
 	type InstructionWithAccounts,
+	type ReadonlyUint8Array,
 } from "@solana/kit";
 import { ANCHOR_EVENTS_PROGRAM_ADDRESS } from "../programs";
 
 export const TEST_EVENT_CPI_DISCRIMINATOR = 2;
 
-export function getTestEventCpiDiscriminatorBytes() {
+export function getTestEventCpiDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(TEST_EVENT_CPI_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/anchor_events/src/generated/programs/anchorEvents.ts
+++ b/codama/clients/js/anchor_events/src/generated/programs/anchorEvents.ts
@@ -11,6 +11,8 @@ import {
 	type ClientWithTransactionPlanning,
 	type ClientWithTransactionSending,
 	containsBytes,
+	extendClient,
+	type ExtendedClient,
 	getU8Encoder,
 	type Instruction,
 	type InstructionWithData,
@@ -116,6 +118,8 @@ export function parseAnchorEventsInstruction<TProgram extends string>(
 
 export type AnchorEventsPlugin = {
 	instructions: AnchorEventsPluginInstructions;
+	identifyInstruction: typeof identifyAnchorEventsInstruction;
+	parseInstruction: typeof parseAnchorEventsInstruction;
 };
 
 export type AnchorEventsPluginInstructions = {
@@ -135,9 +139,10 @@ export type AnchorEventsPluginRequirements =
 	& ClientWithTransactionSending;
 
 export function anchorEventsProgram() {
-	return <T extends AnchorEventsPluginRequirements>(client: T) => {
-		return {
-			...client,
+	return <T extends AnchorEventsPluginRequirements>(
+		client: T,
+	): ExtendedClient<T, { anchorEvents: AnchorEventsPlugin }> => {
+		return extendClient(client, {
 			anchorEvents: <AnchorEventsPlugin> {
 				instructions: {
 					initialize: (input) =>
@@ -153,7 +158,9 @@ export function anchorEventsProgram() {
 							getTestEventCpiInstruction(input),
 						),
 				},
+				identifyInstruction: identifyAnchorEventsInstruction,
+				parseInstruction: parseAnchorEventsInstruction,
 			},
-		};
+		});
 	};
 }

--- a/codama/clients/js/anchor_floats/package.json
+++ b/codama/clients/js/anchor_floats/package.json
@@ -9,9 +9,9 @@
 	"keywords": [],
 	"author": "",
 	"peerDependencies": {
-		"@solana/kit": "^6.1.0"
+		"@solana/kit": "^6.10.0"
 	},
 	"dependencies": {
-		"@solana/program-client-core": "^6.1.0"
+		"@solana/program-client-core": "^6.10.0"
 	}
 }

--- a/codama/clients/js/anchor_floats/src/generated/accounts/floatDataAccount.ts
+++ b/codama/clients/js/anchor_floats/src/generated/accounts/floatDataAccount.ts
@@ -32,11 +32,12 @@ import {
 	getU8Encoder,
 	type MaybeAccount,
 	type MaybeEncodedAccount,
+	type ReadonlyUint8Array,
 } from "@solana/kit";
 
 export const FLOAT_DATA_ACCOUNT_DISCRIMINATOR = 1;
 
-export function getFloatDataAccountDiscriminatorBytes() {
+export function getFloatDataAccountDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(FLOAT_DATA_ACCOUNT_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/anchor_floats/src/generated/errors/anchorFloats.ts
+++ b/codama/clients/js/anchor_floats/src/generated/errors/anchorFloats.ts
@@ -19,12 +19,12 @@ export const ANCHOR_FLOATS_ERROR__AUTHORITY_MISMATCH = 0x0; // 0
 export type AnchorFloatsError = typeof ANCHOR_FLOATS_ERROR__AUTHORITY_MISMATCH;
 
 let anchorFloatsErrorMessages: Record<AnchorFloatsError, string> | undefined;
-if (process.env.NODE_ENV !== "production") {
+if (process.env["NODE_ENV"] !== "production") {
 	anchorFloatsErrorMessages = { [ANCHOR_FLOATS_ERROR__AUTHORITY_MISMATCH]: `` };
 }
 
 export function getAnchorFloatsErrorMessage(code: AnchorFloatsError): string {
-	if (process.env.NODE_ENV !== "production") {
+	if (process.env["NODE_ENV"] !== "production") {
 		return (anchorFloatsErrorMessages as Record<AnchorFloatsError, string>)[
 			code
 		];

--- a/codama/clients/js/anchor_floats/src/generated/instructions/create.ts
+++ b/codama/clients/js/anchor_floats/src/generated/instructions/create.ts
@@ -40,7 +40,7 @@ import { ANCHOR_FLOATS_PROGRAM_ADDRESS } from "../programs";
 
 export const CREATE_DISCRIMINATOR = 0;
 
-export function getCreateDiscriminatorBytes() {
+export function getCreateDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(CREATE_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/anchor_floats/src/generated/instructions/update.ts
+++ b/codama/clients/js/anchor_floats/src/generated/instructions/update.ts
@@ -39,7 +39,7 @@ import { ANCHOR_FLOATS_PROGRAM_ADDRESS } from "../programs";
 
 export const UPDATE_DISCRIMINATOR = 1;
 
-export function getUpdateDiscriminatorBytes() {
+export function getUpdateDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(UPDATE_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/anchor_floats/src/generated/programs/anchorFloats.ts
+++ b/codama/clients/js/anchor_floats/src/generated/programs/anchorFloats.ts
@@ -13,6 +13,8 @@ import {
 	type ClientWithTransactionPlanning,
 	type ClientWithTransactionSending,
 	containsBytes,
+	extendClient,
+	type ExtendedClient,
 	type GetAccountInfoApi,
 	type GetMultipleAccountsApi,
 	getU8Encoder,
@@ -132,6 +134,9 @@ export function parseAnchorFloatsInstruction<TProgram extends string>(
 export type AnchorFloatsPlugin = {
 	accounts: AnchorFloatsPluginAccounts;
 	instructions: AnchorFloatsPluginInstructions;
+	identifyAccount: typeof identifyAnchorFloatsAccount;
+	identifyInstruction: typeof identifyAnchorFloatsInstruction;
+	parseInstruction: typeof parseAnchorFloatsInstruction;
 };
 
 export type AnchorFloatsPluginAccounts = {
@@ -155,9 +160,10 @@ export type AnchorFloatsPluginRequirements =
 	& ClientWithTransactionSending;
 
 export function anchorFloatsProgram() {
-	return <T extends AnchorFloatsPluginRequirements>(client: T) => {
-		return {
-			...client,
+	return <T extends AnchorFloatsPluginRequirements>(
+		client: T,
+	): ExtendedClient<T, { anchorFloats: AnchorFloatsPlugin }> => {
+		return extendClient(client, {
 			anchorFloats: <AnchorFloatsPlugin> {
 				accounts: {
 					floatDataAccount: addSelfFetchFunctions(
@@ -171,7 +177,10 @@ export function anchorFloatsProgram() {
 					update: (input) =>
 						addSelfPlanAndSendFunctions(client, getUpdateInstruction(input)),
 				},
+				identifyAccount: identifyAnchorFloatsAccount,
+				identifyInstruction: identifyAnchorFloatsInstruction,
+				parseInstruction: parseAnchorFloatsInstruction,
 			},
-		};
+		});
 	};
 }

--- a/codama/clients/js/anchor_realloc/package.json
+++ b/codama/clients/js/anchor_realloc/package.json
@@ -9,9 +9,9 @@
 	"keywords": [],
 	"author": "",
 	"peerDependencies": {
-		"@solana/kit": "^6.1.0"
+		"@solana/kit": "^6.10.0"
 	},
 	"dependencies": {
-		"@solana/program-client-core": "^6.1.0"
+		"@solana/program-client-core": "^6.10.0"
 	}
 }

--- a/codama/clients/js/anchor_realloc/src/generated/errors/anchorRealloc.ts
+++ b/codama/clients/js/anchor_realloc/src/generated/errors/anchorRealloc.ts
@@ -22,7 +22,7 @@ export type AnchorReallocError =
 	| typeof ANCHOR_REALLOC_ERROR__ACCOUNT_REALLOC_EXCEEDS_LIMIT;
 
 let anchorReallocErrorMessages: Record<AnchorReallocError, string> | undefined;
-if (process.env.NODE_ENV !== "production") {
+if (process.env["NODE_ENV"] !== "production") {
 	anchorReallocErrorMessages = {
 		[ANCHOR_REALLOC_ERROR__ACCOUNT_DUPLICATE_REALLOCS]: ``,
 		[ANCHOR_REALLOC_ERROR__ACCOUNT_REALLOC_EXCEEDS_LIMIT]: ``,
@@ -30,7 +30,7 @@ if (process.env.NODE_ENV !== "production") {
 }
 
 export function getAnchorReallocErrorMessage(code: AnchorReallocError): string {
-	if (process.env.NODE_ENV !== "production") {
+	if (process.env["NODE_ENV"] !== "production") {
 		return (anchorReallocErrorMessages as Record<AnchorReallocError, string>)[
 			code
 		];

--- a/codama/clients/js/anchor_realloc/src/generated/instructions/realloc.ts
+++ b/codama/clients/js/anchor_realloc/src/generated/instructions/realloc.ts
@@ -38,7 +38,7 @@ import { ANCHOR_REALLOC_PROGRAM_ADDRESS } from "../programs";
 
 export const REALLOC_DISCRIMINATOR = 0;
 
-export function getReallocDiscriminatorBytes() {
+export function getReallocDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(REALLOC_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/anchor_realloc/src/generated/instructions/realloc2.ts
+++ b/codama/clients/js/anchor_realloc/src/generated/instructions/realloc2.ts
@@ -38,7 +38,7 @@ import { ANCHOR_REALLOC_PROGRAM_ADDRESS } from "../programs";
 
 export const REALLOC2_DISCRIMINATOR = 1;
 
-export function getRealloc2DiscriminatorBytes() {
+export function getRealloc2DiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(REALLOC2_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/anchor_realloc/src/generated/programs/anchorRealloc.ts
+++ b/codama/clients/js/anchor_realloc/src/generated/programs/anchorRealloc.ts
@@ -12,6 +12,8 @@ import {
 	type ClientWithTransactionPlanning,
 	type ClientWithTransactionSending,
 	containsBytes,
+	extendClient,
+	type ExtendedClient,
 	getU8Encoder,
 	type Instruction,
 	type InstructionWithData,
@@ -103,6 +105,8 @@ export function parseAnchorReallocInstruction<TProgram extends string>(
 
 export type AnchorReallocPlugin = {
 	instructions: AnchorReallocPluginInstructions;
+	identifyInstruction: typeof identifyAnchorReallocInstruction;
+	parseInstruction: typeof parseAnchorReallocInstruction;
 };
 
 export type AnchorReallocPluginInstructions = {
@@ -119,9 +123,10 @@ export type AnchorReallocPluginRequirements =
 	& ClientWithTransactionSending;
 
 export function anchorReallocProgram() {
-	return <T extends AnchorReallocPluginRequirements>(client: T) => {
-		return {
-			...client,
+	return <T extends AnchorReallocPluginRequirements>(
+		client: T,
+	): ExtendedClient<T, { anchorRealloc: AnchorReallocPlugin }> => {
+		return extendClient(client, {
 			anchorRealloc: <AnchorReallocPlugin> {
 				instructions: {
 					realloc: (input) =>
@@ -129,7 +134,9 @@ export function anchorReallocProgram() {
 					realloc2: (input) =>
 						addSelfPlanAndSendFunctions(client, getRealloc2Instruction(input)),
 				},
+				identifyInstruction: identifyAnchorReallocInstruction,
+				parseInstruction: parseAnchorReallocInstruction,
 			},
-		};
+		});
 	};
 }

--- a/codama/clients/js/anchor_system_accounts/package.json
+++ b/codama/clients/js/anchor_system_accounts/package.json
@@ -9,9 +9,9 @@
 	"keywords": [],
 	"author": "",
 	"peerDependencies": {
-		"@solana/kit": "^6.1.0"
+		"@solana/kit": "^6.10.0"
 	},
 	"dependencies": {
-		"@solana/program-client-core": "^6.1.0"
+		"@solana/program-client-core": "^6.10.0"
 	}
 }

--- a/codama/clients/js/anchor_system_accounts/src/generated/instructions/initialize.ts
+++ b/codama/clients/js/anchor_system_accounts/src/generated/instructions/initialize.ts
@@ -15,6 +15,7 @@ import {
 	type InstructionWithAccounts,
 	type ReadonlyAccount,
 	type ReadonlySignerAccount,
+	type ReadonlyUint8Array,
 	SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
 	SolanaError,
 	type TransactionSigner,
@@ -27,7 +28,7 @@ import { ANCHOR_SYSTEM_ACCOUNTS_PROGRAM_ADDRESS } from "../programs";
 
 export const INITIALIZE_DISCRIMINATOR = 0;
 
-export function getInitializeDiscriminatorBytes() {
+export function getInitializeDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(INITIALIZE_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/anchor_system_accounts/src/generated/programs/anchorSystemAccounts.ts
+++ b/codama/clients/js/anchor_system_accounts/src/generated/programs/anchorSystemAccounts.ts
@@ -12,6 +12,8 @@ import {
 	type ClientWithTransactionPlanning,
 	type ClientWithTransactionSending,
 	containsBytes,
+	extendClient,
+	type ExtendedClient,
 	getU8Encoder,
 	type Instruction,
 	type InstructionWithData,
@@ -86,6 +88,8 @@ export function parseAnchorSystemAccountsInstruction<TProgram extends string>(
 
 export type AnchorSystemAccountsPlugin = {
 	instructions: AnchorSystemAccountsPluginInstructions;
+	identifyInstruction: typeof identifyAnchorSystemAccountsInstruction;
+	parseInstruction: typeof parseAnchorSystemAccountsInstruction;
 };
 
 export type AnchorSystemAccountsPluginInstructions = {
@@ -99,9 +103,13 @@ export type AnchorSystemAccountsPluginRequirements =
 	& ClientWithTransactionSending;
 
 export function anchorSystemAccountsProgram() {
-	return <T extends AnchorSystemAccountsPluginRequirements>(client: T) => {
-		return {
-			...client,
+	return <T extends AnchorSystemAccountsPluginRequirements>(
+		client: T,
+	): ExtendedClient<
+		T,
+		{ anchorSystemAccounts: AnchorSystemAccountsPlugin }
+	> => {
+		return extendClient(client, {
 			anchorSystemAccounts: <AnchorSystemAccountsPlugin> {
 				instructions: {
 					initialize: (input) =>
@@ -110,7 +118,9 @@ export function anchorSystemAccountsProgram() {
 							getInitializeInstruction(input),
 						),
 				},
+				identifyInstruction: identifyAnchorSystemAccountsInstruction,
+				parseInstruction: parseAnchorSystemAccountsInstruction,
 			},
-		};
+		});
 	};
 }

--- a/codama/clients/js/anchor_sysvars/package.json
+++ b/codama/clients/js/anchor_sysvars/package.json
@@ -9,9 +9,9 @@
 	"keywords": [],
 	"author": "",
 	"peerDependencies": {
-		"@solana/kit": "^6.1.0"
+		"@solana/kit": "^6.10.0"
 	},
 	"dependencies": {
-		"@solana/program-client-core": "^6.1.0"
+		"@solana/program-client-core": "^6.10.0"
 	}
 }

--- a/codama/clients/js/anchor_sysvars/src/generated/instructions/sysvars.ts
+++ b/codama/clients/js/anchor_sysvars/src/generated/instructions/sysvars.ts
@@ -13,6 +13,7 @@ import {
 	type Instruction,
 	type InstructionWithAccounts,
 	type ReadonlyAccount,
+	type ReadonlyUint8Array,
 	SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
 	SolanaError,
 } from "@solana/kit";
@@ -24,7 +25,7 @@ import { ANCHOR_SYSVARS_PROGRAM_ADDRESS } from "../programs";
 
 export const SYSVARS_DISCRIMINATOR = 0;
 
-export function getSysvarsDiscriminatorBytes() {
+export function getSysvarsDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(SYSVARS_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/anchor_sysvars/src/generated/programs/anchorSysvars.ts
+++ b/codama/clients/js/anchor_sysvars/src/generated/programs/anchorSysvars.ts
@@ -12,6 +12,8 @@ import {
 	type ClientWithTransactionPlanning,
 	type ClientWithTransactionSending,
 	containsBytes,
+	extendClient,
+	type ExtendedClient,
 	getU8Encoder,
 	type Instruction,
 	type InstructionWithData,
@@ -86,6 +88,8 @@ export function parseAnchorSysvarsInstruction<TProgram extends string>(
 
 export type AnchorSysvarsPlugin = {
 	instructions: AnchorSysvarsPluginInstructions;
+	identifyInstruction: typeof identifyAnchorSysvarsInstruction;
+	parseInstruction: typeof parseAnchorSysvarsInstruction;
 };
 
 export type AnchorSysvarsPluginInstructions = {
@@ -99,15 +103,18 @@ export type AnchorSysvarsPluginRequirements =
 	& ClientWithTransactionSending;
 
 export function anchorSysvarsProgram() {
-	return <T extends AnchorSysvarsPluginRequirements>(client: T) => {
-		return {
-			...client,
+	return <T extends AnchorSysvarsPluginRequirements>(
+		client: T,
+	): ExtendedClient<T, { anchorSysvars: AnchorSysvarsPlugin }> => {
+		return extendClient(client, {
 			anchorSysvars: <AnchorSysvarsPlugin> {
 				instructions: {
 					sysvars: (input) =>
 						addSelfPlanAndSendFunctions(client, getSysvarsInstruction(input)),
 				},
+				identifyInstruction: identifyAnchorSysvarsInstruction,
+				parseInstruction: parseAnchorSysvarsInstruction,
 			},
-		};
+		});
 	};
 }

--- a/codama/clients/js/counter_program/package.json
+++ b/codama/clients/js/counter_program/package.json
@@ -9,9 +9,9 @@
 	"keywords": [],
 	"author": "",
 	"peerDependencies": {
-		"@solana/kit": "^6.1.0"
+		"@solana/kit": "^6.10.0"
 	},
 	"dependencies": {
-		"@solana/program-client-core": "^6.1.0"
+		"@solana/program-client-core": "^6.10.0"
 	}
 }

--- a/codama/clients/js/counter_program/src/generated/accounts/counterState.ts
+++ b/codama/clients/js/counter_program/src/generated/accounts/counterState.ts
@@ -29,11 +29,12 @@ import {
 	getU8Encoder,
 	type MaybeAccount,
 	type MaybeEncodedAccount,
+	type ReadonlyUint8Array,
 } from "@solana/kit";
 
 export const COUNTER_STATE_DISCRIMINATOR = 1;
 
-export function getCounterStateDiscriminatorBytes() {
+export function getCounterStateDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(COUNTER_STATE_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/counter_program/src/generated/instructions/increment.ts
+++ b/codama/clients/js/counter_program/src/generated/instructions/increment.ts
@@ -14,6 +14,7 @@ import {
 	type Instruction,
 	type InstructionWithAccounts,
 	type ReadonlySignerAccount,
+	type ReadonlyUint8Array,
 	SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
 	SolanaError,
 	type TransactionSigner,
@@ -29,7 +30,7 @@ import { COUNTER_PROGRAM_PROGRAM_ADDRESS } from "../programs";
 
 export const INCREMENT_DISCRIMINATOR = 1;
 
-export function getIncrementDiscriminatorBytes() {
+export function getIncrementDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(INCREMENT_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/counter_program/src/generated/instructions/initialize.ts
+++ b/codama/clients/js/counter_program/src/generated/instructions/initialize.ts
@@ -39,7 +39,7 @@ import { COUNTER_PROGRAM_PROGRAM_ADDRESS } from "../programs";
 
 export const INITIALIZE_DISCRIMINATOR = 0;
 
-export function getInitializeDiscriminatorBytes() {
+export function getInitializeDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(INITIALIZE_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/counter_program/src/generated/programs/counterProgram.ts
+++ b/codama/clients/js/counter_program/src/generated/programs/counterProgram.ts
@@ -13,6 +13,8 @@ import {
 	type ClientWithTransactionPlanning,
 	type ClientWithTransactionSending,
 	containsBytes,
+	extendClient,
+	type ExtendedClient,
 	type GetAccountInfoApi,
 	type GetMultipleAccountsApi,
 	getU8Encoder,
@@ -134,6 +136,9 @@ export type CounterProgramPlugin = {
 	accounts: CounterProgramPluginAccounts;
 	instructions: CounterProgramPluginInstructions;
 	pdas: CounterProgramPluginPdas;
+	identifyAccount: typeof identifyCounterProgramAccount;
+	identifyInstruction: typeof identifyCounterProgramInstruction;
+	parseInstruction: typeof parseCounterProgramInstruction;
 };
 
 export type CounterProgramPluginAccounts = {
@@ -163,9 +168,10 @@ export type CounterProgramPluginRequirements =
 	& ClientWithTransactionSending;
 
 export function counterProgramProgram() {
-	return <T extends CounterProgramPluginRequirements>(client: T) => {
-		return {
-			...client,
+	return <T extends CounterProgramPluginRequirements>(
+		client: T,
+	): ExtendedClient<T, { counterProgram: CounterProgramPlugin }> => {
+		return extendClient(client, {
 			counterProgram: <CounterProgramPlugin> {
 				accounts: {
 					counterState: addSelfFetchFunctions(client, getCounterStateCodec()),
@@ -183,7 +189,10 @@ export function counterProgramProgram() {
 						),
 				},
 				pdas: { counter: findCounterPda },
+				identifyAccount: identifyCounterProgramAccount,
+				identifyInstruction: identifyCounterProgramInstruction,
+				parseInstruction: parseCounterProgramInstruction,
 			},
-		};
+		});
 	};
 }

--- a/codama/clients/js/escrow_program/package.json
+++ b/codama/clients/js/escrow_program/package.json
@@ -9,9 +9,9 @@
 	"keywords": [],
 	"author": "",
 	"peerDependencies": {
-		"@solana/kit": "^6.1.0"
+		"@solana/kit": "^6.10.0"
 	},
 	"dependencies": {
-		"@solana/program-client-core": "^6.1.0"
+		"@solana/program-client-core": "^6.10.0"
 	}
 }

--- a/codama/clients/js/escrow_program/src/generated/accounts/escrowState.ts
+++ b/codama/clients/js/escrow_program/src/generated/accounts/escrowState.ts
@@ -31,11 +31,12 @@ import {
 	getU8Encoder,
 	type MaybeAccount,
 	type MaybeEncodedAccount,
+	type ReadonlyUint8Array,
 } from "@solana/kit";
 
 export const ESCROW_STATE_DISCRIMINATOR = 1;
 
-export function getEscrowStateDiscriminatorBytes() {
+export function getEscrowStateDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(ESCROW_STATE_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/escrow_program/src/generated/errors/escrowProgram.ts
+++ b/codama/clients/js/escrow_program/src/generated/errors/escrowProgram.ts
@@ -22,7 +22,7 @@ export type EscrowProgramError =
 	| typeof ESCROW_PROGRAM_ERROR__TOKEN_ACCOUNT_MISMATCH;
 
 let escrowProgramErrorMessages: Record<EscrowProgramError, string> | undefined;
-if (process.env.NODE_ENV !== "production") {
+if (process.env["NODE_ENV"] !== "production") {
 	escrowProgramErrorMessages = {
 		[ESCROW_PROGRAM_ERROR__OFFER_KEY_MISMATCH]: ``,
 		[ESCROW_PROGRAM_ERROR__TOKEN_ACCOUNT_MISMATCH]: ``,
@@ -30,7 +30,7 @@ if (process.env.NODE_ENV !== "production") {
 }
 
 export function getEscrowProgramErrorMessage(code: EscrowProgramError): string {
-	if (process.env.NODE_ENV !== "production") {
+	if (process.env["NODE_ENV"] !== "production") {
 		return (escrowProgramErrorMessages as Record<EscrowProgramError, string>)[
 			code
 		];

--- a/codama/clients/js/escrow_program/src/generated/instructions/make.ts
+++ b/codama/clients/js/escrow_program/src/generated/instructions/make.ts
@@ -39,7 +39,7 @@ import { ESCROW_PROGRAM_PROGRAM_ADDRESS } from "../programs";
 
 export const MAKE_DISCRIMINATOR = 1;
 
-export function getMakeDiscriminatorBytes() {
+export function getMakeDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(MAKE_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/escrow_program/src/generated/instructions/take.ts
+++ b/codama/clients/js/escrow_program/src/generated/instructions/take.ts
@@ -14,6 +14,7 @@ import {
 	type Instruction,
 	type InstructionWithAccounts,
 	type ReadonlyAccount,
+	type ReadonlyUint8Array,
 	SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
 	SolanaError,
 	type TransactionSigner,
@@ -28,7 +29,7 @@ import { ESCROW_PROGRAM_PROGRAM_ADDRESS } from "../programs";
 
 export const TAKE_DISCRIMINATOR = 2;
 
-export function getTakeDiscriminatorBytes() {
+export function getTakeDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(TAKE_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/escrow_program/src/generated/programs/escrowProgram.ts
+++ b/codama/clients/js/escrow_program/src/generated/programs/escrowProgram.ts
@@ -13,6 +13,8 @@ import {
 	type ClientWithTransactionPlanning,
 	type ClientWithTransactionSending,
 	containsBytes,
+	extendClient,
+	type ExtendedClient,
 	type GetAccountInfoApi,
 	type GetMultipleAccountsApi,
 	getU8Encoder,
@@ -134,6 +136,9 @@ export type EscrowProgramPlugin = {
 	accounts: EscrowProgramPluginAccounts;
 	instructions: EscrowProgramPluginInstructions;
 	pdas: EscrowProgramPluginPdas;
+	identifyAccount: typeof identifyEscrowProgramAccount;
+	identifyInstruction: typeof identifyEscrowProgramInstruction;
+	parseInstruction: typeof parseEscrowProgramInstruction;
 };
 
 export type EscrowProgramPluginAccounts = {
@@ -159,9 +164,10 @@ export type EscrowProgramPluginRequirements =
 	& ClientWithTransactionSending;
 
 export function escrowProgramProgram() {
-	return <T extends EscrowProgramPluginRequirements>(client: T) => {
-		return {
-			...client,
+	return <T extends EscrowProgramPluginRequirements>(
+		client: T,
+	): ExtendedClient<T, { escrowProgram: EscrowProgramPlugin }> => {
+		return extendClient(client, {
 			escrowProgram: <EscrowProgramPlugin> {
 				accounts: {
 					escrowState: addSelfFetchFunctions(client, getEscrowStateCodec()),
@@ -173,7 +179,10 @@ export function escrowProgramProgram() {
 						addSelfPlanAndSendFunctions(client, getTakeInstruction(input)),
 				},
 				pdas: { escrow: findEscrowPda },
+				identifyAccount: identifyEscrowProgramAccount,
+				identifyInstruction: identifyEscrowProgramInstruction,
+				parseInstruction: parseEscrowProgramInstruction,
 			},
-		};
+		});
 	};
 }

--- a/codama/clients/js/hello_solana/package.json
+++ b/codama/clients/js/hello_solana/package.json
@@ -9,9 +9,9 @@
 	"keywords": [],
 	"author": "",
 	"peerDependencies": {
-		"@solana/kit": "^6.1.0"
+		"@solana/kit": "^6.10.0"
 	},
 	"dependencies": {
-		"@solana/program-client-core": "^6.1.0"
+		"@solana/program-client-core": "^6.10.0"
 	}
 }

--- a/codama/clients/js/hello_solana/src/generated/instructions/hello.ts
+++ b/codama/clients/js/hello_solana/src/generated/instructions/hello.ts
@@ -14,6 +14,7 @@ import {
 	type Instruction,
 	type InstructionWithAccounts,
 	type ReadonlySignerAccount,
+	type ReadonlyUint8Array,
 	SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
 	SolanaError,
 	type TransactionSigner,
@@ -26,7 +27,7 @@ import { HELLO_SOLANA_PROGRAM_ADDRESS } from "../programs";
 
 export const HELLO_DISCRIMINATOR = 0;
 
-export function getHelloDiscriminatorBytes() {
+export function getHelloDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(HELLO_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/hello_solana/src/generated/programs/helloSolana.ts
+++ b/codama/clients/js/hello_solana/src/generated/programs/helloSolana.ts
@@ -12,6 +12,8 @@ import {
 	type ClientWithTransactionPlanning,
 	type ClientWithTransactionSending,
 	containsBytes,
+	extendClient,
+	type ExtendedClient,
 	getU8Encoder,
 	type Instruction,
 	type InstructionWithData,
@@ -84,7 +86,11 @@ export function parseHelloSolanaInstruction<TProgram extends string>(
 	}
 }
 
-export type HelloSolanaPlugin = { instructions: HelloSolanaPluginInstructions };
+export type HelloSolanaPlugin = {
+	instructions: HelloSolanaPluginInstructions;
+	identifyInstruction: typeof identifyHelloSolanaInstruction;
+	parseInstruction: typeof parseHelloSolanaInstruction;
+};
 
 export type HelloSolanaPluginInstructions = {
 	hello: (
@@ -97,15 +103,18 @@ export type HelloSolanaPluginRequirements =
 	& ClientWithTransactionSending;
 
 export function helloSolanaProgram() {
-	return <T extends HelloSolanaPluginRequirements>(client: T) => {
-		return {
-			...client,
+	return <T extends HelloSolanaPluginRequirements>(
+		client: T,
+	): ExtendedClient<T, { helloSolana: HelloSolanaPlugin }> => {
+		return extendClient(client, {
 			helloSolana: <HelloSolanaPlugin> {
 				instructions: {
 					hello: (input) =>
 						addSelfPlanAndSendFunctions(client, getHelloInstruction(input)),
 				},
+				identifyInstruction: identifyHelloSolanaInstruction,
+				parseInstruction: parseHelloSolanaInstruction,
 			},
-		};
+		});
 	};
 }

--- a/codama/clients/js/pina_bpf/package.json
+++ b/codama/clients/js/pina_bpf/package.json
@@ -9,9 +9,9 @@
 	"keywords": [],
 	"author": "",
 	"peerDependencies": {
-		"@solana/kit": "^6.1.0"
+		"@solana/kit": "^6.10.0"
 	},
 	"dependencies": {
-		"@solana/program-client-core": "^6.1.0"
+		"@solana/program-client-core": "^6.10.0"
 	}
 }

--- a/codama/clients/js/pina_bpf/src/generated/instructions/hello.ts
+++ b/codama/clients/js/pina_bpf/src/generated/instructions/hello.ts
@@ -12,12 +12,13 @@ import {
 	getU8Encoder,
 	type Instruction,
 	type InstructionWithAccounts,
+	type ReadonlyUint8Array,
 } from "@solana/kit";
 import { PINA_BPF_PROGRAM_ADDRESS } from "../programs";
 
 export const HELLO_DISCRIMINATOR = 0;
 
-export function getHelloDiscriminatorBytes() {
+export function getHelloDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(HELLO_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/pina_bpf/src/generated/programs/pinaBpf.ts
+++ b/codama/clients/js/pina_bpf/src/generated/programs/pinaBpf.ts
@@ -11,6 +11,8 @@ import {
 	type ClientWithTransactionPlanning,
 	type ClientWithTransactionSending,
 	containsBytes,
+	extendClient,
+	type ExtendedClient,
 	getU8Encoder,
 	type Instruction,
 	type InstructionWithData,
@@ -79,7 +81,11 @@ export function parsePinaBpfInstruction<TProgram extends string>(
 	}
 }
 
-export type PinaBpfPlugin = { instructions: PinaBpfPluginInstructions };
+export type PinaBpfPlugin = {
+	instructions: PinaBpfPluginInstructions;
+	identifyInstruction: typeof identifyPinaBpfInstruction;
+	parseInstruction: typeof parsePinaBpfInstruction;
+};
 
 export type PinaBpfPluginInstructions = {
 	hello: (
@@ -92,15 +98,18 @@ export type PinaBpfPluginRequirements =
 	& ClientWithTransactionSending;
 
 export function pinaBpfProgram() {
-	return <T extends PinaBpfPluginRequirements>(client: T) => {
-		return {
-			...client,
+	return <T extends PinaBpfPluginRequirements>(
+		client: T,
+	): ExtendedClient<T, { pinaBpf: PinaBpfPlugin }> => {
+		return extendClient(client, {
 			pinaBpf: <PinaBpfPlugin> {
 				instructions: {
 					hello: (input) =>
 						addSelfPlanAndSendFunctions(client, getHelloInstruction(input)),
 				},
+				identifyInstruction: identifyPinaBpfInstruction,
+				parseInstruction: parsePinaBpfInstruction,
 			},
-		};
+		});
 	};
 }

--- a/codama/clients/js/prop_amm_program/package.json
+++ b/codama/clients/js/prop_amm_program/package.json
@@ -9,9 +9,9 @@
 	"keywords": [],
 	"author": "",
 	"peerDependencies": {
-		"@solana/kit": "^6.1.0"
+		"@solana/kit": "^6.10.0"
 	},
 	"dependencies": {
-		"@solana/program-client-core": "^6.1.0"
+		"@solana/program-client-core": "^6.10.0"
 	}
 }

--- a/codama/clients/js/prop_amm_program/src/generated/accounts/oracleState.ts
+++ b/codama/clients/js/prop_amm_program/src/generated/accounts/oracleState.ts
@@ -30,11 +30,12 @@ import {
 	getU8Encoder,
 	type MaybeAccount,
 	type MaybeEncodedAccount,
+	type ReadonlyUint8Array,
 } from "@solana/kit";
 
 export const ORACLE_STATE_DISCRIMINATOR = 1;
 
-export function getOracleStateDiscriminatorBytes() {
+export function getOracleStateDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(ORACLE_STATE_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/prop_amm_program/src/generated/errors/propAmmProgram.ts
+++ b/codama/clients/js/prop_amm_program/src/generated/errors/propAmmProgram.ts
@@ -24,7 +24,7 @@ export type PropAmmProgramError =
 let propAmmProgramErrorMessages:
 	| Record<PropAmmProgramError, string>
 	| undefined;
-if (process.env.NODE_ENV !== "production") {
+if (process.env["NODE_ENV"] !== "production") {
 	propAmmProgramErrorMessages = {
 		[PROP_AMM_PROGRAM_ERROR__UNAUTHORIZED_ORACLE_AUTHORITY]: ``,
 		[PROP_AMM_PROGRAM_ERROR__UNAUTHORIZED_UPDATE_AUTHORITY]: ``,
@@ -34,7 +34,7 @@ if (process.env.NODE_ENV !== "production") {
 export function getPropAmmProgramErrorMessage(
 	code: PropAmmProgramError,
 ): string {
-	if (process.env.NODE_ENV !== "production") {
+	if (process.env["NODE_ENV"] !== "production") {
 		return (propAmmProgramErrorMessages as Record<PropAmmProgramError, string>)[
 			code
 		];

--- a/codama/clients/js/prop_amm_program/src/generated/instructions/initialize.ts
+++ b/codama/clients/js/prop_amm_program/src/generated/instructions/initialize.ts
@@ -14,6 +14,7 @@ import {
 	type Instruction,
 	type InstructionWithAccounts,
 	type ReadonlyAccount,
+	type ReadonlyUint8Array,
 	SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
 	SolanaError,
 	type TransactionSigner,
@@ -27,7 +28,7 @@ import { PROP_AMM_PROGRAM_PROGRAM_ADDRESS } from "../programs";
 
 export const INITIALIZE_DISCRIMINATOR = 0;
 
-export function getInitializeDiscriminatorBytes() {
+export function getInitializeDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(INITIALIZE_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/prop_amm_program/src/generated/instructions/rotateAuthority.ts
+++ b/codama/clients/js/prop_amm_program/src/generated/instructions/rotateAuthority.ts
@@ -37,7 +37,7 @@ import { PROP_AMM_PROGRAM_PROGRAM_ADDRESS } from "../programs";
 
 export const ROTATE_AUTHORITY_DISCRIMINATOR = 2;
 
-export function getRotateAuthorityDiscriminatorBytes() {
+export function getRotateAuthorityDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(ROTATE_AUTHORITY_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/prop_amm_program/src/generated/instructions/update.ts
+++ b/codama/clients/js/prop_amm_program/src/generated/instructions/update.ts
@@ -37,7 +37,7 @@ import { PROP_AMM_PROGRAM_PROGRAM_ADDRESS } from "../programs";
 
 export const UPDATE_DISCRIMINATOR = 1;
 
-export function getUpdateDiscriminatorBytes() {
+export function getUpdateDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(UPDATE_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/prop_amm_program/src/generated/programs/propAmmProgram.ts
+++ b/codama/clients/js/prop_amm_program/src/generated/programs/propAmmProgram.ts
@@ -13,6 +13,8 @@ import {
 	type ClientWithTransactionPlanning,
 	type ClientWithTransactionSending,
 	containsBytes,
+	extendClient,
+	type ExtendedClient,
 	type GetAccountInfoApi,
 	type GetMultipleAccountsApi,
 	getU8Encoder,
@@ -149,6 +151,9 @@ export function parsePropAmmProgramInstruction<TProgram extends string>(
 export type PropAmmProgramPlugin = {
 	accounts: PropAmmProgramPluginAccounts;
 	instructions: PropAmmProgramPluginInstructions;
+	identifyAccount: typeof identifyPropAmmProgramAccount;
+	identifyInstruction: typeof identifyPropAmmProgramInstruction;
+	parseInstruction: typeof parsePropAmmProgramInstruction;
 };
 
 export type PropAmmProgramPluginAccounts = {
@@ -177,9 +182,10 @@ export type PropAmmProgramPluginRequirements =
 	& ClientWithTransactionSending;
 
 export function propAmmProgramProgram() {
-	return <T extends PropAmmProgramPluginRequirements>(client: T) => {
-		return {
-			...client,
+	return <T extends PropAmmProgramPluginRequirements>(
+		client: T,
+	): ExtendedClient<T, { propAmmProgram: PropAmmProgramPlugin }> => {
+		return extendClient(client, {
 			propAmmProgram: <PropAmmProgramPlugin> {
 				accounts: {
 					oracleState: addSelfFetchFunctions(client, getOracleStateCodec()),
@@ -198,7 +204,10 @@ export function propAmmProgramProgram() {
 							getRotateAuthorityInstruction(input),
 						),
 				},
+				identifyAccount: identifyPropAmmProgramAccount,
+				identifyInstruction: identifyPropAmmProgramInstruction,
+				parseInstruction: parsePropAmmProgramInstruction,
 			},
-		};
+		});
 	};
 }

--- a/codama/clients/js/role_registry_program/package.json
+++ b/codama/clients/js/role_registry_program/package.json
@@ -9,9 +9,9 @@
 	"keywords": [],
 	"author": "",
 	"peerDependencies": {
-		"@solana/kit": "^6.1.0"
+		"@solana/kit": "^6.10.0"
 	},
 	"dependencies": {
-		"@solana/program-client-core": "^6.1.0"
+		"@solana/program-client-core": "^6.10.0"
 	}
 }

--- a/codama/clients/js/role_registry_program/src/generated/accounts/registryConfig.ts
+++ b/codama/clients/js/role_registry_program/src/generated/accounts/registryConfig.ts
@@ -31,11 +31,12 @@ import {
 	getU8Encoder,
 	type MaybeAccount,
 	type MaybeEncodedAccount,
+	type ReadonlyUint8Array,
 } from "@solana/kit";
 
 export const REGISTRY_CONFIG_DISCRIMINATOR = 1;
 
-export function getRegistryConfigDiscriminatorBytes() {
+export function getRegistryConfigDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(REGISTRY_CONFIG_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/role_registry_program/src/generated/accounts/roleEntry.ts
+++ b/codama/clients/js/role_registry_program/src/generated/accounts/roleEntry.ts
@@ -33,11 +33,12 @@ import {
 	getU8Encoder,
 	type MaybeAccount,
 	type MaybeEncodedAccount,
+	type ReadonlyUint8Array,
 } from "@solana/kit";
 
 export const ROLE_ENTRY_DISCRIMINATOR = 2;
 
-export function getRoleEntryDiscriminatorBytes() {
+export function getRoleEntryDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(ROLE_ENTRY_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/role_registry_program/src/generated/errors/roleRegistryProgram.ts
+++ b/codama/clients/js/role_registry_program/src/generated/errors/roleRegistryProgram.ts
@@ -26,7 +26,7 @@ export type RoleRegistryProgramError =
 let roleRegistryProgramErrorMessages:
 	| Record<RoleRegistryProgramError, string>
 	| undefined;
-if (process.env.NODE_ENV !== "production") {
+if (process.env["NODE_ENV"] !== "production") {
 	roleRegistryProgramErrorMessages = {
 		[ROLE_REGISTRY_PROGRAM_ERROR__INVALID_PERMISSIONS]: ``,
 		[ROLE_REGISTRY_PROGRAM_ERROR__ROLE_ALREADY_EXISTS]: ``,
@@ -37,7 +37,7 @@ if (process.env.NODE_ENV !== "production") {
 export function getRoleRegistryProgramErrorMessage(
 	code: RoleRegistryProgramError,
 ): string {
-	if (process.env.NODE_ENV !== "production") {
+	if (process.env["NODE_ENV"] !== "production") {
 		return (roleRegistryProgramErrorMessages as Record<
 			RoleRegistryProgramError,
 			string

--- a/codama/clients/js/role_registry_program/src/generated/instructions/addRole.ts
+++ b/codama/clients/js/role_registry_program/src/generated/instructions/addRole.ts
@@ -39,7 +39,7 @@ import { ROLE_REGISTRY_PROGRAM_PROGRAM_ADDRESS } from "../programs";
 
 export const ADD_ROLE_DISCRIMINATOR = 1;
 
-export function getAddRoleDiscriminatorBytes() {
+export function getAddRoleDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(ADD_ROLE_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/role_registry_program/src/generated/instructions/deactivateRole.ts
+++ b/codama/clients/js/role_registry_program/src/generated/instructions/deactivateRole.ts
@@ -15,6 +15,7 @@ import {
 	type InstructionWithAccounts,
 	type ReadonlyAccount,
 	type ReadonlySignerAccount,
+	type ReadonlyUint8Array,
 	SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
 	SolanaError,
 	type TransactionSigner,
@@ -28,7 +29,7 @@ import { ROLE_REGISTRY_PROGRAM_PROGRAM_ADDRESS } from "../programs";
 
 export const DEACTIVATE_ROLE_DISCRIMINATOR = 3;
 
-export function getDeactivateRoleDiscriminatorBytes() {
+export function getDeactivateRoleDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(DEACTIVATE_ROLE_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/role_registry_program/src/generated/instructions/initialize.ts
+++ b/codama/clients/js/role_registry_program/src/generated/instructions/initialize.ts
@@ -39,7 +39,7 @@ import { ROLE_REGISTRY_PROGRAM_PROGRAM_ADDRESS } from "../programs";
 
 export const INITIALIZE_DISCRIMINATOR = 0;
 
-export function getInitializeDiscriminatorBytes() {
+export function getInitializeDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(INITIALIZE_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/role_registry_program/src/generated/instructions/rotateAdmin.ts
+++ b/codama/clients/js/role_registry_program/src/generated/instructions/rotateAdmin.ts
@@ -15,6 +15,7 @@ import {
 	type InstructionWithAccounts,
 	type ReadonlyAccount,
 	type ReadonlySignerAccount,
+	type ReadonlyUint8Array,
 	SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
 	SolanaError,
 	type TransactionSigner,
@@ -28,7 +29,7 @@ import { ROLE_REGISTRY_PROGRAM_PROGRAM_ADDRESS } from "../programs";
 
 export const ROTATE_ADMIN_DISCRIMINATOR = 4;
 
-export function getRotateAdminDiscriminatorBytes() {
+export function getRotateAdminDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(ROTATE_ADMIN_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/role_registry_program/src/generated/instructions/updateRole.ts
+++ b/codama/clients/js/role_registry_program/src/generated/instructions/updateRole.ts
@@ -38,7 +38,7 @@ import { ROLE_REGISTRY_PROGRAM_PROGRAM_ADDRESS } from "../programs";
 
 export const UPDATE_ROLE_DISCRIMINATOR = 2;
 
-export function getUpdateRoleDiscriminatorBytes() {
+export function getUpdateRoleDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(UPDATE_ROLE_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/role_registry_program/src/generated/programs/roleRegistryProgram.ts
+++ b/codama/clients/js/role_registry_program/src/generated/programs/roleRegistryProgram.ts
@@ -13,6 +13,8 @@ import {
 	type ClientWithTransactionPlanning,
 	type ClientWithTransactionSending,
 	containsBytes,
+	extendClient,
+	type ExtendedClient,
 	type GetAccountInfoApi,
 	type GetMultipleAccountsApi,
 	getU8Encoder,
@@ -192,6 +194,9 @@ export type RoleRegistryProgramPlugin = {
 	accounts: RoleRegistryProgramPluginAccounts;
 	instructions: RoleRegistryProgramPluginInstructions;
 	pdas: RoleRegistryProgramPluginPdas;
+	identifyAccount: typeof identifyRoleRegistryProgramAccount;
+	identifyInstruction: typeof identifyRoleRegistryProgramInstruction;
+	parseInstruction: typeof parseRoleRegistryProgramInstruction;
 };
 
 export type RoleRegistryProgramPluginAccounts = {
@@ -236,9 +241,10 @@ export type RoleRegistryProgramPluginRequirements =
 	& ClientWithTransactionSending;
 
 export function roleRegistryProgramProgram() {
-	return <T extends RoleRegistryProgramPluginRequirements>(client: T) => {
-		return {
-			...client,
+	return <T extends RoleRegistryProgramPluginRequirements>(
+		client: T,
+	): ExtendedClient<T, { roleRegistryProgram: RoleRegistryProgramPlugin }> => {
+		return extendClient(client, {
 			roleRegistryProgram: <RoleRegistryProgramPlugin> {
 				accounts: {
 					registryConfig: addSelfFetchFunctions(
@@ -275,7 +281,10 @@ export function roleRegistryProgramProgram() {
 					registryConfig: findRegistryConfigPda,
 					roleEntry: findRoleEntryPda,
 				},
+				identifyAccount: identifyRoleRegistryProgramAccount,
+				identifyInstruction: identifyRoleRegistryProgramInstruction,
+				parseInstruction: parseRoleRegistryProgramInstruction,
 			},
-		};
+		});
 	};
 }

--- a/codama/clients/js/staking_rewards_program/package.json
+++ b/codama/clients/js/staking_rewards_program/package.json
@@ -9,9 +9,9 @@
 	"keywords": [],
 	"author": "",
 	"peerDependencies": {
-		"@solana/kit": "^6.1.0"
+		"@solana/kit": "^6.10.0"
 	},
 	"dependencies": {
-		"@solana/program-client-core": "^6.1.0"
+		"@solana/program-client-core": "^6.10.0"
 	}
 }

--- a/codama/clients/js/staking_rewards_program/src/generated/accounts/poolState.ts
+++ b/codama/clients/js/staking_rewards_program/src/generated/accounts/poolState.ts
@@ -33,11 +33,12 @@ import {
 	getU8Encoder,
 	type MaybeAccount,
 	type MaybeEncodedAccount,
+	type ReadonlyUint8Array,
 } from "@solana/kit";
 
 export const POOL_STATE_DISCRIMINATOR = 1;
 
-export function getPoolStateDiscriminatorBytes() {
+export function getPoolStateDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(POOL_STATE_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/staking_rewards_program/src/generated/accounts/positionState.ts
+++ b/codama/clients/js/staking_rewards_program/src/generated/accounts/positionState.ts
@@ -31,11 +31,12 @@ import {
 	getU8Encoder,
 	type MaybeAccount,
 	type MaybeEncodedAccount,
+	type ReadonlyUint8Array,
 } from "@solana/kit";
 
 export const POSITION_STATE_DISCRIMINATOR = 2;
 
-export function getPositionStateDiscriminatorBytes() {
+export function getPositionStateDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(POSITION_STATE_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/staking_rewards_program/src/generated/errors/stakingRewardsProgram.ts
+++ b/codama/clients/js/staking_rewards_program/src/generated/errors/stakingRewardsProgram.ts
@@ -30,7 +30,7 @@ export type StakingRewardsProgramError =
 let stakingRewardsProgramErrorMessages:
 	| Record<StakingRewardsProgramError, string>
 	| undefined;
-if (process.env.NODE_ENV !== "production") {
+if (process.env["NODE_ENV"] !== "production") {
 	stakingRewardsProgramErrorMessages = {
 		[STAKING_REWARDS_PROGRAM_ERROR__INSUFFICIENT_BALANCE]: ``,
 		[STAKING_REWARDS_PROGRAM_ERROR__INVALID_AMOUNT]: ``,
@@ -43,7 +43,7 @@ if (process.env.NODE_ENV !== "production") {
 export function getStakingRewardsProgramErrorMessage(
 	code: StakingRewardsProgramError,
 ): string {
-	if (process.env.NODE_ENV !== "production") {
+	if (process.env["NODE_ENV"] !== "production") {
 		return (stakingRewardsProgramErrorMessages as Record<
 			StakingRewardsProgramError,
 			string

--- a/codama/clients/js/staking_rewards_program/src/generated/instructions/claim.ts
+++ b/codama/clients/js/staking_rewards_program/src/generated/instructions/claim.ts
@@ -15,6 +15,7 @@ import {
 	type InstructionWithAccounts,
 	type ReadonlyAccount,
 	type ReadonlySignerAccount,
+	type ReadonlyUint8Array,
 	SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
 	SolanaError,
 	type TransactionSigner,
@@ -28,7 +29,7 @@ import { STAKING_REWARDS_PROGRAM_PROGRAM_ADDRESS } from "../programs";
 
 export const CLAIM_DISCRIMINATOR = 4;
 
-export function getClaimDiscriminatorBytes() {
+export function getClaimDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(CLAIM_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/staking_rewards_program/src/generated/instructions/deposit.ts
+++ b/codama/clients/js/staking_rewards_program/src/generated/instructions/deposit.ts
@@ -38,7 +38,7 @@ import { STAKING_REWARDS_PROGRAM_PROGRAM_ADDRESS } from "../programs";
 
 export const DEPOSIT_DISCRIMINATOR = 2;
 
-export function getDepositDiscriminatorBytes() {
+export function getDepositDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(DEPOSIT_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/staking_rewards_program/src/generated/instructions/initializePool.ts
+++ b/codama/clients/js/staking_rewards_program/src/generated/instructions/initializePool.ts
@@ -37,7 +37,7 @@ import { STAKING_REWARDS_PROGRAM_PROGRAM_ADDRESS } from "../programs";
 
 export const INITIALIZE_POOL_DISCRIMINATOR = 0;
 
-export function getInitializePoolDiscriminatorBytes() {
+export function getInitializePoolDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(INITIALIZE_POOL_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/staking_rewards_program/src/generated/instructions/openPosition.ts
+++ b/codama/clients/js/staking_rewards_program/src/generated/instructions/openPosition.ts
@@ -37,7 +37,7 @@ import { STAKING_REWARDS_PROGRAM_PROGRAM_ADDRESS } from "../programs";
 
 export const OPEN_POSITION_DISCRIMINATOR = 1;
 
-export function getOpenPositionDiscriminatorBytes() {
+export function getOpenPositionDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(OPEN_POSITION_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/staking_rewards_program/src/generated/instructions/withdraw.ts
+++ b/codama/clients/js/staking_rewards_program/src/generated/instructions/withdraw.ts
@@ -38,7 +38,7 @@ import { STAKING_REWARDS_PROGRAM_PROGRAM_ADDRESS } from "../programs";
 
 export const WITHDRAW_DISCRIMINATOR = 3;
 
-export function getWithdrawDiscriminatorBytes() {
+export function getWithdrawDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(WITHDRAW_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/staking_rewards_program/src/generated/programs/stakingRewardsProgram.ts
+++ b/codama/clients/js/staking_rewards_program/src/generated/programs/stakingRewardsProgram.ts
@@ -13,6 +13,8 @@ import {
 	type ClientWithTransactionPlanning,
 	type ClientWithTransactionSending,
 	containsBytes,
+	extendClient,
+	type ExtendedClient,
 	type GetAccountInfoApi,
 	type GetMultipleAccountsApi,
 	getU8Encoder,
@@ -192,6 +194,9 @@ export type StakingRewardsProgramPlugin = {
 	accounts: StakingRewardsProgramPluginAccounts;
 	instructions: StakingRewardsProgramPluginInstructions;
 	pdas: StakingRewardsProgramPluginPdas;
+	identifyAccount: typeof identifyStakingRewardsProgramAccount;
+	identifyInstruction: typeof identifyStakingRewardsProgramInstruction;
+	parseInstruction: typeof parseStakingRewardsProgramInstruction;
 };
 
 export type StakingRewardsProgramPluginAccounts = {
@@ -234,9 +239,13 @@ export type StakingRewardsProgramPluginRequirements =
 	& ClientWithTransactionSending;
 
 export function stakingRewardsProgramProgram() {
-	return <T extends StakingRewardsProgramPluginRequirements>(client: T) => {
-		return {
-			...client,
+	return <T extends StakingRewardsProgramPluginRequirements>(
+		client: T,
+	): ExtendedClient<
+		T,
+		{ stakingRewardsProgram: StakingRewardsProgramPlugin }
+	> => {
+		return extendClient(client, {
 			stakingRewardsProgram: <StakingRewardsProgramPlugin> {
 				accounts: {
 					poolState: addSelfFetchFunctions(client, getPoolStateCodec()),
@@ -261,7 +270,10 @@ export function stakingRewardsProgramProgram() {
 						addSelfPlanAndSendFunctions(client, getClaimInstruction(input)),
 				},
 				pdas: { pool: findPoolPda, position: findPositionPda },
+				identifyAccount: identifyStakingRewardsProgramAccount,
+				identifyInstruction: identifyStakingRewardsProgramInstruction,
+				parseInstruction: parseStakingRewardsProgramInstruction,
 			},
-		};
+		});
 	};
 }

--- a/codama/clients/js/todo_program/package.json
+++ b/codama/clients/js/todo_program/package.json
@@ -9,9 +9,9 @@
 	"keywords": [],
 	"author": "",
 	"peerDependencies": {
-		"@solana/kit": "^6.1.0"
+		"@solana/kit": "^6.10.0"
 	},
 	"dependencies": {
-		"@solana/program-client-core": "^6.1.0"
+		"@solana/program-client-core": "^6.10.0"
 	}
 }

--- a/codama/clients/js/todo_program/src/generated/accounts/todoState.ts
+++ b/codama/clients/js/todo_program/src/generated/accounts/todoState.ts
@@ -40,7 +40,7 @@ import {
 
 export const TODO_STATE_DISCRIMINATOR = 1;
 
-export function getTodoStateDiscriminatorBytes() {
+export function getTodoStateDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(TODO_STATE_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/todo_program/src/generated/instructions/initialize.ts
+++ b/codama/clients/js/todo_program/src/generated/instructions/initialize.ts
@@ -43,7 +43,7 @@ import { TODO_PROGRAM_PROGRAM_ADDRESS } from "../programs";
 
 export const INITIALIZE_DISCRIMINATOR = 0;
 
-export function getInitializeDiscriminatorBytes() {
+export function getInitializeDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(INITIALIZE_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/todo_program/src/generated/instructions/toggleCompleted.ts
+++ b/codama/clients/js/todo_program/src/generated/instructions/toggleCompleted.ts
@@ -14,6 +14,7 @@ import {
 	type Instruction,
 	type InstructionWithAccounts,
 	type ReadonlySignerAccount,
+	type ReadonlyUint8Array,
 	SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
 	SolanaError,
 	type TransactionSigner,
@@ -29,7 +30,7 @@ import { TODO_PROGRAM_PROGRAM_ADDRESS } from "../programs";
 
 export const TOGGLE_COMPLETED_DISCRIMINATOR = 1;
 
-export function getToggleCompletedDiscriminatorBytes() {
+export function getToggleCompletedDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(TOGGLE_COMPLETED_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/todo_program/src/generated/instructions/updateDigest.ts
+++ b/codama/clients/js/todo_program/src/generated/instructions/updateDigest.ts
@@ -41,7 +41,7 @@ import { TODO_PROGRAM_PROGRAM_ADDRESS } from "../programs";
 
 export const UPDATE_DIGEST_DISCRIMINATOR = 2;
 
-export function getUpdateDigestDiscriminatorBytes() {
+export function getUpdateDigestDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(UPDATE_DIGEST_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/todo_program/src/generated/programs/todoProgram.ts
+++ b/codama/clients/js/todo_program/src/generated/programs/todoProgram.ts
@@ -13,6 +13,8 @@ import {
 	type ClientWithTransactionPlanning,
 	type ClientWithTransactionSending,
 	containsBytes,
+	extendClient,
+	type ExtendedClient,
 	type GetAccountInfoApi,
 	type GetMultipleAccountsApi,
 	getU8Encoder,
@@ -151,6 +153,9 @@ export type TodoProgramPlugin = {
 	accounts: TodoProgramPluginAccounts;
 	instructions: TodoProgramPluginInstructions;
 	pdas: TodoProgramPluginPdas;
+	identifyAccount: typeof identifyTodoProgramAccount;
+	identifyInstruction: typeof identifyTodoProgramInstruction;
+	parseInstruction: typeof parseTodoProgramInstruction;
 };
 
 export type TodoProgramPluginAccounts = {
@@ -185,9 +190,10 @@ export type TodoProgramPluginRequirements =
 	& ClientWithTransactionSending;
 
 export function todoProgramProgram() {
-	return <T extends TodoProgramPluginRequirements>(client: T) => {
-		return {
-			...client,
+	return <T extends TodoProgramPluginRequirements>(
+		client: T,
+	): ExtendedClient<T, { todoProgram: TodoProgramPlugin }> => {
+		return extendClient(client, {
 			todoProgram: <TodoProgramPlugin> {
 				accounts: {
 					todoState: addSelfFetchFunctions(client, getTodoStateCodec()),
@@ -210,7 +216,10 @@ export function todoProgramProgram() {
 						),
 				},
 				pdas: { todo: findTodoPda },
+				identifyAccount: identifyTodoProgramAccount,
+				identifyInstruction: identifyTodoProgramInstruction,
+				parseInstruction: parseTodoProgramInstruction,
 			},
-		};
+		});
 	};
 }

--- a/codama/clients/js/transfer_sol/package.json
+++ b/codama/clients/js/transfer_sol/package.json
@@ -9,9 +9,9 @@
 	"keywords": [],
 	"author": "",
 	"peerDependencies": {
-		"@solana/kit": "^6.1.0"
+		"@solana/kit": "^6.10.0"
 	},
 	"dependencies": {
-		"@solana/program-client-core": "^6.1.0"
+		"@solana/program-client-core": "^6.10.0"
 	}
 }

--- a/codama/clients/js/transfer_sol/src/generated/errors/transferSol.ts
+++ b/codama/clients/js/transfer_sol/src/generated/errors/transferSol.ts
@@ -20,7 +20,7 @@ export const TRANSFER_SOL_ERROR__INSUFFICIENT_FUNDS = 0x0; // 0
 export type TransferSolError = typeof TRANSFER_SOL_ERROR__INSUFFICIENT_FUNDS;
 
 let transferSolErrorMessages: Record<TransferSolError, string> | undefined;
-if (process.env.NODE_ENV !== "production") {
+if (process.env["NODE_ENV"] !== "production") {
 	transferSolErrorMessages = {
 		[TRANSFER_SOL_ERROR__INSUFFICIENT_FUNDS]:
 			`The sender does not have enough lamports for the transfer.`,
@@ -28,7 +28,7 @@ if (process.env.NODE_ENV !== "production") {
 }
 
 export function getTransferSolErrorMessage(code: TransferSolError): string {
-	if (process.env.NODE_ENV !== "production") {
+	if (process.env["NODE_ENV"] !== "production") {
 		return (transferSolErrorMessages as Record<TransferSolError, string>)[code];
 	}
 

--- a/codama/clients/js/transfer_sol/src/generated/instructions/cpiTransfer.ts
+++ b/codama/clients/js/transfer_sol/src/generated/instructions/cpiTransfer.ts
@@ -38,7 +38,7 @@ import { TRANSFER_SOL_PROGRAM_ADDRESS } from "../programs";
 
 export const CPI_TRANSFER_DISCRIMINATOR = 0;
 
-export function getCpiTransferDiscriminatorBytes() {
+export function getCpiTransferDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(CPI_TRANSFER_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/transfer_sol/src/generated/instructions/directTransfer.ts
+++ b/codama/clients/js/transfer_sol/src/generated/instructions/directTransfer.ts
@@ -37,7 +37,7 @@ import { TRANSFER_SOL_PROGRAM_ADDRESS } from "../programs";
 
 export const DIRECT_TRANSFER_DISCRIMINATOR = 1;
 
-export function getDirectTransferDiscriminatorBytes() {
+export function getDirectTransferDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(DIRECT_TRANSFER_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/transfer_sol/src/generated/programs/transferSol.ts
+++ b/codama/clients/js/transfer_sol/src/generated/programs/transferSol.ts
@@ -12,6 +12,8 @@ import {
 	type ClientWithTransactionPlanning,
 	type ClientWithTransactionSending,
 	containsBytes,
+	extendClient,
+	type ExtendedClient,
 	getU8Encoder,
 	type Instruction,
 	type InstructionWithData,
@@ -101,7 +103,11 @@ export function parseTransferSolInstruction<TProgram extends string>(
 	}
 }
 
-export type TransferSolPlugin = { instructions: TransferSolPluginInstructions };
+export type TransferSolPlugin = {
+	instructions: TransferSolPluginInstructions;
+	identifyInstruction: typeof identifyTransferSolInstruction;
+	parseInstruction: typeof parseTransferSolInstruction;
+};
 
 export type TransferSolPluginInstructions = {
 	cpiTransfer: (
@@ -119,9 +125,10 @@ export type TransferSolPluginRequirements =
 	& ClientWithTransactionSending;
 
 export function transferSolProgram() {
-	return <T extends TransferSolPluginRequirements>(client: T) => {
-		return {
-			...client,
+	return <T extends TransferSolPluginRequirements>(
+		client: T,
+	): ExtendedClient<T, { transferSol: TransferSolPlugin }> => {
+		return extendClient(client, {
 			transferSol: <TransferSolPlugin> {
 				instructions: {
 					cpiTransfer: (input) =>
@@ -135,7 +142,9 @@ export function transferSolProgram() {
 							getDirectTransferInstruction(input),
 						),
 				},
+				identifyInstruction: identifyTransferSolInstruction,
+				parseInstruction: parseTransferSolInstruction,
 			},
-		};
+		});
 	};
 }

--- a/codama/clients/js/vesting_program/package.json
+++ b/codama/clients/js/vesting_program/package.json
@@ -9,9 +9,9 @@
 	"keywords": [],
 	"author": "",
 	"peerDependencies": {
-		"@solana/kit": "^6.1.0"
+		"@solana/kit": "^6.10.0"
 	},
 	"dependencies": {
-		"@solana/program-client-core": "^6.1.0"
+		"@solana/program-client-core": "^6.10.0"
 	}
 }

--- a/codama/clients/js/vesting_program/src/generated/accounts/vestingState.ts
+++ b/codama/clients/js/vesting_program/src/generated/accounts/vestingState.ts
@@ -33,11 +33,12 @@ import {
 	getU8Encoder,
 	type MaybeAccount,
 	type MaybeEncodedAccount,
+	type ReadonlyUint8Array,
 } from "@solana/kit";
 
 export const VESTING_STATE_DISCRIMINATOR = 1;
 
-export function getVestingStateDiscriminatorBytes() {
+export function getVestingStateDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(VESTING_STATE_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/vesting_program/src/generated/errors/vestingProgram.ts
+++ b/codama/clients/js/vesting_program/src/generated/errors/vestingProgram.ts
@@ -26,7 +26,7 @@ export type VestingProgramError =
 let vestingProgramErrorMessages:
 	| Record<VestingProgramError, string>
 	| undefined;
-if (process.env.NODE_ENV !== "production") {
+if (process.env["NODE_ENV"] !== "production") {
 	vestingProgramErrorMessages = {
 		[VESTING_PROGRAM_ERROR__ALREADY_CANCELLED]: ``,
 		[VESTING_PROGRAM_ERROR__CLAIM_TOO_LARGE]: ``,
@@ -37,7 +37,7 @@ if (process.env.NODE_ENV !== "production") {
 export function getVestingProgramErrorMessage(
 	code: VestingProgramError,
 ): string {
-	if (process.env.NODE_ENV !== "production") {
+	if (process.env["NODE_ENV"] !== "production") {
 		return (vestingProgramErrorMessages as Record<VestingProgramError, string>)[
 			code
 		];

--- a/codama/clients/js/vesting_program/src/generated/instructions/cancel.ts
+++ b/codama/clients/js/vesting_program/src/generated/instructions/cancel.ts
@@ -15,6 +15,7 @@ import {
 	type InstructionWithAccounts,
 	type ReadonlyAccount,
 	type ReadonlySignerAccount,
+	type ReadonlyUint8Array,
 	SOLANA_ERROR__PROGRAM_CLIENTS__INSUFFICIENT_ACCOUNT_METAS,
 	SolanaError,
 	type TransactionSigner,
@@ -28,7 +29,7 @@ import { VESTING_PROGRAM_PROGRAM_ADDRESS } from "../programs";
 
 export const CANCEL_DISCRIMINATOR = 2;
 
-export function getCancelDiscriminatorBytes() {
+export function getCancelDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(CANCEL_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/vesting_program/src/generated/instructions/claim.ts
+++ b/codama/clients/js/vesting_program/src/generated/instructions/claim.ts
@@ -38,7 +38,7 @@ import { VESTING_PROGRAM_PROGRAM_ADDRESS } from "../programs";
 
 export const CLAIM_DISCRIMINATOR = 1;
 
-export function getClaimDiscriminatorBytes() {
+export function getClaimDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(CLAIM_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/vesting_program/src/generated/instructions/initialize.ts
+++ b/codama/clients/js/vesting_program/src/generated/instructions/initialize.ts
@@ -39,7 +39,7 @@ import { VESTING_PROGRAM_PROGRAM_ADDRESS } from "../programs";
 
 export const INITIALIZE_DISCRIMINATOR = 0;
 
-export function getInitializeDiscriminatorBytes() {
+export function getInitializeDiscriminatorBytes(): ReadonlyUint8Array {
 	return getU8Encoder().encode(INITIALIZE_DISCRIMINATOR);
 }
 

--- a/codama/clients/js/vesting_program/src/generated/programs/vestingProgram.ts
+++ b/codama/clients/js/vesting_program/src/generated/programs/vestingProgram.ts
@@ -13,6 +13,8 @@ import {
 	type ClientWithTransactionPlanning,
 	type ClientWithTransactionSending,
 	containsBytes,
+	extendClient,
+	type ExtendedClient,
 	type GetAccountInfoApi,
 	type GetMultipleAccountsApi,
 	getU8Encoder,
@@ -151,6 +153,9 @@ export type VestingProgramPlugin = {
 	accounts: VestingProgramPluginAccounts;
 	instructions: VestingProgramPluginInstructions;
 	pdas: VestingProgramPluginPdas;
+	identifyAccount: typeof identifyVestingProgramAccount;
+	identifyInstruction: typeof identifyVestingProgramInstruction;
+	parseInstruction: typeof parseVestingProgramInstruction;
 };
 
 export type VestingProgramPluginAccounts = {
@@ -179,9 +184,10 @@ export type VestingProgramPluginRequirements =
 	& ClientWithTransactionSending;
 
 export function vestingProgramProgram() {
-	return <T extends VestingProgramPluginRequirements>(client: T) => {
-		return {
-			...client,
+	return <T extends VestingProgramPluginRequirements>(
+		client: T,
+	): ExtendedClient<T, { vestingProgram: VestingProgramPlugin }> => {
+		return extendClient(client, {
 			vestingProgram: <VestingProgramPlugin> {
 				accounts: {
 					vestingState: addSelfFetchFunctions(client, getVestingStateCodec()),
@@ -198,7 +204,10 @@ export function vestingProgramProgram() {
 						addSelfPlanAndSendFunctions(client, getCancelInstruction(input)),
 				},
 				pdas: { vesting: findVestingPda },
+				identifyAccount: identifyVestingProgramAccount,
+				identifyInstruction: identifyVestingProgramInstruction,
+				parseInstruction: parseVestingProgramInstruction,
 			},
-		};
+		});
 	};
 }

--- a/codama/idls/anchor_declare_id.json
+++ b/codama/idls/anchor_declare_id.json
@@ -1,19 +1,16 @@
 {
 	"kind": "rootNode",
 	"standard": "codama",
-	"version": "1.0.0",
+	"version": "1.8.0",
 	"program": {
 		"kind": "programNode",
 		"name": "anchorDeclareId",
 		"publicKey": "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
-		"version": "",
-		"accounts": [],
+		"version": "0.0.0",
 		"instructions": [
 			{
 				"kind": "instructionNode",
 				"name": "initialize",
-				"accounts": [],
-				"arguments": [],
 				"discriminators": [
 					{
 						"kind": "constantDiscriminatorNode",
@@ -33,10 +30,6 @@
 					}
 				]
 			}
-		],
-		"definedTypes": [],
-		"pdas": [],
-		"errors": []
-	},
-	"additionalPrograms": []
+		]
+	}
 }

--- a/codama/idls/anchor_declare_program.json
+++ b/codama/idls/anchor_declare_program.json
@@ -1,13 +1,12 @@
 {
 	"kind": "rootNode",
 	"standard": "codama",
-	"version": "1.0.0",
+	"version": "1.8.0",
 	"program": {
 		"kind": "programNode",
 		"name": "anchorDeclareProgram",
 		"publicKey": "Dec1areProgram11111111111111111111111111111",
-		"version": "",
-		"accounts": [],
+		"version": "0.0.0",
 		"instructions": [
 			{
 				"kind": "instructionNode",
@@ -17,16 +16,17 @@
 						"kind": "instructionAccountNode",
 						"name": "authority",
 						"isWritable": false,
-						"isSigner": true
+						"isSigner": true,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "externalProgram",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					}
 				],
-				"arguments": [],
 				"discriminators": [
 					{
 						"kind": "constantDiscriminatorNode",
@@ -46,10 +46,6 @@
 					}
 				]
 			}
-		],
-		"definedTypes": [],
-		"pdas": [],
-		"errors": []
-	},
-	"additionalPrograms": []
+		]
+	}
 }

--- a/codama/idls/anchor_duplicate_mutable_accounts.json
+++ b/codama/idls/anchor_duplicate_mutable_accounts.json
@@ -1,13 +1,12 @@
 {
 	"kind": "rootNode",
 	"standard": "codama",
-	"version": "1.0.0",
+	"version": "1.8.0",
 	"program": {
 		"kind": "programNode",
 		"name": "anchorDuplicateMutableAccounts",
 		"publicKey": "4D6rvpR7TSPwmFottLGa5gpzMcJ76kN8bimQHV9rogjH",
-		"version": "",
-		"accounts": [],
+		"version": "0.0.0",
 		"instructions": [
 			{
 				"kind": "instructionNode",
@@ -17,16 +16,17 @@
 						"kind": "instructionAccountNode",
 						"name": "account1",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "account2",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					}
 				],
-				"arguments": [],
 				"discriminators": [
 					{
 						"kind": "constantDiscriminatorNode",
@@ -49,8 +49,6 @@
 			{
 				"kind": "instructionNode",
 				"name": "allowsDuplicateMutable",
-				"accounts": [],
-				"arguments": [],
 				"discriminators": [
 					{
 						"kind": "constantDiscriminatorNode",
@@ -78,16 +76,17 @@
 						"kind": "instructionAccountNode",
 						"name": "account1",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "account2",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					}
 				],
-				"arguments": [],
 				"discriminators": [
 					{
 						"kind": "constantDiscriminatorNode",
@@ -108,8 +107,6 @@
 				]
 			}
 		],
-		"definedTypes": [],
-		"pdas": [],
 		"errors": [
 			{
 				"kind": "errorNode",
@@ -118,6 +115,5 @@
 				"message": ""
 			}
 		]
-	},
-	"additionalPrograms": []
+	}
 }

--- a/codama/idls/anchor_errors.json
+++ b/codama/idls/anchor_errors.json
@@ -1,19 +1,16 @@
 {
 	"kind": "rootNode",
 	"standard": "codama",
-	"version": "1.0.0",
+	"version": "1.8.0",
 	"program": {
 		"kind": "programNode",
 		"name": "anchorErrors",
 		"publicKey": "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
-		"version": "",
-		"accounts": [],
+		"version": "0.0.0",
 		"instructions": [
 			{
 				"kind": "instructionNode",
 				"name": "hello",
-				"accounts": [],
-				"arguments": [],
 				"discriminators": [
 					{
 						"kind": "constantDiscriminatorNode",
@@ -36,8 +33,6 @@
 			{
 				"kind": "instructionNode",
 				"name": "helloNoMsg",
-				"accounts": [],
-				"arguments": [],
 				"discriminators": [
 					{
 						"kind": "constantDiscriminatorNode",
@@ -60,8 +55,6 @@
 			{
 				"kind": "instructionNode",
 				"name": "helloNext",
-				"accounts": [],
-				"arguments": [],
 				"discriminators": [
 					{
 						"kind": "constantDiscriminatorNode",
@@ -84,8 +77,6 @@
 			{
 				"kind": "instructionNode",
 				"name": "requireEq",
-				"accounts": [],
-				"arguments": [],
 				"discriminators": [
 					{
 						"kind": "constantDiscriminatorNode",
@@ -108,8 +99,6 @@
 			{
 				"kind": "instructionNode",
 				"name": "requireNeq",
-				"accounts": [],
-				"arguments": [],
 				"discriminators": [
 					{
 						"kind": "constantDiscriminatorNode",
@@ -132,8 +121,6 @@
 			{
 				"kind": "instructionNode",
 				"name": "requireGt",
-				"accounts": [],
-				"arguments": [],
 				"discriminators": [
 					{
 						"kind": "constantDiscriminatorNode",
@@ -156,8 +143,6 @@
 			{
 				"kind": "instructionNode",
 				"name": "requireGte",
-				"accounts": [],
-				"arguments": [],
 				"discriminators": [
 					{
 						"kind": "constantDiscriminatorNode",
@@ -178,8 +163,6 @@
 				]
 			}
 		],
-		"definedTypes": [],
-		"pdas": [],
 		"errors": [
 			{
 				"kind": "errorNode",
@@ -230,6 +213,5 @@
 				"message": ""
 			}
 		]
-	},
-	"additionalPrograms": []
+	}
 }

--- a/codama/idls/anchor_events.json
+++ b/codama/idls/anchor_events.json
@@ -1,19 +1,16 @@
 {
 	"kind": "rootNode",
 	"standard": "codama",
-	"version": "1.0.0",
+	"version": "1.8.0",
 	"program": {
 		"kind": "programNode",
 		"name": "anchorEvents",
 		"publicKey": "2dhGsWUzy5YKUsjZdLHLmkNpUDAXkNa9MYWsPc4Ziqzy",
-		"version": "",
-		"accounts": [],
+		"version": "0.0.0",
 		"instructions": [
 			{
 				"kind": "instructionNode",
 				"name": "initialize",
-				"accounts": [],
-				"arguments": [],
 				"discriminators": [
 					{
 						"kind": "constantDiscriminatorNode",
@@ -36,8 +33,6 @@
 			{
 				"kind": "instructionNode",
 				"name": "testEvent",
-				"accounts": [],
-				"arguments": [],
 				"discriminators": [
 					{
 						"kind": "constantDiscriminatorNode",
@@ -60,8 +55,6 @@
 			{
 				"kind": "instructionNode",
 				"name": "testEventCpi",
-				"accounts": [],
-				"arguments": [],
 				"discriminators": [
 					{
 						"kind": "constantDiscriminatorNode",
@@ -81,10 +74,6 @@
 					}
 				]
 			}
-		],
-		"definedTypes": [],
-		"pdas": [],
-		"errors": []
-	},
-	"additionalPrograms": []
+		]
+	}
 }

--- a/codama/idls/anchor_floats.json
+++ b/codama/idls/anchor_floats.json
@@ -1,12 +1,12 @@
 {
 	"kind": "rootNode",
 	"standard": "codama",
-	"version": "1.0.0",
+	"version": "1.8.0",
 	"program": {
 		"kind": "programNode",
 		"name": "anchorFloats",
 		"publicKey": "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
-		"version": "",
+		"version": "0.0.0",
 		"accounts": [
 			{
 				"kind": "accountNode",
@@ -70,19 +70,22 @@
 						"kind": "instructionAccountNode",
 						"name": "account",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "authority",
 						"isWritable": false,
-						"isSigner": true
+						"isSigner": true,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "systemProgram",
 						"isWritable": false,
 						"isSigner": false,
+						"isOptional": false,
 						"defaultValue": {
 							"kind": "publicKeyValueNode",
 							"publicKey": "11111111111111111111111111111111"
@@ -136,13 +139,15 @@
 						"kind": "instructionAccountNode",
 						"name": "account",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "authority",
 						"isWritable": false,
-						"isSigner": true
+						"isSigner": true,
+						"isOptional": false
 					}
 				],
 				"arguments": [
@@ -185,8 +190,6 @@
 				]
 			}
 		],
-		"definedTypes": [],
-		"pdas": [],
 		"errors": [
 			{
 				"kind": "errorNode",
@@ -195,6 +198,5 @@
 				"message": ""
 			}
 		]
-	},
-	"additionalPrograms": []
+	}
 }

--- a/codama/idls/anchor_realloc.json
+++ b/codama/idls/anchor_realloc.json
@@ -1,13 +1,12 @@
 {
 	"kind": "rootNode",
 	"standard": "codama",
-	"version": "1.0.0",
+	"version": "1.8.0",
 	"program": {
 		"kind": "programNode",
 		"name": "anchorRealloc",
 		"publicKey": "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
-		"version": "",
-		"accounts": [],
+		"version": "0.0.0",
 		"instructions": [
 			{
 				"kind": "instructionNode",
@@ -17,19 +16,22 @@
 						"kind": "instructionAccountNode",
 						"name": "authority",
 						"isWritable": false,
-						"isSigner": true
+						"isSigner": true,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "sample",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "systemProgram",
 						"isWritable": false,
 						"isSigner": false,
+						"isOptional": false,
 						"defaultValue": {
 							"kind": "publicKeyValueNode",
 							"publicKey": "11111111111111111111111111111111"
@@ -74,25 +76,29 @@
 						"kind": "instructionAccountNode",
 						"name": "authority",
 						"isWritable": false,
-						"isSigner": true
+						"isSigner": true,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "sample1",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "sample2",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "systemProgram",
 						"isWritable": false,
 						"isSigner": false,
+						"isOptional": false,
 						"defaultValue": {
 							"kind": "publicKeyValueNode",
 							"publicKey": "11111111111111111111111111111111"
@@ -130,8 +136,6 @@
 				]
 			}
 		],
-		"definedTypes": [],
-		"pdas": [],
 		"errors": [
 			{
 				"kind": "errorNode",
@@ -146,6 +150,5 @@
 				"message": ""
 			}
 		]
-	},
-	"additionalPrograms": []
+	}
 }

--- a/codama/idls/anchor_system_accounts.json
+++ b/codama/idls/anchor_system_accounts.json
@@ -1,13 +1,12 @@
 {
 	"kind": "rootNode",
 	"standard": "codama",
-	"version": "1.0.0",
+	"version": "1.8.0",
 	"program": {
 		"kind": "programNode",
 		"name": "anchorSystemAccounts",
 		"publicKey": "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
-		"version": "",
-		"accounts": [],
+		"version": "0.0.0",
 		"instructions": [
 			{
 				"kind": "instructionNode",
@@ -17,16 +16,17 @@
 						"kind": "instructionAccountNode",
 						"name": "authority",
 						"isWritable": false,
-						"isSigner": true
+						"isSigner": true,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "wallet",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					}
 				],
-				"arguments": [],
 				"discriminators": [
 					{
 						"kind": "constantDiscriminatorNode",
@@ -46,10 +46,6 @@
 					}
 				]
 			}
-		],
-		"definedTypes": [],
-		"pdas": [],
-		"errors": []
-	},
-	"additionalPrograms": []
+		]
+	}
 }

--- a/codama/idls/anchor_sysvars.json
+++ b/codama/idls/anchor_sysvars.json
@@ -1,13 +1,12 @@
 {
 	"kind": "rootNode",
 	"standard": "codama",
-	"version": "1.0.0",
+	"version": "1.8.0",
 	"program": {
 		"kind": "programNode",
 		"name": "anchorSysvars",
 		"publicKey": "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
-		"version": "",
-		"accounts": [],
+		"version": "0.0.0",
 		"instructions": [
 			{
 				"kind": "instructionNode",
@@ -17,22 +16,24 @@
 						"kind": "instructionAccountNode",
 						"name": "clock",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "rent",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "stakeHistory",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					}
 				],
-				"arguments": [],
 				"discriminators": [
 					{
 						"kind": "constantDiscriminatorNode",
@@ -52,10 +53,6 @@
 					}
 				]
 			}
-		],
-		"definedTypes": [],
-		"pdas": [],
-		"errors": []
-	},
-	"additionalPrograms": []
+		]
+	}
 }

--- a/codama/idls/counter_program.json
+++ b/codama/idls/counter_program.json
@@ -1,12 +1,12 @@
 {
 	"kind": "rootNode",
 	"standard": "codama",
-	"version": "1.0.0",
+	"version": "1.8.0",
 	"program": {
 		"kind": "programNode",
 		"name": "counterProgram",
 		"publicKey": "GJQcuWrT2f3f4KNuJcXhhwUa1ZQTYbxzzJ1hotzKu8hS",
-		"version": "",
+		"version": "0.0.0",
 		"accounts": [
 			{
 				"kind": "accountNode",
@@ -97,6 +97,7 @@
 						"name": "authority",
 						"isWritable": false,
 						"isSigner": true,
+						"isOptional": false,
 						"docs": [
 							"The wallet creating the counter. Pays for account creation and becomes",
 							"the authority whose address seeds the PDA."
@@ -107,6 +108,7 @@
 						"name": "counter",
 						"isWritable": true,
 						"isSigner": false,
+						"isOptional": false,
 						"docs": [
 							"The counter PDA account (must be empty — not yet created)."
 						],
@@ -133,6 +135,7 @@
 						"name": "systemProgram",
 						"isWritable": false,
 						"isSigner": false,
+						"isOptional": false,
 						"docs": [
 							"The system program, required for `CreateAccount` CPI."
 						],
@@ -185,6 +188,7 @@
 						"name": "authority",
 						"isWritable": false,
 						"isSigner": true,
+						"isOptional": false,
 						"docs": [
 							"The counter's authority. Must sign to prove ownership."
 						]
@@ -194,6 +198,7 @@
 						"name": "counter",
 						"isWritable": true,
 						"isSigner": false,
+						"isOptional": false,
 						"docs": [
 							"The counter PDA account (must already exist and be writable)."
 						],
@@ -216,7 +221,6 @@
 						}
 					}
 				],
-				"arguments": [],
 				"discriminators": [
 					{
 						"kind": "constantDiscriminatorNode",
@@ -237,7 +241,6 @@
 				]
 			}
 		],
-		"definedTypes": [],
 		"pdas": [
 			{
 				"kind": "pdaNode",
@@ -263,8 +266,6 @@
 					}
 				]
 			}
-		],
-		"errors": []
-	},
-	"additionalPrograms": []
+		]
+	}
 }

--- a/codama/idls/escrow_program.json
+++ b/codama/idls/escrow_program.json
@@ -1,12 +1,12 @@
 {
 	"kind": "rootNode",
 	"standard": "codama",
-	"version": "1.0.0",
+	"version": "1.8.0",
 	"program": {
 		"kind": "programNode",
 		"name": "escrowProgram",
 		"publicKey": "4ibrEMW5F6hKnkW4jVedswYv6H6VtwPN6ar6dvXDN1nT",
-		"version": "",
+		"version": "0.0.0",
 		"accounts": [
 			{
 				"kind": "accountNode",
@@ -108,43 +108,50 @@
 						"kind": "instructionAccountNode",
 						"name": "maker",
 						"isWritable": false,
-						"isSigner": true
+						"isSigner": true,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "mintA",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "mintB",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "makerAtaA",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "escrow",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "vault",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "systemProgram",
 						"isWritable": false,
 						"isSigner": false,
+						"isOptional": false,
 						"defaultValue": {
 							"kind": "publicKeyValueNode",
 							"publicKey": "11111111111111111111111111111111"
@@ -154,7 +161,8 @@
 						"kind": "instructionAccountNode",
 						"name": "tokenProgram",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					}
 				],
 				"arguments": [
@@ -222,74 +230,84 @@
 						"kind": "instructionAccountNode",
 						"name": "taker",
 						"isWritable": true,
-						"isSigner": true
+						"isSigner": true,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "mintA",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "mintB",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "takerAtaA",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "takerAtaB",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "maker",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "makerAtaB",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "escrow",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "vault",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "tokenProgram",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "systemProgram",
 						"isWritable": false,
 						"isSigner": false,
+						"isOptional": false,
 						"defaultValue": {
 							"kind": "publicKeyValueNode",
 							"publicKey": "11111111111111111111111111111111"
 						}
 					}
 				],
-				"arguments": [],
 				"discriminators": [
 					{
 						"kind": "constantDiscriminatorNode",
@@ -310,7 +328,6 @@
 				]
 			}
 		],
-		"definedTypes": [],
 		"pdas": [
 			{
 				"kind": "pdaNode",
@@ -358,6 +375,5 @@
 				"message": ""
 			}
 		]
-	},
-	"additionalPrograms": []
+	}
 }

--- a/codama/idls/hello_solana.json
+++ b/codama/idls/hello_solana.json
@@ -1,13 +1,12 @@
 {
 	"kind": "rootNode",
 	"standard": "codama",
-	"version": "1.0.0",
+	"version": "1.8.0",
 	"program": {
 		"kind": "programNode",
 		"name": "helloSolana",
 		"publicKey": "DCF5KBmtQ9ryDC7mQezKLwuJHem6coVUCmKkw37M9J4A",
-		"version": "",
-		"accounts": [],
+		"version": "0.0.0",
 		"instructions": [
 			{
 				"kind": "instructionNode",
@@ -30,13 +29,13 @@
 						"name": "user",
 						"isWritable": false,
 						"isSigner": true,
+						"isOptional": false,
 						"docs": [
 							"The user invoking the program. Must be a signer so we can trust the",
 							"address is authentic."
 						]
 					}
 				],
-				"arguments": [],
 				"discriminators": [
 					{
 						"kind": "constantDiscriminatorNode",
@@ -56,10 +55,6 @@
 					}
 				]
 			}
-		],
-		"definedTypes": [],
-		"pdas": [],
-		"errors": []
-	},
-	"additionalPrograms": []
+		]
+	}
 }

--- a/codama/idls/pina_bpf.json
+++ b/codama/idls/pina_bpf.json
@@ -1,19 +1,16 @@
 {
 	"kind": "rootNode",
 	"standard": "codama",
-	"version": "1.0.0",
+	"version": "1.8.0",
 	"program": {
 		"kind": "programNode",
 		"name": "pinaBpf",
 		"publicKey": "2nYtoevJCC8AFjdsfmkf8y1jN2nN9k4jVtD7G3f5n1Qe",
-		"version": "",
-		"accounts": [],
+		"version": "0.0.0",
 		"instructions": [
 			{
 				"kind": "instructionNode",
 				"name": "hello",
-				"accounts": [],
-				"arguments": [],
 				"discriminators": [
 					{
 						"kind": "constantDiscriminatorNode",
@@ -33,10 +30,6 @@
 					}
 				]
 			}
-		],
-		"definedTypes": [],
-		"pdas": [],
-		"errors": []
-	},
-	"additionalPrograms": []
+		]
+	}
 }

--- a/codama/idls/prop_amm_program.json
+++ b/codama/idls/prop_amm_program.json
@@ -1,12 +1,12 @@
 {
 	"kind": "rootNode",
 	"standard": "codama",
-	"version": "1.0.0",
+	"version": "1.8.0",
 	"program": {
 		"kind": "programNode",
 		"name": "propAmmProgram",
 		"publicKey": "55555555555555555555555555555555555555555555",
-		"version": "",
+		"version": "0.0.0",
 		"accounts": [
 			{
 				"kind": "accountNode",
@@ -61,26 +61,28 @@
 						"kind": "instructionAccountNode",
 						"name": "payer",
 						"isWritable": true,
-						"isSigner": true
+						"isSigner": true,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "oracle",
 						"isWritable": true,
-						"isSigner": true
+						"isSigner": true,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "systemProgram",
 						"isWritable": false,
 						"isSigner": false,
+						"isOptional": false,
 						"defaultValue": {
 							"kind": "publicKeyValueNode",
 							"publicKey": "11111111111111111111111111111111"
 						}
 					}
 				],
-				"arguments": [],
 				"discriminators": [
 					{
 						"kind": "constantDiscriminatorNode",
@@ -108,13 +110,15 @@
 						"kind": "instructionAccountNode",
 						"name": "oracle",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "authority",
 						"isWritable": false,
-						"isSigner": true
+						"isSigner": true,
+						"isOptional": false
 					}
 				],
 				"arguments": [
@@ -155,13 +159,15 @@
 						"kind": "instructionAccountNode",
 						"name": "oracle",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "authority",
 						"isWritable": false,
-						"isSigner": true
+						"isSigner": true,
+						"isOptional": false
 					}
 				],
 				"arguments": [
@@ -193,8 +199,6 @@
 				]
 			}
 		],
-		"definedTypes": [],
-		"pdas": [],
 		"errors": [
 			{
 				"kind": "errorNode",
@@ -209,6 +213,5 @@
 				"message": ""
 			}
 		]
-	},
-	"additionalPrograms": []
+	}
 }

--- a/codama/idls/role_registry_program.json
+++ b/codama/idls/role_registry_program.json
@@ -1,12 +1,12 @@
 {
 	"kind": "rootNode",
 	"standard": "codama",
-	"version": "1.0.0",
+	"version": "1.8.0",
 	"program": {
 		"kind": "programNode",
 		"name": "roleRegistryProgram",
 		"publicKey": "3B7roNNQLnW43Par9AfTuVzEqZx7yPtXRA9K3Ev7RHyX",
-		"version": "",
+		"version": "0.0.0",
 		"accounts": [
 			{
 				"kind": "accountNode",
@@ -150,13 +150,15 @@
 						"kind": "instructionAccountNode",
 						"name": "admin",
 						"isWritable": true,
-						"isSigner": true
+						"isSigner": true,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "registryConfig",
 						"isWritable": true,
 						"isSigner": false,
+						"isOptional": false,
 						"defaultValue": {
 							"kind": "pdaValueNode",
 							"pda": {
@@ -180,6 +182,7 @@
 						"name": "systemProgram",
 						"isWritable": false,
 						"isSigner": false,
+						"isOptional": false,
 						"defaultValue": {
 							"kind": "publicKeyValueNode",
 							"publicKey": "11111111111111111111111111111111"
@@ -224,31 +227,36 @@
 						"kind": "instructionAccountNode",
 						"name": "admin",
 						"isWritable": true,
-						"isSigner": true
+						"isSigner": true,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "grantee",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "registryConfig",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "roleEntry",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "systemProgram",
 						"isWritable": false,
 						"isSigner": false,
+						"isOptional": false,
 						"defaultValue": {
 							"kind": "publicKeyValueNode",
 							"publicKey": "11111111111111111111111111111111"
@@ -311,19 +319,22 @@
 						"kind": "instructionAccountNode",
 						"name": "admin",
 						"isWritable": false,
-						"isSigner": true
+						"isSigner": true,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "registryConfig",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "roleEntry",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					}
 				],
 				"arguments": [
@@ -364,22 +375,24 @@
 						"kind": "instructionAccountNode",
 						"name": "admin",
 						"isWritable": false,
-						"isSigner": true
+						"isSigner": true,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "registryConfig",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "roleEntry",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					}
 				],
-				"arguments": [],
 				"discriminators": [
 					{
 						"kind": "constantDiscriminatorNode",
@@ -407,22 +420,24 @@
 						"kind": "instructionAccountNode",
 						"name": "admin",
 						"isWritable": false,
-						"isSigner": true
+						"isSigner": true,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "newAdmin",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "registryConfig",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					}
 				],
-				"arguments": [],
 				"discriminators": [
 					{
 						"kind": "constantDiscriminatorNode",
@@ -443,7 +458,6 @@
 				]
 			}
 		],
-		"definedTypes": [],
 		"pdas": [
 			{
 				"kind": "pdaNode",
@@ -521,6 +535,5 @@
 				"message": ""
 			}
 		]
-	},
-	"additionalPrograms": []
+	}
 }

--- a/codama/idls/staking_rewards_program.json
+++ b/codama/idls/staking_rewards_program.json
@@ -1,12 +1,12 @@
 {
 	"kind": "rootNode",
 	"standard": "codama",
-	"version": "1.0.0",
+	"version": "1.8.0",
 	"program": {
 		"kind": "programNode",
 		"name": "stakingRewardsProgram",
 		"publicKey": "9MBwKBjzTLtLe8PkHVhi5CfGxKo8gCYbMEg5NMt1tcvr",
-		"version": "",
+		"version": "0.0.0",
 		"accounts": [
 			{
 				"kind": "accountNode",
@@ -182,43 +182,50 @@
 						"kind": "instructionAccountNode",
 						"name": "admin",
 						"isWritable": false,
-						"isSigner": true
+						"isSigner": true,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "stakeMint",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "rewardMint",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "poolState",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "stakeVault",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "rewardVault",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "systemProgram",
 						"isWritable": false,
 						"isSigner": false,
+						"isOptional": false,
 						"defaultValue": {
 							"kind": "publicKeyValueNode",
 							"publicKey": "11111111111111111111111111111111"
@@ -228,7 +235,8 @@
 						"kind": "instructionAccountNode",
 						"name": "tokenProgram",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					}
 				],
 				"arguments": [
@@ -269,25 +277,29 @@
 						"kind": "instructionAccountNode",
 						"name": "user",
 						"isWritable": false,
-						"isSigner": true
+						"isSigner": true,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "poolState",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "positionState",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "systemProgram",
 						"isWritable": false,
 						"isSigner": false,
+						"isOptional": false,
 						"defaultValue": {
 							"kind": "publicKeyValueNode",
 							"publicKey": "11111111111111111111111111111111"
@@ -332,43 +344,50 @@
 						"kind": "instructionAccountNode",
 						"name": "user",
 						"isWritable": false,
-						"isSigner": true
+						"isSigner": true,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "stakeMint",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "poolState",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "positionState",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "userStakeAta",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "tokenProgram",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "systemProgram",
 						"isWritable": false,
 						"isSigner": false,
+						"isOptional": false,
 						"defaultValue": {
 							"kind": "publicKeyValueNode",
 							"publicKey": "11111111111111111111111111111111"
@@ -413,43 +432,50 @@
 						"kind": "instructionAccountNode",
 						"name": "user",
 						"isWritable": false,
-						"isSigner": true
+						"isSigner": true,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "stakeMint",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "poolState",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "positionState",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "userStakeAta",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "tokenProgram",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "systemProgram",
 						"isWritable": false,
 						"isSigner": false,
+						"isOptional": false,
 						"defaultValue": {
 							"kind": "publicKeyValueNode",
 							"publicKey": "11111111111111111111111111111111"
@@ -494,50 +520,56 @@
 						"kind": "instructionAccountNode",
 						"name": "user",
 						"isWritable": false,
-						"isSigner": true
+						"isSigner": true,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "rewardMint",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "poolState",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "positionState",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "userRewardAta",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "tokenProgram",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "systemProgram",
 						"isWritable": false,
 						"isSigner": false,
+						"isOptional": false,
 						"defaultValue": {
 							"kind": "publicKeyValueNode",
 							"publicKey": "11111111111111111111111111111111"
 						}
 					}
 				],
-				"arguments": [],
 				"discriminators": [
 					{
 						"kind": "constantDiscriminatorNode",
@@ -558,7 +590,6 @@
 				]
 			}
 		],
-		"definedTypes": [],
 		"pdas": [
 			{
 				"kind": "pdaNode",
@@ -655,6 +686,5 @@
 				"message": ""
 			}
 		]
-	},
-	"additionalPrograms": []
+	}
 }

--- a/codama/idls/todo_program.json
+++ b/codama/idls/todo_program.json
@@ -1,12 +1,12 @@
 {
 	"kind": "rootNode",
 	"standard": "codama",
-	"version": "1.0.0",
+	"version": "1.8.0",
 	"program": {
 		"kind": "programNode",
 		"name": "todoProgram",
 		"publicKey": "Fc5A5xvNQ6w7kn2P7FpC18JNpDutLCRa14Q6gttxyPjd",
-		"version": "",
+		"version": "0.0.0",
 		"accounts": [
 			{
 				"kind": "accountNode",
@@ -84,13 +84,15 @@
 						"kind": "instructionAccountNode",
 						"name": "owner",
 						"isWritable": false,
-						"isSigner": true
+						"isSigner": true,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "todo",
 						"isWritable": true,
 						"isSigner": false,
+						"isOptional": false,
 						"defaultValue": {
 							"kind": "pdaValueNode",
 							"pda": {
@@ -114,6 +116,7 @@
 						"name": "systemProgram",
 						"isWritable": false,
 						"isSigner": false,
+						"isOptional": false,
 						"defaultValue": {
 							"kind": "publicKeyValueNode",
 							"publicKey": "11111111111111111111111111111111"
@@ -169,13 +172,15 @@
 						"kind": "instructionAccountNode",
 						"name": "owner",
 						"isWritable": false,
-						"isSigner": true
+						"isSigner": true,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "todo",
 						"isWritable": true,
 						"isSigner": false,
+						"isOptional": false,
 						"defaultValue": {
 							"kind": "pdaValueNode",
 							"pda": {
@@ -195,7 +200,6 @@
 						}
 					}
 				],
-				"arguments": [],
 				"discriminators": [
 					{
 						"kind": "constantDiscriminatorNode",
@@ -223,13 +227,15 @@
 						"kind": "instructionAccountNode",
 						"name": "owner",
 						"isWritable": false,
-						"isSigner": true
+						"isSigner": true,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "todo",
 						"isWritable": true,
 						"isSigner": false,
+						"isOptional": false,
 						"defaultValue": {
 							"kind": "pdaValueNode",
 							"pda": {
@@ -282,7 +288,6 @@
 				]
 			}
 		],
-		"definedTypes": [],
 		"pdas": [
 			{
 				"kind": "pdaNode",
@@ -308,8 +313,6 @@
 					}
 				]
 			}
-		],
-		"errors": []
-	},
-	"additionalPrograms": []
+		]
+	}
 }

--- a/codama/idls/transfer_sol.json
+++ b/codama/idls/transfer_sol.json
@@ -1,13 +1,12 @@
 {
 	"kind": "rootNode",
 	"standard": "codama",
-	"version": "1.0.0",
+	"version": "1.8.0",
 	"program": {
 		"kind": "programNode",
 		"name": "transferSol",
 		"publicKey": "BuXKn8EiVMKF8zYThuea3xhLq3jUHTTwDDLfCoehq7WG",
-		"version": "",
-		"accounts": [],
+		"version": "0.0.0",
 		"instructions": [
 			{
 				"kind": "instructionNode",
@@ -29,6 +28,7 @@
 						"name": "sender",
 						"isWritable": true,
 						"isSigner": true,
+						"isOptional": false,
 						"docs": [
 							"The sender. Must be a signer and writable (lamports will be debited)."
 						]
@@ -38,6 +38,7 @@
 						"name": "recipient",
 						"isWritable": true,
 						"isSigner": false,
+						"isOptional": false,
 						"docs": [
 							"The recipient. Must be writable (lamports will be credited)."
 						]
@@ -47,6 +48,7 @@
 						"name": "systemProgram",
 						"isWritable": false,
 						"isSigner": false,
+						"isOptional": false,
 						"docs": [
 							"The system program."
 						],
@@ -101,6 +103,7 @@
 						"name": "sender",
 						"isWritable": true,
 						"isSigner": true,
+						"isOptional": false,
 						"docs": [
 							"The sender. Must be owned by this program, writable, and a signer."
 						]
@@ -110,6 +113,7 @@
 						"name": "recipient",
 						"isWritable": true,
 						"isSigner": false,
+						"isOptional": false,
 						"docs": [
 							"The recipient. Must be writable."
 						]
@@ -146,8 +150,6 @@
 				]
 			}
 		],
-		"definedTypes": [],
-		"pdas": [],
 		"errors": [
 			{
 				"kind": "errorNode",
@@ -159,6 +161,5 @@
 				]
 			}
 		]
-	},
-	"additionalPrograms": []
+	}
 }

--- a/codama/idls/vesting_program.json
+++ b/codama/idls/vesting_program.json
@@ -1,12 +1,12 @@
 {
 	"kind": "rootNode",
 	"standard": "codama",
-	"version": "1.0.0",
+	"version": "1.8.0",
 	"program": {
 		"kind": "programNode",
 		"name": "vestingProgram",
 		"publicKey": "FEa5fqN6NACrhWUZSBdGKybJKNxkdw8cdLvRvTARsFHh",
-		"version": "",
+		"version": "0.0.0",
 		"accounts": [
 			{
 				"kind": "accountNode",
@@ -132,37 +132,43 @@
 						"kind": "instructionAccountNode",
 						"name": "admin",
 						"isWritable": false,
-						"isSigner": true
+						"isSigner": true,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "beneficiary",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "mint",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "vestingState",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "vault",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "systemProgram",
 						"isWritable": false,
 						"isSigner": false,
+						"isOptional": false,
 						"defaultValue": {
 							"kind": "publicKeyValueNode",
 							"publicKey": "11111111111111111111111111111111"
@@ -172,7 +178,8 @@
 						"kind": "instructionAccountNode",
 						"name": "tokenProgram",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					}
 				],
 				"arguments": [
@@ -249,37 +256,43 @@
 						"kind": "instructionAccountNode",
 						"name": "beneficiary",
 						"isWritable": false,
-						"isSigner": true
+						"isSigner": true,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "mint",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "vestingState",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "beneficiaryAta",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "vault",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "systemProgram",
 						"isWritable": false,
 						"isSigner": false,
+						"isOptional": false,
 						"defaultValue": {
 							"kind": "publicKeyValueNode",
 							"publicKey": "11111111111111111111111111111111"
@@ -289,7 +302,8 @@
 						"kind": "instructionAccountNode",
 						"name": "tokenProgram",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					}
 				],
 				"arguments": [
@@ -330,34 +344,38 @@
 						"kind": "instructionAccountNode",
 						"name": "admin",
 						"isWritable": false,
-						"isSigner": true
+						"isSigner": true,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "mint",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "vestingState",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "vault",
 						"isWritable": true,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					},
 					{
 						"kind": "instructionAccountNode",
 						"name": "tokenProgram",
 						"isWritable": false,
-						"isSigner": false
+						"isSigner": false,
+						"isOptional": false
 					}
 				],
-				"arguments": [],
 				"discriminators": [
 					{
 						"kind": "constantDiscriminatorNode",
@@ -378,7 +396,6 @@
 				]
 			}
 		],
-		"definedTypes": [],
 		"pdas": [
 			{
 				"kind": "pdaNode",
@@ -439,6 +456,5 @@
 				"message": ""
 			}
 		]
-	},
-	"additionalPrograms": []
+	}
 }

--- a/codama/tests/js/package.json
+++ b/codama/tests/js/package.json
@@ -6,6 +6,6 @@
 		"test": "node validate-idls.mjs"
 	},
 	"devDependencies": {
-		"codama": "1.5.1"
+		"codama": "^1.10.0"
 	}
 }

--- a/crates/pina_cli/src/codama.rs
+++ b/crates/pina_cli/src/codama.rs
@@ -220,9 +220,9 @@ fn run_js_generation_with_npx(
 	command
 		.arg("-y")
 		.arg("-p")
-		.arg("codama@1.5.1")
+		.arg("codama@1.10.1")
 		.arg("-p")
-		.arg("@codama/renderers-js@2.0.2")
+		.arg("@codama/renderers-js@2.3.1")
 		.arg("node")
 		.arg("--input-type=module")
 		.arg("-e")
@@ -244,9 +244,9 @@ fn run_js_generation_with_pnpm(
 	command
 		.arg("dlx")
 		.arg("--package")
-		.arg("codama@1.5.1")
+		.arg("codama@1.10.1")
 		.arg("--package")
-		.arg("@codama/renderers-js@2.0.2")
+		.arg("@codama/renderers-js@2.3.1")
 		.arg("node")
 		.arg("--input-type=module")
 		.arg("-e")

--- a/crates/pina_cli/src/codegen/mod.rs
+++ b/crates/pina_cli/src/codegen/mod.rs
@@ -10,7 +10,7 @@ use codama_nodes::InstructionAccountNode;
 use codama_nodes::InstructionArgumentNode;
 use codama_nodes::InstructionInputValueNode;
 use codama_nodes::InstructionNode;
-use codama_nodes::IsAccountSigner;
+use codama_nodes::IsSigner;
 use codama_nodes::NumberFormat;
 use codama_nodes::NumberTypeNode;
 use codama_nodes::NumberValueNode;
@@ -113,23 +113,23 @@ fn build_instruction_account_node(
 	pdas: &[PdaIr],
 ) -> InstructionAccountNode {
 	let is_signer = if account.is_signer {
-		IsAccountSigner::True
+		IsSigner::True
 	} else {
-		IsAccountSigner::False
+		IsSigner::False
 	};
 
 	let mut node =
 		InstructionAccountNode::new(account.name.as_str(), account.is_writable, is_signer);
-	node.is_optional = account.is_optional;
+	node.is_optional = Some(account.is_optional);
 
 	if !account.docs.is_empty() {
 		node.docs = account.docs.clone().into();
 	}
 
 	if let Some(default_value) = &account.default_value {
-		node.default_value = Some(build_default_value(default_value));
+		node.default_value = Box::new(Some(build_default_value(default_value)));
 	} else if let Some(default_value) = build_pda_default_value(account, instruction, pdas) {
-		node.default_value = Some(default_value);
+		node.default_value = Box::new(Some(default_value));
 	}
 
 	node
@@ -161,7 +161,10 @@ fn build_pda_default_value(
 				return None;
 			}
 
-			PdaSeedValueNode::new(name.as_str(), AccountValueNode::new(name.as_str()))
+			PdaSeedValueNode {
+				name: name.as_str().into(),
+				value: Box::new(AccountValueNode::new(name.as_str()).into()),
+			}
 		} else {
 			return None;
 		};
@@ -169,7 +172,7 @@ fn build_pda_default_value(
 		seed_values.push(value);
 	}
 
-	Some(InstructionInputValueNode::Pda(PdaValueNode::new(
+	Some(InstructionInputValueNode::PdaValue(PdaValueNode::new(
 		PdaLinkNode::new(pda_name.as_str()),
 		seed_values,
 	)))
@@ -178,7 +181,7 @@ fn build_pda_default_value(
 fn build_default_value(default_value: &DefaultValueIr) -> InstructionInputValueNode {
 	match default_value {
 		DefaultValueIr::ProgramId(addr) | DefaultValueIr::PublicKey(addr) => {
-			InstructionInputValueNode::PublicKey(PublicKeyValueNode::new(addr.as_str()))
+			InstructionInputValueNode::PublicKeyValue(PublicKeyValueNode::new(addr.as_str()))
 		}
 	}
 }
@@ -250,7 +253,7 @@ fn build_pda_node(pda: &PdaIr) -> PdaNode {
 fn build_error_node(error: &ErrorIr) -> ErrorNode {
 	let message = error.docs.first().cloned().unwrap_or_default();
 
-	let mut node = ErrorNode::new(error.name.as_str(), error.code as usize, message);
+	let mut node = ErrorNode::new(error.name.as_str(), error.code, message);
 
 	if !error.docs.is_empty() {
 		node.docs = error.docs.clone().into();
@@ -262,8 +265,8 @@ fn build_error_node(error: &ErrorIr) -> ErrorNode {
 #[cfg(test)]
 mod tests {
 	use codama_nodes::InstructionInputValueNode;
-	use codama_nodes::PdaSeedValueValueNode;
-	use codama_nodes::PdaValue;
+	use codama_nodes::PdaSeedValueValue;
+	use codama_nodes::PdaValuePda;
 
 	use super::*;
 
@@ -321,17 +324,19 @@ mod tests {
 
 		let root = ir_to_root_node(&ir);
 		let account = &root.program.instructions[0].accounts[1];
-		let Some(InstructionInputValueNode::Pda(default_value)) = &account.default_value else {
+		let Some(InstructionInputValueNode::PdaValue(default_value)) =
+			account.default_value.as_ref()
+		else {
 			panic!("expected PDA account default");
 		};
 
 		assert!(
-			matches!(&default_value.pda, PdaValue::Linked(link) if link.name.as_ref() == "state")
+			matches!(default_value.pda.as_ref(), PdaValuePda::PdaLink(link) if link.name.as_ref() == "state")
 		);
 		assert_eq!(default_value.seeds.len(), 1);
 		assert!(matches!(
-			&default_value.seeds[0].value,
-			PdaSeedValueValueNode::Account(account) if account.name.as_ref() == "authority"
+			default_value.seeds[0].value.as_ref(),
+			PdaSeedValueValue::Account(account) if account.name.as_ref() == "authority"
 		));
 	}
 }

--- a/crates/pina_cli/src/parse/validation.rs
+++ b/crates/pina_cli/src/parse/validation.rs
@@ -45,7 +45,7 @@ pub fn extract_validation_properties(
 		};
 
 		// Must be `impl ProcessAccountInfos for X`.
-		let Some(trait_path) = item_impl.trait_.as_ref().map(|(_, path, _)| path) else {
+		let Some(trait_path) = item_impl.trait_.as_ref().map(|(path, _)| path) else {
 			continue;
 		};
 

--- a/crates/pina_cli/tests/snapshots/cli_snapshots__idl_success_output.snap
+++ b/crates/pina_cli/tests/snapshots/cli_snapshots__idl_success_output.snap
@@ -25,19 +25,16 @@ exit_code: 0
 {
   "kind": "rootNode",
   "standard": "codama",
-  "version": "1.0.0",
+  "version": "1.8.0",
   "program": {
     "kind": "programNode",
     "name": "anchorDeclareId",
     "publicKey": "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
-    "version": "",
-    "accounts": [],
+    "version": "0.0.0",
     "instructions": [
       {
         "kind": "instructionNode",
         "name": "initialize",
-        "accounts": [],
-        "arguments": [],
         "discriminators": [
           {
             "kind": "constantDiscriminatorNode",
@@ -57,12 +54,8 @@ exit_code: 0
           }
         ]
       }
-    ],
-    "definedTypes": [],
-    "pdas": [],
-    "errors": []
-  },
-  "additionalPrograms": []
+    ]
+  }
 }
 
 ----- stderr -----

--- a/crates/pina_cli/tests/snapshots/examples__counter_program.snap
+++ b/crates/pina_cli/tests/snapshots/examples__counter_program.snap
@@ -1,16 +1,17 @@
 ---
 source: crates/pina_cli/tests/examples.rs
+assertion_line: 43
 expression: idl
 ---
 {
   "kind": "rootNode",
   "standard": "codama",
-  "version": "1.0.0",
+  "version": "1.8.0",
   "program": {
     "kind": "programNode",
     "name": "counterProgram",
     "publicKey": "GJQcuWrT2f3f4KNuJcXhhwUa1ZQTYbxzzJ1hotzKu8hS",
-    "version": "",
+    "version": "0.0.0",
     "accounts": [
       {
         "kind": "accountNode",
@@ -101,6 +102,7 @@ expression: idl
             "name": "authority",
             "isWritable": false,
             "isSigner": true,
+            "isOptional": false,
             "docs": [
               "The wallet creating the counter. Pays for account creation and becomes",
               "the authority whose address seeds the PDA."
@@ -111,6 +113,7 @@ expression: idl
             "name": "counter",
             "isWritable": true,
             "isSigner": false,
+            "isOptional": false,
             "docs": [
               "The counter PDA account (must be empty — not yet created)."
             ],
@@ -137,6 +140,7 @@ expression: idl
             "name": "systemProgram",
             "isWritable": false,
             "isSigner": false,
+            "isOptional": false,
             "docs": [
               "The system program, required for `CreateAccount` CPI."
             ],
@@ -189,6 +193,7 @@ expression: idl
             "name": "authority",
             "isWritable": false,
             "isSigner": true,
+            "isOptional": false,
             "docs": [
               "The counter's authority. Must sign to prove ownership."
             ]
@@ -198,6 +203,7 @@ expression: idl
             "name": "counter",
             "isWritable": true,
             "isSigner": false,
+            "isOptional": false,
             "docs": [
               "The counter PDA account (must already exist and be writable)."
             ],
@@ -220,7 +226,6 @@ expression: idl
             }
           }
         ],
-        "arguments": [],
         "discriminators": [
           {
             "kind": "constantDiscriminatorNode",
@@ -241,7 +246,6 @@ expression: idl
         ]
       }
     ],
-    "definedTypes": [],
     "pdas": [
       {
         "kind": "pdaNode",
@@ -267,8 +271,6 @@ expression: idl
           }
         ]
       }
-    ],
-    "errors": []
-  },
-  "additionalPrograms": []
+    ]
+  }
 }

--- a/crates/pina_cli/tests/snapshots/examples__escrow_program.snap
+++ b/crates/pina_cli/tests/snapshots/examples__escrow_program.snap
@@ -1,16 +1,17 @@
 ---
 source: crates/pina_cli/tests/examples.rs
+assertion_line: 49
 expression: idl
 ---
 {
   "kind": "rootNode",
   "standard": "codama",
-  "version": "1.0.0",
+  "version": "1.8.0",
   "program": {
     "kind": "programNode",
     "name": "escrowProgram",
     "publicKey": "4ibrEMW5F6hKnkW4jVedswYv6H6VtwPN6ar6dvXDN1nT",
-    "version": "",
+    "version": "0.0.0",
     "accounts": [
       {
         "kind": "accountNode",
@@ -112,43 +113,50 @@ expression: idl
             "kind": "instructionAccountNode",
             "name": "maker",
             "isWritable": false,
-            "isSigner": true
+            "isSigner": true,
+            "isOptional": false
           },
           {
             "kind": "instructionAccountNode",
             "name": "mintA",
             "isWritable": false,
-            "isSigner": false
+            "isSigner": false,
+            "isOptional": false
           },
           {
             "kind": "instructionAccountNode",
             "name": "mintB",
             "isWritable": false,
-            "isSigner": false
+            "isSigner": false,
+            "isOptional": false
           },
           {
             "kind": "instructionAccountNode",
             "name": "makerAtaA",
             "isWritable": false,
-            "isSigner": false
+            "isSigner": false,
+            "isOptional": false
           },
           {
             "kind": "instructionAccountNode",
             "name": "escrow",
             "isWritable": true,
-            "isSigner": false
+            "isSigner": false,
+            "isOptional": false
           },
           {
             "kind": "instructionAccountNode",
             "name": "vault",
             "isWritable": true,
-            "isSigner": false
+            "isSigner": false,
+            "isOptional": false
           },
           {
             "kind": "instructionAccountNode",
             "name": "systemProgram",
             "isWritable": false,
             "isSigner": false,
+            "isOptional": false,
             "defaultValue": {
               "kind": "publicKeyValueNode",
               "publicKey": "11111111111111111111111111111111"
@@ -158,7 +166,8 @@ expression: idl
             "kind": "instructionAccountNode",
             "name": "tokenProgram",
             "isWritable": false,
-            "isSigner": false
+            "isSigner": false,
+            "isOptional": false
           }
         ],
         "arguments": [
@@ -226,74 +235,84 @@ expression: idl
             "kind": "instructionAccountNode",
             "name": "taker",
             "isWritable": true,
-            "isSigner": true
+            "isSigner": true,
+            "isOptional": false
           },
           {
             "kind": "instructionAccountNode",
             "name": "mintA",
             "isWritable": false,
-            "isSigner": false
+            "isSigner": false,
+            "isOptional": false
           },
           {
             "kind": "instructionAccountNode",
             "name": "mintB",
             "isWritable": false,
-            "isSigner": false
+            "isSigner": false,
+            "isOptional": false
           },
           {
             "kind": "instructionAccountNode",
             "name": "takerAtaA",
             "isWritable": false,
-            "isSigner": false
+            "isSigner": false,
+            "isOptional": false
           },
           {
             "kind": "instructionAccountNode",
             "name": "takerAtaB",
             "isWritable": true,
-            "isSigner": false
+            "isSigner": false,
+            "isOptional": false
           },
           {
             "kind": "instructionAccountNode",
             "name": "maker",
             "isWritable": true,
-            "isSigner": false
+            "isSigner": false,
+            "isOptional": false
           },
           {
             "kind": "instructionAccountNode",
             "name": "makerAtaB",
             "isWritable": true,
-            "isSigner": false
+            "isSigner": false,
+            "isOptional": false
           },
           {
             "kind": "instructionAccountNode",
             "name": "escrow",
             "isWritable": true,
-            "isSigner": false
+            "isSigner": false,
+            "isOptional": false
           },
           {
             "kind": "instructionAccountNode",
             "name": "vault",
             "isWritable": true,
-            "isSigner": false
+            "isSigner": false,
+            "isOptional": false
           },
           {
             "kind": "instructionAccountNode",
             "name": "tokenProgram",
             "isWritable": false,
-            "isSigner": false
+            "isSigner": false,
+            "isOptional": false
           },
           {
             "kind": "instructionAccountNode",
             "name": "systemProgram",
             "isWritable": false,
             "isSigner": false,
+            "isOptional": false,
             "defaultValue": {
               "kind": "publicKeyValueNode",
               "publicKey": "11111111111111111111111111111111"
             }
           }
         ],
-        "arguments": [],
         "discriminators": [
           {
             "kind": "constantDiscriminatorNode",
@@ -314,7 +333,6 @@ expression: idl
         ]
       }
     ],
-    "definedTypes": [],
     "pdas": [
       {
         "kind": "pdaNode",
@@ -362,6 +380,5 @@ expression: idl
         "message": ""
       }
     ]
-  },
-  "additionalPrograms": []
+  }
 }

--- a/crates/pina_cli/tests/snapshots/examples__hello_solana.snap
+++ b/crates/pina_cli/tests/snapshots/examples__hello_solana.snap
@@ -1,17 +1,17 @@
 ---
 source: crates/pina_cli/tests/examples.rs
+assertion_line: 67
 expression: idl
 ---
 {
   "kind": "rootNode",
   "standard": "codama",
-  "version": "1.0.0",
+  "version": "1.8.0",
   "program": {
     "kind": "programNode",
     "name": "helloSolana",
     "publicKey": "DCF5KBmtQ9ryDC7mQezKLwuJHem6coVUCmKkw37M9J4A",
-    "version": "",
-    "accounts": [],
+    "version": "0.0.0",
     "instructions": [
       {
         "kind": "instructionNode",
@@ -34,13 +34,13 @@ expression: idl
             "name": "user",
             "isWritable": false,
             "isSigner": true,
+            "isOptional": false,
             "docs": [
               "The user invoking the program. Must be a signer so we can trust the",
               "address is authentic."
             ]
           }
         ],
-        "arguments": [],
         "discriminators": [
           {
             "kind": "constantDiscriminatorNode",
@@ -60,10 +60,6 @@ expression: idl
           }
         ]
       }
-    ],
-    "definedTypes": [],
-    "pdas": [],
-    "errors": []
-  },
-  "additionalPrograms": []
+    ]
+  }
 }

--- a/crates/pina_cli/tests/snapshots/examples__todo_program.snap
+++ b/crates/pina_cli/tests/snapshots/examples__todo_program.snap
@@ -1,16 +1,17 @@
 ---
 source: crates/pina_cli/tests/examples.rs
+assertion_line: 55
 expression: idl
 ---
 {
   "kind": "rootNode",
   "standard": "codama",
-  "version": "1.0.0",
+  "version": "1.8.0",
   "program": {
     "kind": "programNode",
     "name": "todoProgram",
     "publicKey": "Fc5A5xvNQ6w7kn2P7FpC18JNpDutLCRa14Q6gttxyPjd",
-    "version": "",
+    "version": "0.0.0",
     "accounts": [
       {
         "kind": "accountNode",
@@ -88,13 +89,15 @@ expression: idl
             "kind": "instructionAccountNode",
             "name": "owner",
             "isWritable": false,
-            "isSigner": true
+            "isSigner": true,
+            "isOptional": false
           },
           {
             "kind": "instructionAccountNode",
             "name": "todo",
             "isWritable": true,
             "isSigner": false,
+            "isOptional": false,
             "defaultValue": {
               "kind": "pdaValueNode",
               "pda": {
@@ -118,6 +121,7 @@ expression: idl
             "name": "systemProgram",
             "isWritable": false,
             "isSigner": false,
+            "isOptional": false,
             "defaultValue": {
               "kind": "publicKeyValueNode",
               "publicKey": "11111111111111111111111111111111"
@@ -173,13 +177,15 @@ expression: idl
             "kind": "instructionAccountNode",
             "name": "owner",
             "isWritable": false,
-            "isSigner": true
+            "isSigner": true,
+            "isOptional": false
           },
           {
             "kind": "instructionAccountNode",
             "name": "todo",
             "isWritable": true,
             "isSigner": false,
+            "isOptional": false,
             "defaultValue": {
               "kind": "pdaValueNode",
               "pda": {
@@ -199,7 +205,6 @@ expression: idl
             }
           }
         ],
-        "arguments": [],
         "discriminators": [
           {
             "kind": "constantDiscriminatorNode",
@@ -227,13 +232,15 @@ expression: idl
             "kind": "instructionAccountNode",
             "name": "owner",
             "isWritable": false,
-            "isSigner": true
+            "isSigner": true,
+            "isOptional": false
           },
           {
             "kind": "instructionAccountNode",
             "name": "todo",
             "isWritable": true,
             "isSigner": false,
+            "isOptional": false,
             "defaultValue": {
               "kind": "pdaValueNode",
               "pda": {
@@ -286,7 +293,6 @@ expression: idl
         ]
       }
     ],
-    "definedTypes": [],
     "pdas": [
       {
         "kind": "pdaNode",
@@ -312,8 +318,6 @@ expression: idl
           }
         ]
       }
-    ],
-    "errors": []
-  },
-  "additionalPrograms": []
+    ]
+  }
 }

--- a/crates/pina_cli/tests/snapshots/examples__transfer_sol.snap
+++ b/crates/pina_cli/tests/snapshots/examples__transfer_sol.snap
@@ -1,17 +1,17 @@
 ---
 source: crates/pina_cli/tests/examples.rs
+assertion_line: 61
 expression: idl
 ---
 {
   "kind": "rootNode",
   "standard": "codama",
-  "version": "1.0.0",
+  "version": "1.8.0",
   "program": {
     "kind": "programNode",
     "name": "transferSol",
     "publicKey": "BuXKn8EiVMKF8zYThuea3xhLq3jUHTTwDDLfCoehq7WG",
-    "version": "",
-    "accounts": [],
+    "version": "0.0.0",
     "instructions": [
       {
         "kind": "instructionNode",
@@ -33,6 +33,7 @@ expression: idl
             "name": "sender",
             "isWritable": true,
             "isSigner": true,
+            "isOptional": false,
             "docs": [
               "The sender. Must be a signer and writable (lamports will be debited)."
             ]
@@ -42,6 +43,7 @@ expression: idl
             "name": "recipient",
             "isWritable": true,
             "isSigner": false,
+            "isOptional": false,
             "docs": [
               "The recipient. Must be writable (lamports will be credited)."
             ]
@@ -51,6 +53,7 @@ expression: idl
             "name": "systemProgram",
             "isWritable": false,
             "isSigner": false,
+            "isOptional": false,
             "docs": [
               "The system program."
             ],
@@ -105,6 +108,7 @@ expression: idl
             "name": "sender",
             "isWritable": true,
             "isSigner": true,
+            "isOptional": false,
             "docs": [
               "The sender. Must be owned by this program, writable, and a signer."
             ]
@@ -114,6 +118,7 @@ expression: idl
             "name": "recipient",
             "isWritable": true,
             "isSigner": false,
+            "isOptional": false,
             "docs": [
               "The recipient. Must be writable."
             ]
@@ -150,8 +155,6 @@ expression: idl
         ]
       }
     ],
-    "definedTypes": [],
-    "pdas": [],
     "errors": [
       {
         "kind": "errorNode",
@@ -163,6 +166,5 @@ expression: idl
         ]
       }
     ]
-  },
-  "additionalPrograms": []
+  }
 }

--- a/crates/pina_cli/tests/snapshots/fixtures__doc_comments.snap
+++ b/crates/pina_cli/tests/snapshots/fixtures__doc_comments.snap
@@ -1,16 +1,17 @@
 ---
 source: crates/pina_cli/tests/fixtures.rs
+assertion_line: 38
 expression: idl
 ---
 {
   "kind": "rootNode",
   "standard": "codama",
-  "version": "1.0.0",
+  "version": "1.8.0",
   "program": {
     "kind": "programNode",
     "name": "docComments",
     "publicKey": "GJQcuWrT2f3f4KNuJcXhhwUa1ZQTYbxzzJ1hotzKu8hS",
-    "version": "",
+    "version": "0.0.0",
     "accounts": [
       {
         "kind": "accountNode",
@@ -78,6 +79,7 @@ expression: idl
             "name": "payer",
             "isWritable": false,
             "isSigner": true,
+            "isOptional": false,
             "docs": [
               "Payer funding the account creation."
             ]
@@ -87,6 +89,7 @@ expression: idl
             "name": "document",
             "isWritable": true,
             "isSigner": false,
+            "isOptional": false,
             "docs": [
               "Document account to initialize."
             ]
@@ -123,8 +126,6 @@ expression: idl
         ]
       }
     ],
-    "definedTypes": [],
-    "pdas": [],
     "errors": [
       {
         "kind": "errorNode",
@@ -136,6 +137,5 @@ expression: idl
         ]
       }
     ]
-  },
-  "additionalPrograms": []
+  }
 }

--- a/crates/pina_cli/tests/snapshots/fixtures__error_enum.snap
+++ b/crates/pina_cli/tests/snapshots/fixtures__error_enum.snap
@@ -1,20 +1,17 @@
 ---
 source: crates/pina_cli/tests/fixtures.rs
+assertion_line: 38
 expression: idl
 ---
 {
   "kind": "rootNode",
   "standard": "codama",
-  "version": "1.0.0",
+  "version": "1.8.0",
   "program": {
     "kind": "programNode",
     "name": "errorEnum",
     "publicKey": "GJQcuWrT2f3f4KNuJcXhhwUa1ZQTYbxzzJ1hotzKu8hS",
-    "version": "",
-    "accounts": [],
-    "instructions": [],
-    "definedTypes": [],
-    "pdas": [],
+    "version": "0.0.0",
     "errors": [
       {
         "kind": "errorNode",
@@ -35,6 +32,5 @@ expression: idl
         ]
       }
     ]
-  },
-  "additionalPrograms": []
+  }
 }

--- a/crates/pina_cli/tests/snapshots/fixtures__minimal.snap
+++ b/crates/pina_cli/tests/snapshots/fixtures__minimal.snap
@@ -1,21 +1,16 @@
 ---
 source: crates/pina_cli/tests/fixtures.rs
+assertion_line: 38
 expression: idl
 ---
 {
   "kind": "rootNode",
   "standard": "codama",
-  "version": "1.0.0",
+  "version": "1.8.0",
   "program": {
     "kind": "programNode",
     "name": "minimal",
     "publicKey": "GJQcuWrT2f3f4KNuJcXhhwUa1ZQTYbxzzJ1hotzKu8hS",
-    "version": "",
-    "accounts": [],
-    "instructions": [],
-    "definedTypes": [],
-    "pdas": [],
-    "errors": []
-  },
-  "additionalPrograms": []
+    "version": "0.0.0"
+  }
 }

--- a/crates/pina_cli/tests/snapshots/fixtures__multiple_instructions.snap
+++ b/crates/pina_cli/tests/snapshots/fixtures__multiple_instructions.snap
@@ -1,17 +1,17 @@
 ---
 source: crates/pina_cli/tests/fixtures.rs
+assertion_line: 38
 expression: idl
 ---
 {
   "kind": "rootNode",
   "standard": "codama",
-  "version": "1.0.0",
+  "version": "1.8.0",
   "program": {
     "kind": "programNode",
     "name": "multipleInstructions",
     "publicKey": "GJQcuWrT2f3f4KNuJcXhhwUa1ZQTYbxzzJ1hotzKu8hS",
-    "version": "",
-    "accounts": [],
+    "version": "0.0.0",
     "instructions": [
       {
         "kind": "instructionNode",
@@ -21,13 +21,15 @@ expression: idl
             "kind": "instructionAccountNode",
             "name": "authority",
             "isWritable": false,
-            "isSigner": true
+            "isSigner": true,
+            "isOptional": false
           },
           {
             "kind": "instructionAccountNode",
             "name": "state",
             "isWritable": true,
-            "isSigner": false
+            "isSigner": false,
+            "isOptional": false
           }
         ],
         "arguments": [
@@ -68,13 +70,15 @@ expression: idl
             "kind": "instructionAccountNode",
             "name": "authority",
             "isWritable": false,
-            "isSigner": true
+            "isSigner": true,
+            "isOptional": false
           },
           {
             "kind": "instructionAccountNode",
             "name": "state",
             "isWritable": true,
-            "isSigner": false
+            "isSigner": false,
+            "isOptional": false
           }
         ],
         "arguments": [
@@ -107,10 +111,6 @@ expression: idl
           }
         ]
       }
-    ],
-    "definedTypes": [],
-    "pdas": [],
-    "errors": []
-  },
-  "additionalPrograms": []
+    ]
+  }
 }

--- a/crates/pina_cli/tests/snapshots/fixtures__pda_seeds.snap
+++ b/crates/pina_cli/tests/snapshots/fixtures__pda_seeds.snap
@@ -1,17 +1,17 @@
 ---
 source: crates/pina_cli/tests/fixtures.rs
+assertion_line: 38
 expression: idl
 ---
 {
   "kind": "rootNode",
   "standard": "codama",
-  "version": "1.0.0",
+  "version": "1.8.0",
   "program": {
     "kind": "programNode",
     "name": "pdaSeeds",
     "publicKey": "GJQcuWrT2f3f4KNuJcXhhwUa1ZQTYbxzzJ1hotzKu8hS",
-    "version": "",
-    "accounts": [],
+    "version": "0.0.0",
     "instructions": [
       {
         "kind": "instructionNode",
@@ -21,13 +21,15 @@ expression: idl
             "kind": "instructionAccountNode",
             "name": "authority",
             "isWritable": false,
-            "isSigner": false
+            "isSigner": false,
+            "isOptional": false
           },
           {
             "kind": "instructionAccountNode",
             "name": "counter",
             "isWritable": true,
             "isSigner": false,
+            "isOptional": false,
             "defaultValue": {
               "kind": "pdaValueNode",
               "pda": {
@@ -78,7 +80,6 @@ expression: idl
         ]
       }
     ],
-    "definedTypes": [],
     "pdas": [
       {
         "kind": "pdaNode",
@@ -104,8 +105,6 @@ expression: idl
           }
         ]
       }
-    ],
-    "errors": []
-  },
-  "additionalPrograms": []
+    ]
+  }
 }

--- a/crates/pina_cli/tests/snapshots/fixtures__single_account.snap
+++ b/crates/pina_cli/tests/snapshots/fixtures__single_account.snap
@@ -1,16 +1,17 @@
 ---
 source: crates/pina_cli/tests/fixtures.rs
+assertion_line: 38
 expression: idl
 ---
 {
   "kind": "rootNode",
   "standard": "codama",
-  "version": "1.0.0",
+  "version": "1.8.0",
   "program": {
     "kind": "programNode",
     "name": "singleAccount",
     "publicKey": "GJQcuWrT2f3f4KNuJcXhhwUa1ZQTYbxzzJ1hotzKu8hS",
-    "version": "",
+    "version": "0.0.0",
     "accounts": [
       {
         "kind": "accountNode",
@@ -55,11 +56,6 @@ expression: idl
           }
         ]
       }
-    ],
-    "instructions": [],
-    "definedTypes": [],
-    "pdas": [],
-    "errors": []
-  },
-  "additionalPrograms": []
+    ]
+  }
 }

--- a/crates/pina_cli/tests/snapshots/fixtures__single_instruction.snap
+++ b/crates/pina_cli/tests/snapshots/fixtures__single_instruction.snap
@@ -1,17 +1,17 @@
 ---
 source: crates/pina_cli/tests/fixtures.rs
+assertion_line: 38
 expression: idl
 ---
 {
   "kind": "rootNode",
   "standard": "codama",
-  "version": "1.0.0",
+  "version": "1.8.0",
   "program": {
     "kind": "programNode",
     "name": "singleInstruction",
     "publicKey": "GJQcuWrT2f3f4KNuJcXhhwUa1ZQTYbxzzJ1hotzKu8hS",
-    "version": "",
-    "accounts": [],
+    "version": "0.0.0",
     "instructions": [
       {
         "kind": "instructionNode",
@@ -21,13 +21,15 @@ expression: idl
             "kind": "instructionAccountNode",
             "name": "authority",
             "isWritable": false,
-            "isSigner": false
+            "isSigner": false,
+            "isOptional": false
           },
           {
             "kind": "instructionAccountNode",
             "name": "target",
             "isWritable": false,
-            "isSigner": false
+            "isSigner": false,
+            "isOptional": false
           }
         ],
         "arguments": [
@@ -72,10 +74,6 @@ expression: idl
           }
         ]
       }
-    ],
-    "definedTypes": [],
-    "pdas": [],
-    "errors": []
-  },
-  "additionalPrograms": []
+    ]
+  }
 }

--- a/crates/pina_cli/tests/snapshots/fixtures__validation_known_programs.snap
+++ b/crates/pina_cli/tests/snapshots/fixtures__validation_known_programs.snap
@@ -1,17 +1,17 @@
 ---
 source: crates/pina_cli/tests/fixtures.rs
+assertion_line: 38
 expression: idl
 ---
 {
   "kind": "rootNode",
   "standard": "codama",
-  "version": "1.0.0",
+  "version": "1.8.0",
   "program": {
     "kind": "programNode",
     "name": "validationKnownPrograms",
     "publicKey": "GJQcuWrT2f3f4KNuJcXhhwUa1ZQTYbxzzJ1hotzKu8hS",
-    "version": "",
-    "accounts": [],
+    "version": "0.0.0",
     "instructions": [
       {
         "kind": "instructionNode",
@@ -22,6 +22,7 @@ expression: idl
             "name": "systemProgram",
             "isWritable": false,
             "isSigner": false,
+            "isOptional": false,
             "defaultValue": {
               "kind": "publicKeyValueNode",
               "publicKey": "11111111111111111111111111111111"
@@ -32,6 +33,7 @@ expression: idl
             "name": "tokenProgram",
             "isWritable": false,
             "isSigner": false,
+            "isOptional": false,
             "defaultValue": {
               "kind": "publicKeyValueNode",
               "publicKey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
@@ -42,6 +44,7 @@ expression: idl
             "name": "token2022Program",
             "isWritable": false,
             "isSigner": false,
+            "isOptional": false,
             "defaultValue": {
               "kind": "publicKeyValueNode",
               "publicKey": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
@@ -52,13 +55,13 @@ expression: idl
             "name": "associatedTokenProgram",
             "isWritable": false,
             "isSigner": false,
+            "isOptional": false,
             "defaultValue": {
               "kind": "publicKeyValueNode",
               "publicKey": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
             }
           }
         ],
-        "arguments": [],
         "discriminators": [
           {
             "kind": "constantDiscriminatorNode",
@@ -78,10 +81,6 @@ expression: idl
           }
         ]
       }
-    ],
-    "definedTypes": [],
-    "pdas": [],
-    "errors": []
-  },
-  "additionalPrograms": []
+    ]
+  }
 }

--- a/crates/pina_cli/tests/snapshots/fixtures__validation_signer_writable.snap
+++ b/crates/pina_cli/tests/snapshots/fixtures__validation_signer_writable.snap
@@ -1,17 +1,17 @@
 ---
 source: crates/pina_cli/tests/fixtures.rs
+assertion_line: 38
 expression: idl
 ---
 {
   "kind": "rootNode",
   "standard": "codama",
-  "version": "1.0.0",
+  "version": "1.8.0",
   "program": {
     "kind": "programNode",
     "name": "validationSignerWritable",
     "publicKey": "GJQcuWrT2f3f4KNuJcXhhwUa1ZQTYbxzzJ1hotzKu8hS",
-    "version": "",
-    "accounts": [],
+    "version": "0.0.0",
     "instructions": [
       {
         "kind": "instructionNode",
@@ -21,22 +21,24 @@ expression: idl
             "kind": "instructionAccountNode",
             "name": "authority",
             "isWritable": false,
-            "isSigner": true
+            "isSigner": true,
+            "isOptional": false
           },
           {
             "kind": "instructionAccountNode",
             "name": "payer",
             "isWritable": true,
-            "isSigner": true
+            "isSigner": true,
+            "isOptional": false
           },
           {
             "kind": "instructionAccountNode",
             "name": "recipient",
             "isWritable": true,
-            "isSigner": false
+            "isSigner": false,
+            "isOptional": false
           }
         ],
-        "arguments": [],
         "discriminators": [
           {
             "kind": "constantDiscriminatorNode",
@@ -56,10 +58,6 @@ expression: idl
           }
         ]
       }
-    ],
-    "definedTypes": [],
-    "pdas": [],
-    "errors": []
-  },
-  "additionalPrograms": []
+    ]
+  }
 }

--- a/crates/pina_codama_renderer/src/__tests.rs
+++ b/crates/pina_codama_renderer/src/__tests.rs
@@ -13,15 +13,15 @@ use codama_nodes::ConstantValueNode;
 use codama_nodes::DefinedTypeNode;
 use codama_nodes::DiscriminatorNode;
 use codama_nodes::Docs;
-use codama_nodes::Endian;
+use codama_nodes::Endianness;
 use codama_nodes::InstructionAccountNode;
 use codama_nodes::InstructionInputValueNode;
 use codama_nodes::InstructionNode;
-use codama_nodes::InstructionOptionalAccountStrategy;
-use codama_nodes::IsAccountSigner;
+use codama_nodes::IsSigner;
 use codama_nodes::NumberFormat;
 use codama_nodes::NumberTypeNode;
 use codama_nodes::NumberValueNode;
+use codama_nodes::OptionalAccountStrategy;
 use codama_nodes::PdaLinkNode;
 use codama_nodes::PdaNode;
 use codama_nodes::PdaSeedNode;
@@ -145,6 +145,8 @@ fn renders_pda_helpers_for_linked_account() {
 			))],
 		)],
 		errors: vec![],
+		events: vec![],
+		constants: vec![],
 		version: String::new(),
 		origin: None,
 		docs: Docs::default(),
@@ -164,16 +166,18 @@ fn renders_pda_helpers_for_linked_account() {
 #[test]
 fn renders_instruction_account_default_from_pda() {
 	let mut state = InstructionAccountNode::new("state", true, false);
-	state.default_value = Some(InstructionInputValueNode::Pda(PdaValueNode::new(
-		PdaLinkNode::new("statePda"),
-		vec![PdaSeedValueNode::new(
-			"authority",
-			AccountValueNode::new("authority"),
-		)],
+	state.default_value = Box::new(Some(InstructionInputValueNode::PdaValue(
+		PdaValueNode::new(
+			PdaLinkNode::new("statePda"),
+			vec![PdaSeedValueNode {
+				name: "authority".into(),
+				value: Box::new(AccountValueNode::new("authority").into()),
+			}],
+		),
 	)));
 
 	let mut authority = InstructionAccountNode::new("authority", false, true);
-	authority.is_signer = IsAccountSigner::Either;
+	authority.is_signer = IsSigner::Either;
 
 	let program = ProgramNode {
 		name: "defaultProgram".into(),
@@ -182,7 +186,7 @@ fn renders_instruction_account_default_from_pda() {
 		instructions: vec![InstructionNode {
 			name: "initialize".into(),
 			docs: Docs::default(),
-			optional_account_strategy: InstructionOptionalAccountStrategy::ProgramId,
+			optional_account_strategy: Some(OptionalAccountStrategy::ProgramId),
 			accounts: vec![authority, state],
 			arguments: vec![],
 			extra_arguments: vec![],
@@ -194,6 +198,9 @@ fn renders_instruction_account_default_from_pda() {
 			))],
 			status: None,
 			sub_instructions: vec![],
+			provides: vec![],
+			display: None,
+			plugins: vec![],
 		}],
 		defined_types: vec![],
 		pdas: vec![PdaNode::new(
@@ -210,6 +217,8 @@ fn renders_instruction_account_default_from_pda() {
 			],
 		)],
 		errors: vec![],
+		events: vec![],
+		constants: vec![],
 		version: String::new(),
 		origin: None,
 		docs: Docs::default(),
@@ -230,8 +239,8 @@ fn renders_instruction_account_default_from_pda() {
 #[test]
 fn renders_optional_accounts_with_program_fallback_strategy() {
 	let mut optional_signer = InstructionAccountNode::new("optionalSigner", false, false);
-	optional_signer.is_optional = true;
-	optional_signer.is_signer = IsAccountSigner::Either;
+	optional_signer.is_optional = Some(true);
+	optional_signer.is_signer = IsSigner::Either;
 
 	let program = ProgramNode {
 		name: "optionalProgram".into(),
@@ -240,7 +249,7 @@ fn renders_optional_accounts_with_program_fallback_strategy() {
 		instructions: vec![InstructionNode {
 			name: "maybe".into(),
 			docs: Docs::default(),
-			optional_account_strategy: InstructionOptionalAccountStrategy::ProgramId,
+			optional_account_strategy: Some(OptionalAccountStrategy::ProgramId),
 			accounts: vec![optional_signer],
 			arguments: vec![],
 			extra_arguments: vec![],
@@ -252,10 +261,15 @@ fn renders_optional_accounts_with_program_fallback_strategy() {
 			))],
 			status: None,
 			sub_instructions: vec![],
+			provides: vec![],
+			display: None,
+			plugins: vec![],
 		}],
 		defined_types: vec![],
 		pdas: vec![],
 		errors: vec![],
+		events: vec![],
+		constants: vec![],
 		version: String::new(),
 		origin: None,
 		docs: Docs::default(),
@@ -297,6 +311,8 @@ fn rejects_variable_size_strings() {
 		defined_types: vec![],
 		pdas: vec![],
 		errors: vec![],
+		events: vec![],
+		constants: vec![],
 		version: String::new(),
 		origin: None,
 		docs: Docs::default(),
@@ -329,7 +345,8 @@ fn rejects_big_endian_numbers() {
 				"count",
 				NumberTypeNode {
 					format: NumberFormat::U16,
-					endian: Endian::Big,
+					endian: Endianness::Be,
+					display: Box::new(None),
 				},
 			)])
 			.into(),
@@ -343,6 +360,8 @@ fn rejects_big_endian_numbers() {
 		defined_types: vec![],
 		pdas: vec![],
 		errors: vec![],
+		events: vec![],
+		constants: vec![],
 		version: String::new(),
 		origin: None,
 		docs: Docs::default(),
@@ -369,13 +388,16 @@ fn renders_defined_type_aliases_with_pod_wrappers() {
 		defined_types: vec![DefinedTypeNode {
 			name: "counter".into(),
 			docs: Docs::default(),
-			r#type: TypeNode::Number(NumberTypeNode {
+			r#type: Box::new(TypeNode::Number(NumberTypeNode {
 				format: NumberFormat::U64,
-				endian: Endian::Little,
-			}),
+				endian: Endianness::Le,
+				display: Box::new(None),
+			})),
 		}],
 		pdas: vec![],
 		errors: vec![],
+		events: vec![],
+		constants: vec![],
 		version: String::new(),
 		origin: None,
 		docs: Docs::default(),
@@ -400,7 +422,7 @@ fn rejects_missing_instruction_discriminators() {
 		instructions: vec![InstructionNode {
 			name: "doThing".into(),
 			docs: Docs::default(),
-			optional_account_strategy: InstructionOptionalAccountStrategy::ProgramId,
+			optional_account_strategy: Some(OptionalAccountStrategy::ProgramId),
 			accounts: vec![InstructionAccountNode::new("payer", true, true)],
 			arguments: vec![],
 			extra_arguments: vec![],
@@ -409,10 +431,15 @@ fn rejects_missing_instruction_discriminators() {
 			discriminators: vec![],
 			status: None,
 			sub_instructions: vec![],
+			provides: vec![],
+			display: None,
+			plugins: vec![],
 		}],
 		defined_types: vec![],
 		pdas: vec![],
 		errors: vec![],
+		events: vec![],
+		constants: vec![],
 		version: String::new(),
 		origin: None,
 		docs: Docs::default(),
@@ -458,7 +485,8 @@ fn validates_boolean_encoding_for_pda_variable_seed() {
 	let boolean_type = BooleanTypeNode {
 		size: NumberTypeNode {
 			format: NumberFormat::U16,
-			endian: Endian::Little,
+			endian: Endianness::Le,
+			display: Box::new(None),
 		}
 		.into(),
 	};

--- a/crates/pina_codama_renderer/src/render/discriminator.rs
+++ b/crates/pina_codama_renderer/src/render/discriminator.rs
@@ -1,6 +1,6 @@
 use codama_nodes::ConstantDiscriminatorNode;
 use codama_nodes::DiscriminatorNode;
-use codama_nodes::Endian;
+use codama_nodes::Endianness;
 use codama_nodes::HasKind;
 use codama_nodes::Number;
 use codama_nodes::NumberFormat;
@@ -74,7 +74,7 @@ fn render_constant_discriminator_value(
 }
 
 fn render_discriminator_type(number_type: &NumberTypeNode, context: &str) -> Result<String> {
-	if !matches!(number_type.endian, Endian::Little) {
+	if !matches!(number_type.endian, Endianness::Le) {
 		return Err(RenderError::UnsupportedDiscriminator {
 			context: context.to_string(),
 			reason: "only little-endian discriminators are supported".to_string(),

--- a/crates/pina_codama_renderer/src/render/instructions.rs
+++ b/crates/pina_codama_renderer/src/render/instructions.rs
@@ -2,13 +2,13 @@ use codama_nodes::HasKind;
 use codama_nodes::InstructionAccountNode;
 use codama_nodes::InstructionInputValueNode;
 use codama_nodes::InstructionNode;
-use codama_nodes::InstructionOptionalAccountStrategy;
-use codama_nodes::IsAccountSigner;
+use codama_nodes::IsSigner;
+use codama_nodes::OptionalAccountStrategy;
 use codama_nodes::PdaNode;
 use codama_nodes::PdaSeedNode;
-use codama_nodes::PdaSeedValueValueNode;
-use codama_nodes::PdaValue;
+use codama_nodes::PdaSeedValueValue;
 use codama_nodes::PdaValueNode;
+use codama_nodes::PdaValuePda;
 use codama_nodes::ProgramNode;
 
 use super::discriminator::render_constant_discriminator;
@@ -217,17 +217,17 @@ fn render_instruction_account_metas(
 		};
 
 		let signer_expr = match account.is_signer {
-			IsAccountSigner::False => "false".to_string(),
-			IsAccountSigner::True => "true".to_string(),
-			IsAccountSigner::Either => format!("self.{field_name}.1"),
+			IsSigner::False => "false".to_string(),
+			IsSigner::True => "true".to_string(),
+			IsSigner::Either => format!("self.{field_name}.1"),
 		};
 		let key_expr = match account.is_signer {
-			IsAccountSigner::Either => format!("self.{field_name}.0"),
+			IsSigner::Either => format!("self.{field_name}.0"),
 			_ => format!("self.{field_name}"),
 		};
 
-		if account.is_optional {
-			if account.is_signer == IsAccountSigner::Either {
+		if account.is_optional == Some(true) {
+			if account.is_signer == IsSigner::Either {
 				lines.push(format!(
 					"\t\tif let Some(({field_name}, signer)) = self.{field_name} {{"
 				));
@@ -247,7 +247,7 @@ fn render_instruction_account_metas(
 
 			if matches!(
 				instruction.optional_account_strategy,
-				InstructionOptionalAccountStrategy::ProgramId
+				Some(OptionalAccountStrategy::ProgramId)
 			) {
 				lines.push("\t\telse {".to_string());
 				lines.push(format!(
@@ -271,10 +271,10 @@ fn render_instruction_account_metas(
 
 fn render_instruction_account_field_type(account: &InstructionAccountNode) -> (String, String) {
 	let base_type = match account.is_signer {
-		IsAccountSigner::Either => "(solana_pubkey::Pubkey, bool)".to_string(),
-		IsAccountSigner::False | IsAccountSigner::True => "solana_pubkey::Pubkey".to_string(),
+		IsSigner::Either => "(solana_pubkey::Pubkey, bool)".to_string(),
+		IsSigner::False | IsSigner::True => "solana_pubkey::Pubkey".to_string(),
 	};
-	if account.is_optional {
+	if account.is_optional == Some(true) {
 		(format!("Option<{base_type}>"), base_type)
 	} else {
 		(base_type.clone(), base_type)
@@ -288,8 +288,8 @@ fn render_pda_default_value(
 	program: &ProgramNode,
 	account: &InstructionAccountNode,
 ) -> Result<String> {
-	let pda = match &pda_value.pda {
-		PdaValue::Linked(link) => {
+	let pda = match pda_value.pda.as_ref() {
+		PdaValuePda::PdaLink(link) => {
 			program
 				.pdas
 				.iter()
@@ -306,7 +306,7 @@ fn render_pda_default_value(
 					}
 				})?
 		}
-		PdaValue::Nested(pda) => pda,
+		PdaValuePda::Pda(pda) => pda,
 	};
 
 	let seed_expressions = render_pda_default_seed_expressions(
@@ -375,8 +375,8 @@ fn render_pda_default_seed_value(
 	default_account: &InstructionAccountNode,
 	context: &str,
 ) -> Result<String> {
-	match &value.value {
-		PdaSeedValueValueNode::Account(account) => {
+	match value.value.as_ref() {
+		PdaSeedValueValue::Account(account) => {
 			let name = account.name.as_ref();
 			let referenced_account = instruction
 				.accounts
@@ -391,7 +391,7 @@ fn render_pda_default_seed_value(
 				})?;
 
 			if referenced_account.name == default_account.name
-				|| referenced_account.is_optional
+				|| referenced_account.is_optional == Some(true)
 				|| referenced_account.default_value.is_some()
 			{
 				return Err(RenderError::UnsupportedValue {
@@ -404,13 +404,13 @@ fn render_pda_default_seed_value(
 			}
 
 			let seed_name = snake(name);
-			if matches!(referenced_account.is_signer, IsAccountSigner::Either) {
+			if matches!(referenced_account.is_signer, IsSigner::Either) {
 				Ok(format!("{seed_name}.0.as_ref()"))
 			} else {
 				Ok(format!("{seed_name}.as_ref()"))
 			}
 		}
-		PdaSeedValueValueNode::Argument(_) => {
+		PdaSeedValueValue::Argument(_) => {
 			Err(RenderError::UnsupportedValue {
 				context: context.to_string(),
 				kind: value.value.kind(),
@@ -444,19 +444,19 @@ fn render_instruction_account_default_value(
 	primary_program_const: &str,
 	program: &ProgramNode,
 ) -> Result<Option<String>> {
-	if account.is_optional {
+	if account.is_optional == Some(true) {
 		return Ok(Some("None".to_string()));
 	}
 
-	let Some(default_value) = &account.default_value else {
+	let Some(default_value) = account.default_value.as_ref() else {
 		return Ok(None);
 	};
 
 	let value = match default_value {
-		InstructionInputValueNode::PublicKey(public_key) => {
+		InstructionInputValueNode::PublicKeyValue(public_key) => {
 			format!("solana_pubkey::pubkey!(\"{}\")", public_key.public_key)
 		}
-		InstructionInputValueNode::ProgramId(_) => {
+		InstructionInputValueNode::ProgramIdValue(_) => {
 			format!("crate::{primary_program_const}")
 		}
 		InstructionInputValueNode::ProgramLink(program_link) => {
@@ -465,7 +465,7 @@ fn render_instruction_account_default_value(
 				program_id_const_name(program_link.name.as_ref())
 			)
 		}
-		InstructionInputValueNode::Pda(pda) => {
+		InstructionInputValueNode::PdaValue(pda) => {
 			render_pda_default_value(pda, instruction, primary_program_const, program, account)?
 		}
 		_ => {
@@ -481,7 +481,7 @@ fn render_instruction_account_default_value(
 		}
 	};
 
-	if matches!(account.is_signer, IsAccountSigner::Either) {
+	if matches!(account.is_signer, IsSigner::Either) {
 		return Ok(Some(format!("({value}, false)")));
 	}
 

--- a/crates/pina_codama_renderer/src/render/seeds.rs
+++ b/crates/pina_codama_renderer/src/render/seeds.rs
@@ -1,5 +1,6 @@
+use codama_nodes::ConstantPdaSeedValue;
 use codama_nodes::CountNode;
-use codama_nodes::Endian;
+use codama_nodes::Endianness;
 use codama_nodes::HasKind;
 use codama_nodes::NestedTypeNodeTrait;
 use codama_nodes::Number;
@@ -28,7 +29,7 @@ pub(crate) fn render_variable_seed_parameter(
 		TypeNode::Boolean(boolean_type) => {
 			let number_type = boolean_type.size.get_nested_type_node();
 			if !matches!(number_type.format, NumberFormat::U8)
-				|| !matches!(number_type.endian, Endian::Little)
+				|| !matches!(number_type.endian, Endianness::Le)
 			{
 				return Err(RenderError::UnsupportedType {
 					context: context.to_string(),
@@ -39,7 +40,7 @@ pub(crate) fn render_variable_seed_parameter(
 			Ok(("bool".to_string(), format!("&[u8::from({seed_name})]")))
 		}
 		TypeNode::Number(number_type) => {
-			if !matches!(number_type.endian, Endian::Little) {
+			if !matches!(number_type.endian, Endianness::Le) {
 				return Err(RenderError::UnsupportedType {
 					context: context.to_string(),
 					kind: "numberTypeNode",
@@ -83,7 +84,7 @@ pub(crate) fn render_variable_seed_parameter(
 			}
 		}
 		TypeNode::Array(array) => {
-			match &array.count {
+			match array.count.as_ref() {
 				CountNode::Fixed(count) => {
 					let inner = render_type_for_pod(&array.item, context)?;
 					Ok((
@@ -112,22 +113,24 @@ pub(crate) fn render_variable_seed_parameter(
 
 pub(crate) fn render_constant_seed_expression(
 	r#type: &TypeNode,
-	value: &ValueNode,
+	value: &ConstantPdaSeedValue,
 	context: &str,
 	primary_program_const: &str,
 ) -> Result<String> {
 	match value {
-		ValueNode::String(string_value) => Ok(format!("{:?}.as_bytes()", string_value.string)),
-		ValueNode::Number(number_value) => {
+		ConstantPdaSeedValue::String(string_value) => {
+			Ok(format!("{:?}.as_bytes()", string_value.string))
+		}
+		ConstantPdaSeedValue::Number(number_value) => {
 			render_number_seed_expression(r#type, &number_value.number, context)
 		}
-		ValueNode::PublicKey(public_key_value) => {
+		ConstantPdaSeedValue::PublicKey(public_key_value) => {
 			Ok(format!(
 				"solana_pubkey::pubkey!(\"{}\").as_ref()",
 				public_key_value.public_key
 			))
 		}
-		ValueNode::Constant(constant_value) => {
+		ConstantPdaSeedValue::Constant(constant_value) => {
 			match constant_value.value.as_ref() {
 				ValueNode::String(string_value) => {
 					Ok(format!("{:?}.as_bytes()", string_value.string))
@@ -148,7 +151,7 @@ pub(crate) fn render_constant_seed_expression(
 				}
 			}
 		}
-		ValueNode::Bytes(bytes_value) => {
+		ConstantPdaSeedValue::Bytes(bytes_value) => {
 			if matches!(bytes_value.encoding, codama_nodes::BytesEncoding::Utf8) {
 				Ok(format!("{:?}.as_bytes()", bytes_value.data))
 			} else {
@@ -184,7 +187,7 @@ pub(crate) fn render_number_seed_expression(
 			reason: "numeric seed value requires number type".to_string(),
 		});
 	};
-	if !matches!(number_type.endian, Endian::Little) {
+	if !matches!(number_type.endian, Endianness::Le) {
 		return Err(RenderError::UnsupportedType {
 			context: context.to_string(),
 			kind: "numberTypeNode",

--- a/crates/pina_codama_renderer/src/render/types.rs
+++ b/crates/pina_codama_renderer/src/render/types.rs
@@ -2,7 +2,7 @@ use codama_nodes::BooleanTypeNode;
 use codama_nodes::CountNode;
 use codama_nodes::DefinedTypeNode;
 use codama_nodes::Docs;
-use codama_nodes::Endian;
+use codama_nodes::Endianness;
 use codama_nodes::HasKind;
 use codama_nodes::NestedTypeNodeTrait;
 use codama_nodes::NumberFormat;
@@ -45,7 +45,7 @@ pub(crate) fn render_type_for_pod(r#type: &TypeNode, context: &str) -> Result<St
 		}
 		TypeNode::Array(array_type) => {
 			let item_type = render_type_for_pod(&array_type.item, context)?;
-			match &array_type.count {
+			match array_type.count.as_ref() {
 				CountNode::Fixed(count) => Ok(format!("[{item_type}; {}]", count.value)),
 				CountNode::Prefixed(_) | CountNode::Remainder(_) => {
 					Err(RenderError::UnsupportedType {
@@ -73,7 +73,7 @@ pub(crate) fn render_type_for_pod(r#type: &TypeNode, context: &str) -> Result<St
 }
 
 fn render_number_type_for_pod(number_type: &NumberTypeNode, context: &str) -> Result<String> {
-	if !matches!(number_type.endian, Endian::Little) {
+	if !matches!(number_type.endian, Endianness::Le) {
 		return Err(RenderError::UnsupportedType {
 			context: context.to_string(),
 			kind: "numberTypeNode",
@@ -105,7 +105,7 @@ fn render_number_type_for_pod(number_type: &NumberTypeNode, context: &str) -> Re
 fn render_boolean_type(boolean_type: &BooleanTypeNode, context: &str) -> Result<String> {
 	let number_type = boolean_type.size.get_nested_type_node();
 	if !matches!(number_type.format, NumberFormat::U8)
-		|| !matches!(number_type.endian, Endian::Little)
+		|| !matches!(number_type.endian, Endianness::Le)
 	{
 		return Err(RenderError::UnsupportedType {
 			context: context.to_string(),
@@ -119,7 +119,7 @@ fn render_boolean_type(boolean_type: &BooleanTypeNode, context: &str) -> Result<
 pub(crate) fn render_defined_type_page(defined_type: &DefinedTypeNode) -> Result<String> {
 	let name = pascal(defined_type.name.as_ref());
 	let context = format!("defined type `{name}`");
-	match &defined_type.r#type {
+	match defined_type.r#type.as_ref() {
 		TypeNode::Struct(struct_type) => {
 			render_defined_struct(name.as_str(), struct_type, &defined_type.docs)
 		}

--- a/devenv.nix
+++ b/devenv.nix
@@ -868,6 +868,10 @@ in
     "security:audit" = {
       exec = ''
         set -euo pipefail
+        # The advisory DB lives inside the cached target dir; a stale or
+        # partial clone from a cache restore makes cargo-audit refuse to
+        # (re)initialize it. Remove it so the clone always starts fresh.
+        rm -rf "$DEVENV_ROOT/target/advisory-db-audit"
         cargo-audit audit \
           --db "$DEVENV_ROOT/target/advisory-db-audit" \
           --url "https://github.com/RustSec/advisory-db.git" \

--- a/examples/escrow_program/src/lib.rs
+++ b/examples/escrow_program/src/lib.rs
@@ -193,15 +193,14 @@ impl<'a> ProcessAccountInfos<'a> for MakeAccounts<'a> {
 
 		// Transfer tokens to vault
 		let decimals = self.mint_a.as_token_mint()?.decimals();
-		token_2022::instructions::TransferChecked {
-			from: self.maker_ata_a,
-			to: self.vault,
-			authority: self.maker,
-			amount: args.amount_a.into(),
-			mint: self.mint_a,
+		token_2022::instructions::TransferChecked::new(
+			self.maker_ata_a,
+			self.mint_a,
+			self.vault,
+			self.maker,
+			args.amount_a.into(),
 			decimals,
-			token_program: self.token_program.address(),
-		}
+		)
 		.invoke()?;
 
 		Ok(())
@@ -312,15 +311,14 @@ impl<'a> ProcessAccountInfos<'a> for TakeAccounts<'a> {
 		.invoke()?;
 
 		// Transfer token B from taker to maker
-		token_2022::instructions::TransferChecked {
-			from: self.taker_ata_b,
-			mint: self.mint_b,
-			to: self.maker_ata_b,
-			authority: self.taker,
-			amount: u64::from(amount_b),
-			decimals: self.mint_b.as_token_2022_mint()?.decimals(),
-			token_program: self.token_program.address(),
-		}
+		token_2022::instructions::TransferChecked::new(
+			self.taker_ata_b,
+			self.mint_b,
+			self.maker_ata_b,
+			self.taker,
+			u64::from(amount_b),
+			self.mint_b.as_token_2022_mint()?.decimals(),
+		)
 		.invoke()?;
 
 		// Prepare escrow signer for vault operations
@@ -331,25 +329,19 @@ impl<'a> ProcessAccountInfos<'a> for TakeAccounts<'a> {
 		let signers = [escrow_signer];
 
 		// Transfer token A from vault to taker
-		token_2022::instructions::TransferChecked {
-			from: self.vault,
-			mint: self.mint_a,
-			to: self.taker_ata_a,
-			authority: self.escrow,
-			amount: self.vault.as_token_2022_account()?.amount(),
-			decimals: self.mint_a.as_token_2022_mint()?.decimals(),
-			token_program: self.token_program.address(),
-		}
+		token_2022::instructions::TransferChecked::new(
+			self.vault,
+			self.mint_a,
+			self.taker_ata_a,
+			self.escrow,
+			self.vault.as_token_2022_account()?.amount(),
+			self.mint_a.as_token_2022_mint()?.decimals(),
+		)
 		.invoke_signed(&signers)?;
 
 		// Close vault account
-		token_2022::instructions::CloseAccount {
-			account: self.vault,
-			destination: self.maker,
-			authority: self.escrow,
-			token_program: self.token_program.address(),
-		}
-		.invoke_signed(&signers)?;
+		token_2022::instructions::CloseAccount::new(self.vault, self.maker, self.escrow)
+			.invoke_signed(&signers)?;
 
 		// Zero out escrow state and close
 		self.escrow.as_account_mut::<EscrowState>(&ID)?.zeroed();

--- a/examples/escrow_program/src/lib.rs
+++ b/examples/escrow_program/src/lib.rs
@@ -329,12 +329,14 @@ impl<'a> ProcessAccountInfos<'a> for TakeAccounts<'a> {
 		let signers = [escrow_signer];
 
 		// Transfer token A from vault to taker
+		self.vault.assert_owners(&SPL_PROGRAM_IDS)?;
+		let vault_amount = self.vault.as_token_2022_account()?.amount();
 		token_2022::instructions::TransferChecked::new(
 			self.vault,
 			self.mint_a,
 			self.taker_ata_a,
 			self.escrow,
-			self.vault.as_token_2022_account()?.amount(),
+			vault_amount,
 			self.mint_a.as_token_2022_mint()?.decimals(),
 		)
 		.invoke_signed(&signers)?;

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
 		"test": "pnpm run generate && pnpm run check:js"
 	},
 	"dependencies": {
-		"@codama/renderers-js": "^2.1.0",
-		"codama": "^1.5.1"
+		"@codama/renderers-js": "^2.3.1",
+		"codama": "^1.10.0"
 	},
 	"devDependencies": {
 		"@solana/kit": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
 		"codama": "^1.10.0"
 	},
 	"devDependencies": {
-		"@solana/kit": "^6.5.0",
-		"@solana/program-client-core": "^6.5.0",
+		"@solana/kit": "^6.10.0",
+		"@solana/program-client-core": "^6.10.0",
 		"@types/node": "^25.5.0",
 		"typescript": "^5.9.3"
 	}

--- a/packages/nodes-from-pina/package.json
+++ b/packages/nodes-from-pina/package.json
@@ -33,7 +33,7 @@
 		"test:unit": "vitest run"
 	},
 	"dependencies": {
-		"codama": "^1.5.1"
+		"codama": "^1.10.0"
 	},
 	"devDependencies": {
 		"@types/node": "^25.5.0",

--- a/packages/nodes-from-pina/test/rootNodeFromPina.test.ts
+++ b/packages/nodes-from-pina/test/rootNodeFromPina.test.ts
@@ -25,7 +25,7 @@ test("it creates root nodes from a Pina IDL JSON string", () => {
 	expect(root.program.publicKey).toBe(
 		"Fc5A5xvNQ6w7kn2P7FpC18JNpDutLCRa14Q6gttxyPjd",
 	);
-	expect(root.program.accounts[0]?.size).toBeDefined();
+	expect(root.program.accounts?.[0]?.size).toBeDefined();
 });
 
 test("it creates root nodes from parsed Pina IDL objects", () => {
@@ -36,7 +36,7 @@ test("it creates root nodes from parsed Pina IDL objects", () => {
 
 	expect(root.kind).toBe("rootNode");
 	expect(root.program.name).toBe("todoProgram");
-	expect(root.program.accounts[0]?.size).toBeDefined();
+	expect(root.program.accounts?.[0]?.size).toBeDefined();
 });
 
 test("it can skip the default visitor", () => {
@@ -47,7 +47,7 @@ test("it can skip the default visitor", () => {
 	);
 
 	expect(root.kind).toBe("rootNode");
-	expect(root.program.accounts[0]?.size).toBeUndefined();
+	expect(root.program.accounts?.[0]?.size).toBeUndefined();
 });
 
 test("it throws on invalid input", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@codama/renderers-js':
-        specifier: ^2.1.0
-        version: 2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+        specifier: ^2.3.1
+        version: 2.3.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       codama:
-        specifier: ^1.5.1
-        version: 1.5.1
+        specifier: ^1.10.0
+        version: 1.10.0
     devDependencies:
       '@solana/kit':
         specifier: ^6.5.0
@@ -93,7 +93,7 @@ importers:
         version: 6.1.3
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.8)(typescript@6.0.2)
+        version: 8.5.1(postcss@8.5.26)(typescript@6.0.2)
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
@@ -141,28 +141,54 @@ packages:
     resolution: {integrity: sha512-+q62IvEA6o7ji/mcnGgAvyPWyiFx3cojVGrFNG8NSm0zFXrBk1lT3n/qg+2Ag8C8aHwno9boXgDTxV+P5VCDYw==}
     hasBin: true
 
+  '@codama/cli@1.6.0':
+    resolution: {integrity: sha512-68fam0kzWsKp2ip/LZn3kDyFjWcbzHExCuDgEHGTX8C0gSscMch/c4EgtTq7NsWKc1cse0GMC5WIxCFumroTyQ==}
+    hasBin: true
+
+  '@codama/errors@1.10.0':
+    resolution: {integrity: sha512-/qiWQcbPIsyFlP1LrLqJfHt1QNbkY2wtC4UxZyKLnuZtc62YPlgDrN2wp4wcfRuE/DC0n3Y6ZSwYUrDBZyAnvA==}
+    hasBin: true
+
   '@codama/errors@1.5.1':
     resolution: {integrity: sha512-kdLk/OSLBt03DoViRU1Xr0M7NZ7J/CSqaXV8fooF9qMRGPRJdgUeW2VkCGlLXDQSaIALrls3HkHmKRKbqqjSOA==}
     hasBin: true
 
+  '@codama/fragments@0.1.3':
+    resolution: {integrity: sha512-ITa3UYs74AWx7se/6EZN+YXqV1Vu89L3n2v0/irsQNbPcy8wP26p/GKns/1H4a8vGvAKuzWdIGO535dwcauInw==}
+
+  '@codama/node-types@1.10.0':
+    resolution: {integrity: sha512-fMoJQ8TgB9A5Pl+GA8ffhDbGK63cV1nrbDrYTgIhPDKeVqBSdkSAoAuAtvWfRd7X2ML73H6RRi6jZRJmo2xfHQ==}
+
   '@codama/node-types@1.5.1':
     resolution: {integrity: sha512-jMGz93MSszb1iXAAyWWa0i7RQbLxGihLKRZ+zr9aBsjaFFmhXhONfTFeSXzbEfc05cajpd/gW2QI7xmQHlUDKQ==}
+
+  '@codama/nodes@1.10.0':
+    resolution: {integrity: sha512-P3NXVw6kZq2VDb4wYU6zQ3xFksDqSuDYqp11P6Dpei9XIZZ11NtL2jBjBcqsIudGIx104bMgSo4SZ7Hlej056A==}
 
   '@codama/nodes@1.5.1':
     resolution: {integrity: sha512-6fIoH5Cfa5dFUE1fRxymZloeNg02klOT4fHsWwQavkkRWkoySgiti//w0j1itiZj6j5O+usujrwsZUJqSFjnhQ==}
 
-  '@codama/renderers-core@1.3.6':
-    resolution: {integrity: sha512-m3yAmhrObnagyC7d8g9bZxyLC5YMpttLagRE0aAKD4zlDDh23o3zV7TxSYCh2nRCg5ObceflgvXdauIHUm/6Xg==}
+  '@codama/renderers-core@1.3.11':
+    resolution: {integrity: sha512-VSGrfmwPVv5cRAiHitgIq+rc9ktIN/Q9czbUORaqhZCmM+M3Ux5cd5r90PVTbeIt8vI0Zlw74OUFwdKqdEfSNw==}
 
-  '@codama/renderers-js@2.1.0':
-    resolution: {integrity: sha512-Zs9avEFb1+Y4GDPIBTEv/bhHCdjRkAkisWSqNo9edxQyfPj4GzV+0/FtE0AfR+yFkxQVHANlaEpo2dtdS0UPbA==}
+  '@codama/renderers-js@2.3.1':
+    resolution: {integrity: sha512-+7WtjpcqnlPkweG+tWWiER2XkJP7SF+RJgYpI0RHc91ZP60Umt0qc+0JPuqMyiPhVrLTN2U/lpsBDQw2MeEsvA==}
     engines: {node: '>=20.18.0'}
+
+  '@codama/validators@1.10.0':
+    resolution: {integrity: sha512-5WH1IHmyVVG/9QThZsrVM2ROv5w3yLF/8+4HK/kr8uw0ZXnIBGidnmyrxr1P8V+X6DgZqKJaX46V30dSs/NOTQ==}
 
   '@codama/validators@1.5.1':
     resolution: {integrity: sha512-aUXl39AMa091CBWpYiK2XCXP/uyKOOtAT399TzRld3z8dIH9E0fGyu4ocP+IhQKXWXDPsh7V3qPmqsdyevOPcQ==}
 
+  '@codama/visitors-core@1.10.0':
+    resolution: {integrity: sha512-8koBGs4m/NI4nDLJZx7Q1KzRUKkBy/GAnZq4xOEFGlhTvDCIAzEgo3biAhNFynGY45gzZJSX08QTDWKsPRjnaA==}
+
   '@codama/visitors-core@1.5.1':
     resolution: {integrity: sha512-JotrDJLI7OfPNHulu4KtPfUDF/FYMC3RgEnv9lu47Fiiy0upbGAw1NorgBuoreyJ9Uj0GZyHt7Q5rjrCoa1U0g==}
+
+  '@codama/visitors@1.10.0':
+    resolution: {integrity: sha512-xAGKosZQnXBo9MiHFipA9Dsec1k9nbpv5UgUyY1j3l85FGEZQT2tHqrNxtBmPrC3LNSLVOfAdiUUMVUXUX5ydA==}
 
   '@codama/visitors@1.5.1':
     resolution: {integrity: sha512-8WcGP1tJKtqBfZ4mJsBRPjZ/H6+SPLWmiUoDTXRrVePQE4X4Yb04o6BoX2Uc3heZbfEc0rXdM1w8HTFvXBX4/A==}
@@ -173,8 +199,8 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/aix-ppc64@0.27.4':
-    resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
@@ -185,8 +211,8 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm64@0.27.4':
-    resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -197,8 +223,8 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.27.4':
-    resolution: {integrity: sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==}
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
@@ -209,8 +235,8 @@ packages:
     cpu: [x64]
     os: [android]
 
-  '@esbuild/android-x64@0.27.4':
-    resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -221,8 +247,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.27.4':
-    resolution: {integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==}
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
@@ -233,8 +259,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.4':
-    resolution: {integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==}
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -245,8 +271,8 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.27.4':
-    resolution: {integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==}
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
@@ -257,8 +283,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.4':
-    resolution: {integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==}
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -269,8 +295,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.27.4':
-    resolution: {integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==}
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
@@ -281,8 +307,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.4':
-    resolution: {integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==}
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -293,8 +319,8 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.4':
-    resolution: {integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==}
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
@@ -305,8 +331,8 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.4':
-    resolution: {integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==}
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -317,8 +343,8 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.4':
-    resolution: {integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==}
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
@@ -329,8 +355,8 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.4':
-    resolution: {integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==}
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -341,8 +367,8 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.4':
-    resolution: {integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==}
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
@@ -353,8 +379,8 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.4':
-    resolution: {integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==}
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -365,8 +391,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.4':
-    resolution: {integrity: sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==}
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
@@ -377,8 +403,8 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-arm64@0.27.4':
-    resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -389,8 +415,8 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.4':
-    resolution: {integrity: sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==}
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
@@ -401,8 +427,8 @@ packages:
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-arm64@0.27.4':
-    resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -413,8 +439,8 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.4':
-    resolution: {integrity: sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==}
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
@@ -425,8 +451,8 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/openharmony-arm64@0.27.4':
-    resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -437,8 +463,8 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.27.4':
-    resolution: {integrity: sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==}
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
@@ -449,8 +475,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-arm64@0.27.4':
-    resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -461,8 +487,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.4':
-    resolution: {integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==}
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
@@ -473,8 +499,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@esbuild/win32-x64@0.27.4':
-    resolution: {integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==}
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -492,13 +518,20 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@rollup/rollup-android-arm-eabi@4.59.0':
     resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm-eabi@4.60.0':
-    resolution: {integrity: sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==}
+  '@rollup/rollup-android-arm-eabi@4.62.4':
+    resolution: {integrity: sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==}
     cpu: [arm]
     os: [android]
 
@@ -507,8 +540,8 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.60.0':
-    resolution: {integrity: sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==}
+  '@rollup/rollup-android-arm64@4.62.4':
+    resolution: {integrity: sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==}
     cpu: [arm64]
     os: [android]
 
@@ -517,8 +550,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-arm64@4.60.0':
-    resolution: {integrity: sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==}
+  '@rollup/rollup-darwin-arm64@4.62.4':
+    resolution: {integrity: sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==}
     cpu: [arm64]
     os: [darwin]
 
@@ -527,8 +560,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.60.0':
-    resolution: {integrity: sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==}
+  '@rollup/rollup-darwin-x64@4.62.4':
+    resolution: {integrity: sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==}
     cpu: [x64]
     os: [darwin]
 
@@ -537,8 +570,8 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-arm64@4.60.0':
-    resolution: {integrity: sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==}
+  '@rollup/rollup-freebsd-arm64@4.62.4':
+    resolution: {integrity: sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==}
     cpu: [arm64]
     os: [freebsd]
 
@@ -547,8 +580,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.60.0':
-    resolution: {integrity: sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==}
+  '@rollup/rollup-freebsd-x64@4.62.4':
+    resolution: {integrity: sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==}
     cpu: [x64]
     os: [freebsd]
 
@@ -558,8 +591,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.0':
-    resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
+    resolution: {integrity: sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
@@ -570,8 +603,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.60.0':
-    resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
+  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
+    resolution: {integrity: sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==}
     cpu: [arm]
     os: [linux]
     libc: [musl]
@@ -582,8 +615,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm64-gnu@4.60.0':
-    resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
+  '@rollup/rollup-linux-arm64-gnu@4.62.4':
+    resolution: {integrity: sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -594,8 +627,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-arm64-musl@4.60.0':
-    resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
+  '@rollup/rollup-linux-arm64-musl@4.62.4':
+    resolution: {integrity: sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
@@ -606,8 +639,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.0':
-    resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
+  '@rollup/rollup-linux-loong64-gnu@4.62.4':
+    resolution: {integrity: sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==}
     cpu: [loong64]
     os: [linux]
     libc: [glibc]
@@ -618,8 +651,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-loong64-musl@4.60.0':
-    resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
+  '@rollup/rollup-linux-loong64-musl@4.62.4':
+    resolution: {integrity: sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==}
     cpu: [loong64]
     os: [linux]
     libc: [musl]
@@ -630,8 +663,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.60.0':
-    resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
+  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
+    resolution: {integrity: sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
@@ -642,8 +675,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-ppc64-musl@4.60.0':
-    resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
+  '@rollup/rollup-linux-ppc64-musl@4.62.4':
+    resolution: {integrity: sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==}
     cpu: [ppc64]
     os: [linux]
     libc: [musl]
@@ -654,8 +687,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.60.0':
-    resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
+  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
+    resolution: {integrity: sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
@@ -666,8 +699,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-riscv64-musl@4.60.0':
-    resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
+  '@rollup/rollup-linux-riscv64-musl@4.62.4':
+    resolution: {integrity: sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
@@ -678,8 +711,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-s390x-gnu@4.60.0':
-    resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
+  '@rollup/rollup-linux-s390x-gnu@4.62.4':
+    resolution: {integrity: sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
@@ -690,8 +723,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-gnu@4.60.0':
-    resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
+  '@rollup/rollup-linux-x64-gnu@4.62.4':
+    resolution: {integrity: sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -702,8 +735,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-x64-musl@4.60.0':
-    resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
+  '@rollup/rollup-linux-x64-musl@4.62.4':
+    resolution: {integrity: sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
@@ -713,8 +746,8 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@rollup/rollup-openbsd-x64@4.60.0':
-    resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
+  '@rollup/rollup-openbsd-x64@4.62.4':
+    resolution: {integrity: sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==}
     cpu: [x64]
     os: [openbsd]
 
@@ -723,8 +756,8 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-openharmony-arm64@4.60.0':
-    resolution: {integrity: sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==}
+  '@rollup/rollup-openharmony-arm64@4.62.4':
+    resolution: {integrity: sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==}
     cpu: [arm64]
     os: [openharmony]
 
@@ -733,8 +766,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-arm64-msvc@4.60.0':
-    resolution: {integrity: sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==}
+  '@rollup/rollup-win32-arm64-msvc@4.62.4':
+    resolution: {integrity: sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==}
     cpu: [arm64]
     os: [win32]
 
@@ -743,8 +776,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.60.0':
-    resolution: {integrity: sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==}
+  '@rollup/rollup-win32-ia32-msvc@4.62.4':
+    resolution: {integrity: sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==}
     cpu: [ia32]
     os: [win32]
 
@@ -753,8 +786,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.60.0':
-    resolution: {integrity: sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==}
+  '@rollup/rollup-win32-x64-gnu@4.62.4':
+    resolution: {integrity: sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==}
     cpu: [x64]
     os: [win32]
 
@@ -763,8 +796,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.60.0':
-    resolution: {integrity: sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==}
+  '@rollup/rollup-win32-x64-msvc@4.62.4':
+    resolution: {integrity: sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==}
     cpu: [x64]
     os: [win32]
 
@@ -819,6 +852,15 @@ packages:
       typescript:
         optional: true
 
+  '@solana/codecs-core@7.0.0':
+    resolution: {integrity: sha512-6HtEisZEtFb6okARUgYqmKdDbn2aHRrSCDgB1/GEwr0s6fK5XNYpafaSjorbs2MEyZV3tCUFTj2j6fk/4nNcLg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/codecs-data-structures@6.5.0':
     resolution: {integrity: sha512-Rxi5zVJ1YA+E6FoSQ7RHP+3DF4U7ski0mJ3H5CsYQP24QLRlBqWB3X6m2n9GHT5O3s49UR0sqeF4oyq0lF8bKw==}
     engines: {node: '>=20.18.0'}
@@ -837,12 +879,33 @@ packages:
       typescript:
         optional: true
 
+  '@solana/codecs-numbers@7.0.0':
+    resolution: {integrity: sha512-XL0jnmnXr3ceoX4tusT+XkBVR2iGKEJecTIXbIV7ILi9xObg3fNXafNbTmbIOvKc0ByTyjo8EWZ9jQKSRWgsgA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/codecs-strings@6.5.0':
     resolution: {integrity: sha512-9TuQQxumA9gWJeJzbv1GUg0+o0nZp204EijX3efR+lgBOKbkU7W0UWp33ygAZ+RvWE+kTs48ePoYoJ7UHpyxkQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
       typescript: ^5.0.0
+    peerDependenciesMeta:
+      fastestsmallesttextencoderdecoder:
+        optional: true
+      typescript:
+        optional: true
+
+  '@solana/codecs-strings@7.0.0':
+    resolution: {integrity: sha512-zXE1PE9HkVk6phZ6aqHTXvLZ0qIl5bJNIvG9eMB7LuFO1XBVQywJUtjKS8fE3/xmRCWSMilFSrEXGA+SpOyLrQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      fastestsmallesttextencoderdecoder: ^1.0.22
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       fastestsmallesttextencoderdecoder:
         optional: true
@@ -864,6 +927,16 @@ packages:
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/errors@7.0.0':
+    resolution: {integrity: sha512-94r+LLSzZ0XVp+LOogwxWGXeo138uvwqtqRW9Tjl1DIXrFgh8euXnJSXZyydu1UXJs7ItOSm0QreJviSGw3TGQ==}
+    engines: {node: '>=20.18.0'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -1168,6 +1241,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
 
@@ -1254,6 +1330,10 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
+  codama@1.10.0:
+    resolution: {integrity: sha512-fH1wz1P6bbPOWNM23Sk4VzRSpqxRW1CpXNiWQY23vHT2tno/K1/JtaaUc7DS5ddl5rGFKtq9R2UFsegR96IxRQ==}
+    hasBin: true
+
   codama@1.5.1:
     resolution: {integrity: sha512-kZbYgesIxwGNZ1JsYIWFzAsLtBuLZy/S1pCxJZgYaE13NJwDzi+bsEYqRSOUQ9ISN7FJR3SCyAE+vgzvcJpg2A==}
     hasBin: true
@@ -1261,6 +1341,10 @@ packages:
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
+
+  commander@15.0.0:
+    resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
+    engines: {node: '>=22.12.0'}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -1313,8 +1397,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  esbuild@0.27.4:
-    resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1479,8 +1563,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1512,6 +1596,10 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
@@ -1537,8 +1625,8 @@ packages:
       yaml:
         optional: true
 
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prettier@3.8.1:
@@ -1568,8 +1656,8 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  rollup@4.60.0:
-    resolution: {integrity: sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==}
+  rollup@4.62.4:
+    resolution: {integrity: sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -1626,6 +1714,10 @@ packages:
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
   tinyrainbow@3.1.0:
@@ -1818,37 +1910,70 @@ snapshots:
       picocolors: 1.1.1
       prompts: 2.4.2
 
+  '@codama/cli@1.6.0':
+    dependencies:
+      '@codama/nodes': 1.10.0
+      '@codama/visitors': 1.10.0
+      '@codama/visitors-core': 1.10.0
+      commander: 14.0.3
+      picocolors: 1.1.1
+      prompts: 2.4.2
+
+  '@codama/errors@1.10.0':
+    dependencies:
+      '@codama/node-types': 1.10.0
+      commander: 14.0.3
+      picocolors: 1.1.1
+
   '@codama/errors@1.5.1':
     dependencies:
       '@codama/node-types': 1.5.1
       commander: 14.0.3
       picocolors: 1.1.1
 
+  '@codama/fragments@0.1.3':
+    dependencies:
+      '@codama/errors': 1.10.0
+
+  '@codama/node-types@1.10.0': {}
+
   '@codama/node-types@1.5.1': {}
+
+  '@codama/nodes@1.10.0':
+    dependencies:
+      '@codama/errors': 1.10.0
+      '@codama/node-types': 1.10.0
 
   '@codama/nodes@1.5.1':
     dependencies:
       '@codama/errors': 1.5.1
       '@codama/node-types': 1.5.1
 
-  '@codama/renderers-core@1.3.6':
+  '@codama/renderers-core@1.3.11':
     dependencies:
-      '@codama/errors': 1.5.1
-      '@codama/nodes': 1.5.1
-      '@codama/visitors-core': 1.5.1
+      '@codama/errors': 1.10.0
+      '@codama/fragments': 0.1.3
+      '@codama/nodes': 1.10.0
+      '@codama/visitors-core': 1.10.0
 
-  '@codama/renderers-js@2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+  '@codama/renderers-js@2.3.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
-      '@codama/errors': 1.5.1
-      '@codama/nodes': 1.5.1
-      '@codama/renderers-core': 1.3.6
-      '@codama/visitors-core': 1.5.1
-      '@solana/codecs-strings': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@codama/errors': 1.10.0
+      '@codama/nodes': 1.10.0
+      '@codama/renderers-core': 1.3.11
+      '@codama/visitors-core': 1.10.0
+      '@solana/codecs-strings': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       prettier: 3.8.1
       semver: 7.7.4
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - typescript
+
+  '@codama/validators@1.10.0':
+    dependencies:
+      '@codama/errors': 1.10.0
+      '@codama/nodes': 1.10.0
+      '@codama/visitors-core': 1.10.0
 
   '@codama/validators@1.5.1':
     dependencies:
@@ -1856,11 +1981,23 @@ snapshots:
       '@codama/nodes': 1.5.1
       '@codama/visitors-core': 1.5.1
 
+  '@codama/visitors-core@1.10.0':
+    dependencies:
+      '@codama/errors': 1.10.0
+      '@codama/nodes': 1.10.0
+      json-stable-stringify: 1.3.0
+
   '@codama/visitors-core@1.5.1':
     dependencies:
       '@codama/errors': 1.5.1
       '@codama/nodes': 1.5.1
       json-stable-stringify: 1.3.0
+
+  '@codama/visitors@1.10.0':
+    dependencies:
+      '@codama/errors': 1.10.0
+      '@codama/nodes': 1.10.0
+      '@codama/visitors-core': 1.10.0
 
   '@codama/visitors@1.5.1':
     dependencies:
@@ -1871,157 +2008,157 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.3':
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.4':
+  '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
   '@esbuild/android-arm64@0.27.3':
     optional: true
 
-  '@esbuild/android-arm64@0.27.4':
+  '@esbuild/android-arm64@0.27.7':
     optional: true
 
   '@esbuild/android-arm@0.27.3':
     optional: true
 
-  '@esbuild/android-arm@0.27.4':
+  '@esbuild/android-arm@0.27.7':
     optional: true
 
   '@esbuild/android-x64@0.27.3':
     optional: true
 
-  '@esbuild/android-x64@0.27.4':
+  '@esbuild/android-x64@0.27.7':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.3':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.4':
+  '@esbuild/darwin-arm64@0.27.7':
     optional: true
 
   '@esbuild/darwin-x64@0.27.3':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.4':
+  '@esbuild/darwin-x64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.3':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.4':
+  '@esbuild/freebsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.3':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.4':
+  '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
   '@esbuild/linux-arm64@0.27.3':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.4':
+  '@esbuild/linux-arm64@0.27.7':
     optional: true
 
   '@esbuild/linux-arm@0.27.3':
     optional: true
 
-  '@esbuild/linux-arm@0.27.4':
+  '@esbuild/linux-arm@0.27.7':
     optional: true
 
   '@esbuild/linux-ia32@0.27.3':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.4':
+  '@esbuild/linux-ia32@0.27.7':
     optional: true
 
   '@esbuild/linux-loong64@0.27.3':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.4':
+  '@esbuild/linux-loong64@0.27.7':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.3':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.4':
+  '@esbuild/linux-mips64el@0.27.7':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.3':
     optional: true
 
-  '@esbuild/linux-ppc64@0.27.4':
+  '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.3':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.4':
+  '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
   '@esbuild/linux-s390x@0.27.3':
     optional: true
 
-  '@esbuild/linux-s390x@0.27.4':
+  '@esbuild/linux-s390x@0.27.7':
     optional: true
 
   '@esbuild/linux-x64@0.27.3':
     optional: true
 
-  '@esbuild/linux-x64@0.27.4':
+  '@esbuild/linux-x64@0.27.7':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.3':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.27.4':
+  '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/netbsd-x64@0.27.3':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.4':
+  '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.3':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.27.4':
+  '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.3':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.4':
+  '@esbuild/openbsd-x64@0.27.7':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.3':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.27.4':
+  '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
   '@esbuild/sunos-x64@0.27.3':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.4':
+  '@esbuild/sunos-x64@0.27.7':
     optional: true
 
   '@esbuild/win32-arm64@0.27.3':
     optional: true
 
-  '@esbuild/win32-arm64@0.27.4':
+  '@esbuild/win32-arm64@0.27.7':
     optional: true
 
   '@esbuild/win32-ia32@0.27.3':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.4':
+  '@esbuild/win32-ia32@0.27.7':
     optional: true
 
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
-  '@esbuild/win32-x64@0.27.4':
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -2038,154 +2175,157 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    optional: true
+
   '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.60.0':
+  '@rollup/rollup-android-arm-eabi@4.62.4':
     optional: true
 
   '@rollup/rollup-android-arm64@4.59.0':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.60.0':
+  '@rollup/rollup-android-arm64@4.62.4':
     optional: true
 
   '@rollup/rollup-darwin-arm64@4.59.0':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.60.0':
+  '@rollup/rollup-darwin-arm64@4.62.4':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.59.0':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.60.0':
+  '@rollup/rollup-darwin-x64@4.62.4':
     optional: true
 
   '@rollup/rollup-freebsd-arm64@4.59.0':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.60.0':
+  '@rollup/rollup-freebsd-arm64@4.62.4':
     optional: true
 
   '@rollup/rollup-freebsd-x64@4.59.0':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.60.0':
+  '@rollup/rollup-freebsd-x64@4.62.4':
     optional: true
 
   '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.0':
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.60.0':
+  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
     optional: true
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.60.0':
+  '@rollup/rollup-linux-arm64-gnu@4.62.4':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.60.0':
+  '@rollup/rollup-linux-arm64-musl@4.62.4':
     optional: true
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.0':
+  '@rollup/rollup-linux-loong64-gnu@4.62.4':
     optional: true
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-loong64-musl@4.60.0':
+  '@rollup/rollup-linux-loong64-musl@4.62.4':
     optional: true
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.60.0':
+  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
     optional: true
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-musl@4.60.0':
+  '@rollup/rollup-linux-ppc64-musl@4.62.4':
     optional: true
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.60.0':
+  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
     optional: true
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.60.0':
+  '@rollup/rollup-linux-riscv64-musl@4.62.4':
     optional: true
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.60.0':
+  '@rollup/rollup-linux-s390x-gnu@4.62.4':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.60.0':
+  '@rollup/rollup-linux-x64-gnu@4.62.4':
     optional: true
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.60.0':
+  '@rollup/rollup-linux-x64-musl@4.62.4':
     optional: true
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     optional: true
 
-  '@rollup/rollup-openbsd-x64@4.60.0':
+  '@rollup/rollup-openbsd-x64@4.62.4':
     optional: true
 
   '@rollup/rollup-openharmony-arm64@4.59.0':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.60.0':
+  '@rollup/rollup-openharmony-arm64@4.62.4':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.59.0':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.60.0':
+  '@rollup/rollup-win32-arm64-msvc@4.62.4':
     optional: true
 
   '@rollup/rollup-win32-ia32-msvc@4.59.0':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.60.0':
+  '@rollup/rollup-win32-ia32-msvc@4.62.4':
     optional: true
 
   '@rollup/rollup-win32-x64-gnu@4.59.0':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.60.0':
+  '@rollup/rollup-win32-x64-gnu@4.62.4':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.60.0':
+  '@rollup/rollup-win32-x64-msvc@4.62.4':
     optional: true
 
   '@solana-program/system@0.12.0(@solana/kit@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))':
@@ -2239,6 +2379,12 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  '@solana/codecs-core@7.0.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 7.0.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
   '@solana/codecs-data-structures@6.5.0(typescript@5.9.3)':
     dependencies:
       '@solana/codecs-core': 6.5.0(typescript@5.9.3)
@@ -2254,11 +2400,27 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  '@solana/codecs-numbers@7.0.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 7.0.0(typescript@5.9.3)
+      '@solana/errors': 7.0.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
   '@solana/codecs-strings@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@solana/codecs-core': 6.5.0(typescript@5.9.3)
       '@solana/codecs-numbers': 6.5.0(typescript@5.9.3)
       '@solana/errors': 6.5.0(typescript@5.9.3)
+    optionalDependencies:
+      fastestsmallesttextencoderdecoder: 1.0.22
+      typescript: 5.9.3
+
+  '@solana/codecs-strings@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 7.0.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 7.0.0(typescript@5.9.3)
+      '@solana/errors': 7.0.0(typescript@5.9.3)
     optionalDependencies:
       fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.9.3
@@ -2279,6 +2441,13 @@ snapshots:
     dependencies:
       chalk: 5.6.2
       commander: 14.0.3
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/errors@7.0.0(typescript@5.9.3)':
+    dependencies:
+      chalk: 5.6.2
+      commander: 15.0.0
     optionalDependencies:
       typescript: 5.9.3
 
@@ -2672,6 +2841,8 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/estree@1.0.9': {}
+
   '@types/node@25.5.0':
     dependencies:
       undici-types: 7.18.2
@@ -2761,6 +2932,14 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
+  codama@1.10.0:
+    dependencies:
+      '@codama/cli': 1.6.0
+      '@codama/errors': 1.10.0
+      '@codama/nodes': 1.10.0
+      '@codama/validators': 1.10.0
+      '@codama/visitors': 1.10.0
+
   codama@1.5.1:
     dependencies:
       '@codama/cli': 1.5.0
@@ -2770,6 +2949,8 @@ snapshots:
       '@codama/visitors': 1.5.1
 
   commander@14.0.3: {}
+
+  commander@15.0.0: {}
 
   commander@4.1.1: {}
 
@@ -2834,34 +3015,34 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.3
       '@esbuild/win32-x64': 0.27.3
 
-  esbuild@0.27.4:
+  esbuild@0.27.7:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.4
-      '@esbuild/android-arm': 0.27.4
-      '@esbuild/android-arm64': 0.27.4
-      '@esbuild/android-x64': 0.27.4
-      '@esbuild/darwin-arm64': 0.27.4
-      '@esbuild/darwin-x64': 0.27.4
-      '@esbuild/freebsd-arm64': 0.27.4
-      '@esbuild/freebsd-x64': 0.27.4
-      '@esbuild/linux-arm': 0.27.4
-      '@esbuild/linux-arm64': 0.27.4
-      '@esbuild/linux-ia32': 0.27.4
-      '@esbuild/linux-loong64': 0.27.4
-      '@esbuild/linux-mips64el': 0.27.4
-      '@esbuild/linux-ppc64': 0.27.4
-      '@esbuild/linux-riscv64': 0.27.4
-      '@esbuild/linux-s390x': 0.27.4
-      '@esbuild/linux-x64': 0.27.4
-      '@esbuild/netbsd-arm64': 0.27.4
-      '@esbuild/netbsd-x64': 0.27.4
-      '@esbuild/openbsd-arm64': 0.27.4
-      '@esbuild/openbsd-x64': 0.27.4
-      '@esbuild/openharmony-arm64': 0.27.4
-      '@esbuild/sunos-x64': 0.27.4
-      '@esbuild/win32-arm64': 0.27.4
-      '@esbuild/win32-ia32': 0.27.4
-      '@esbuild/win32-x64': 0.27.4
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
 
   estree-walker@3.0.3:
     dependencies:
@@ -2875,6 +3056,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
 
   fix-dts-default-cjs-exports@1.0.1:
     dependencies:
@@ -3012,7 +3197,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.18: {}
 
   object-assign@4.1.1: {}
 
@@ -3033,6 +3218,8 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  picomatch@4.0.5: {}
+
   pirates@4.0.7: {}
 
   pkg-types@1.3.1:
@@ -3041,15 +3228,15 @@ snapshots:
       mlly: 1.8.0
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(postcss@8.5.8):
+  postcss-load-config@6.0.1(postcss@8.5.26):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
-      postcss: 8.5.8
+      postcss: 8.5.26
 
-  postcss@8.5.8:
+  postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -3100,35 +3287,36 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
 
-  rollup@4.60.0:
+  rollup@4.62.4:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.60.0
-      '@rollup/rollup-android-arm64': 4.60.0
-      '@rollup/rollup-darwin-arm64': 4.60.0
-      '@rollup/rollup-darwin-x64': 4.60.0
-      '@rollup/rollup-freebsd-arm64': 4.60.0
-      '@rollup/rollup-freebsd-x64': 4.60.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.60.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.60.0
-      '@rollup/rollup-linux-arm64-gnu': 4.60.0
-      '@rollup/rollup-linux-arm64-musl': 4.60.0
-      '@rollup/rollup-linux-loong64-gnu': 4.60.0
-      '@rollup/rollup-linux-loong64-musl': 4.60.0
-      '@rollup/rollup-linux-ppc64-gnu': 4.60.0
-      '@rollup/rollup-linux-ppc64-musl': 4.60.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.60.0
-      '@rollup/rollup-linux-riscv64-musl': 4.60.0
-      '@rollup/rollup-linux-s390x-gnu': 4.60.0
-      '@rollup/rollup-linux-x64-gnu': 4.60.0
-      '@rollup/rollup-linux-x64-musl': 4.60.0
-      '@rollup/rollup-openbsd-x64': 4.60.0
-      '@rollup/rollup-openharmony-arm64': 4.60.0
-      '@rollup/rollup-win32-arm64-msvc': 4.60.0
-      '@rollup/rollup-win32-ia32-msvc': 4.60.0
-      '@rollup/rollup-win32-x64-gnu': 4.60.0
-      '@rollup/rollup-win32-x64-msvc': 4.60.0
+      '@napi-rs/lzma-linux-x64-gnu': 1.5.1
+      '@rollup/rollup-android-arm-eabi': 4.62.4
+      '@rollup/rollup-android-arm64': 4.62.4
+      '@rollup/rollup-darwin-arm64': 4.62.4
+      '@rollup/rollup-darwin-x64': 4.62.4
+      '@rollup/rollup-freebsd-arm64': 4.62.4
+      '@rollup/rollup-freebsd-x64': 4.62.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.4
+      '@rollup/rollup-linux-arm64-gnu': 4.62.4
+      '@rollup/rollup-linux-arm64-musl': 4.62.4
+      '@rollup/rollup-linux-loong64-gnu': 4.62.4
+      '@rollup/rollup-linux-loong64-musl': 4.62.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.4
+      '@rollup/rollup-linux-ppc64-musl': 4.62.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.4
+      '@rollup/rollup-linux-riscv64-musl': 4.62.4
+      '@rollup/rollup-linux-s390x-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-musl': 4.62.4
+      '@rollup/rollup-openbsd-x64': 4.62.4
+      '@rollup/rollup-openharmony-arm64': 4.62.4
+      '@rollup/rollup-win32-arm64-msvc': 4.62.4
+      '@rollup/rollup-win32-ia32-msvc': 4.62.4
+      '@rollup/rollup-win32-x64-gnu': 4.62.4
+      '@rollup/rollup-win32-x64-msvc': 4.62.4
       fsevents: 2.3.3
 
   semver@7.7.4: {}
@@ -3183,13 +3371,18 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
   tinyrainbow@3.1.0: {}
 
   tree-kill@1.2.2: {}
 
   ts-interface-checker@0.1.13: {}
 
-  tsup@8.5.1(postcss@8.5.8)(typescript@6.0.2):
+  tsup@8.5.1(postcss@8.5.26)(typescript@6.0.2):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.3)
       cac: 6.7.14
@@ -3200,7 +3393,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.8)
+      postcss-load-config: 6.0.1(postcss@8.5.26)
       resolve-from: 5.0.0
       rollup: 4.59.0
       source-map: 0.7.6
@@ -3209,7 +3402,7 @@ snapshots:
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.5.8
+      postcss: 8.5.26
       typescript: 6.0.2
     transitivePeerDependencies:
       - jiti
@@ -3229,12 +3422,12 @@ snapshots:
 
   vite@7.3.1(@types/node@25.5.0):
     dependencies:
-      esbuild: 0.27.4
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.8
-      rollup: 4.60.0
-      tinyglobby: 0.2.15
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rollup: 4.62.4
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.5.0
       fsevents: 2.3.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,11 +16,11 @@ importers:
         version: 1.10.0
     devDependencies:
       '@solana/kit':
-        specifier: ^6.5.0
-        version: 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+        specifier: ^6.10.0
+        version: 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/program-client-core':
-        specifier: ^6.5.0
-        version: 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+        specifier: ^6.10.0
+        version: 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@types/node':
         specifier: ^25.5.0
         version: 25.5.0
@@ -31,8 +31,8 @@ importers:
   codama/tests/js:
     devDependencies:
       codama:
-        specifier: 1.5.1
-        version: 1.5.1
+        specifier: ^1.10.0
+        version: 1.10.0
 
   codama/tests/litesvm:
     devDependencies:
@@ -82,8 +82,8 @@ importers:
   packages/nodes-from-pina:
     dependencies:
       codama:
-        specifier: ^1.5.1
-        version: 1.5.1
+        specifier: ^1.10.0
+        version: 1.10.0
     devDependencies:
       '@types/node':
         specifier: ^25.5.0
@@ -137,10 +137,6 @@ packages:
       '@solana/web3.js':
         optional: true
 
-  '@codama/cli@1.5.0':
-    resolution: {integrity: sha512-+q62IvEA6o7ji/mcnGgAvyPWyiFx3cojVGrFNG8NSm0zFXrBk1lT3n/qg+2Ag8C8aHwno9boXgDTxV+P5VCDYw==}
-    hasBin: true
-
   '@codama/cli@1.6.0':
     resolution: {integrity: sha512-68fam0kzWsKp2ip/LZn3kDyFjWcbzHExCuDgEHGTX8C0gSscMch/c4EgtTq7NsWKc1cse0GMC5WIxCFumroTyQ==}
     hasBin: true
@@ -149,24 +145,14 @@ packages:
     resolution: {integrity: sha512-/qiWQcbPIsyFlP1LrLqJfHt1QNbkY2wtC4UxZyKLnuZtc62YPlgDrN2wp4wcfRuE/DC0n3Y6ZSwYUrDBZyAnvA==}
     hasBin: true
 
-  '@codama/errors@1.5.1':
-    resolution: {integrity: sha512-kdLk/OSLBt03DoViRU1Xr0M7NZ7J/CSqaXV8fooF9qMRGPRJdgUeW2VkCGlLXDQSaIALrls3HkHmKRKbqqjSOA==}
-    hasBin: true
-
   '@codama/fragments@0.1.3':
     resolution: {integrity: sha512-ITa3UYs74AWx7se/6EZN+YXqV1Vu89L3n2v0/irsQNbPcy8wP26p/GKns/1H4a8vGvAKuzWdIGO535dwcauInw==}
 
   '@codama/node-types@1.10.0':
     resolution: {integrity: sha512-fMoJQ8TgB9A5Pl+GA8ffhDbGK63cV1nrbDrYTgIhPDKeVqBSdkSAoAuAtvWfRd7X2ML73H6RRi6jZRJmo2xfHQ==}
 
-  '@codama/node-types@1.5.1':
-    resolution: {integrity: sha512-jMGz93MSszb1iXAAyWWa0i7RQbLxGihLKRZ+zr9aBsjaFFmhXhONfTFeSXzbEfc05cajpd/gW2QI7xmQHlUDKQ==}
-
   '@codama/nodes@1.10.0':
     resolution: {integrity: sha512-P3NXVw6kZq2VDb4wYU6zQ3xFksDqSuDYqp11P6Dpei9XIZZ11NtL2jBjBcqsIudGIx104bMgSo4SZ7Hlej056A==}
-
-  '@codama/nodes@1.5.1':
-    resolution: {integrity: sha512-6fIoH5Cfa5dFUE1fRxymZloeNg02klOT4fHsWwQavkkRWkoySgiti//w0j1itiZj6j5O+usujrwsZUJqSFjnhQ==}
 
   '@codama/renderers-core@1.3.11':
     resolution: {integrity: sha512-VSGrfmwPVv5cRAiHitgIq+rc9ktIN/Q9czbUORaqhZCmM+M3Ux5cd5r90PVTbeIt8vI0Zlw74OUFwdKqdEfSNw==}
@@ -178,20 +164,11 @@ packages:
   '@codama/validators@1.10.0':
     resolution: {integrity: sha512-5WH1IHmyVVG/9QThZsrVM2ROv5w3yLF/8+4HK/kr8uw0ZXnIBGidnmyrxr1P8V+X6DgZqKJaX46V30dSs/NOTQ==}
 
-  '@codama/validators@1.5.1':
-    resolution: {integrity: sha512-aUXl39AMa091CBWpYiK2XCXP/uyKOOtAT399TzRld3z8dIH9E0fGyu4ocP+IhQKXWXDPsh7V3qPmqsdyevOPcQ==}
-
   '@codama/visitors-core@1.10.0':
     resolution: {integrity: sha512-8koBGs4m/NI4nDLJZx7Q1KzRUKkBy/GAnZq4xOEFGlhTvDCIAzEgo3biAhNFynGY45gzZJSX08QTDWKsPRjnaA==}
 
-  '@codama/visitors-core@1.5.1':
-    resolution: {integrity: sha512-JotrDJLI7OfPNHulu4KtPfUDF/FYMC3RgEnv9lu47Fiiy0upbGAw1NorgBuoreyJ9Uj0GZyHt7Q5rjrCoa1U0g==}
-
   '@codama/visitors@1.10.0':
     resolution: {integrity: sha512-xAGKosZQnXBo9MiHFipA9Dsec1k9nbpv5UgUyY1j3l85FGEZQT2tHqrNxtBmPrC3LNSLVOfAdiUUMVUXUX5ydA==}
-
-  '@codama/visitors@1.5.1':
-    resolution: {integrity: sha512-8WcGP1tJKtqBfZ4mJsBRPjZ/H6+SPLWmiUoDTXRrVePQE4X4Yb04o6BoX2Uc3heZbfEc0rXdM1w8HTFvXBX4/A==}
 
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
@@ -816,11 +793,29 @@ packages:
     peerDependencies:
       '@solana/kit': ^6.5.0
 
+  '@solana/accounts@6.10.0':
+    resolution: {integrity: sha512-+FxfDOrnifoPlBkF+fr8eeQdgM6xtIgAg9xKMu3WnIz60oZd4Xnry6+ff6t+ePPoZZp397FSg9ZJet68VCWm5Q==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/accounts@6.5.0':
     resolution: {integrity: sha512-h3zQFjwZjmy+YxgTGOEna6g74Tsn4hTBaBCslwPT4QjqWhywe2JrM2Ab0ANfJcj7g/xrHF5QJ/FnUIcyUTeVfQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/addresses@6.10.0':
+    resolution: {integrity: sha512-vEoCGBTxG0HCERAn84KXkrJjl+pDaNzOpZ0qbgcPS98fYxP5yzbKB8SNOY2bzrbkRUmmw5Q3hqTRERemUN2Gcw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -834,11 +829,29 @@ packages:
       typescript:
         optional: true
 
+  '@solana/assertions@6.10.0':
+    resolution: {integrity: sha512-lKSAdVo+P/6Lp4vs6shstXmFOpvxrABwn4o1462tb7sKkNapk6o9pPFVPGw4DUgPS3WqWRs1j2tmpuVjhQRntg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/assertions@6.5.0':
     resolution: {integrity: sha512-rEAf40TtC9r6EtJFLe39WID4xnTNT6hdOVRfD1xDzmIQdVOyGgIbJGt2FAuB/uQDKLWneWMnvGDBim+K61Bljw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/codecs-core@6.10.0':
+    resolution: {integrity: sha512-nfAl9OMGo4HanIMxGsQoVB7BxMoqBCYEUxl8oEAZZ09pDxnaXQZkTRXEwPPccag37XfW1ciPd1vWPKwB2b0HHQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -861,11 +874,29 @@ packages:
       typescript:
         optional: true
 
+  '@solana/codecs-data-structures@6.10.0':
+    resolution: {integrity: sha512-CNasJW3bq5u+632Zt5aJ8rOjAjv2HyenpV8o9kAIqdmV4CBpjCCoBnKn8LkuR/sbeREZxJYfhKTXO/9ruAkw7A==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/codecs-data-structures@6.5.0':
     resolution: {integrity: sha512-Rxi5zVJ1YA+E6FoSQ7RHP+3DF4U7ski0mJ3H5CsYQP24QLRlBqWB3X6m2n9GHT5O3s49UR0sqeF4oyq0lF8bKw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/codecs-numbers@6.10.0':
+    resolution: {integrity: sha512-CcM+wX4zOiA9zkh8A7t1787A0Ehgmu5+6Z2tKoHew6cNw/dkaUTPa8JnNHbvfsLC8dfHC1BhAEJl86sKmRsfkQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -885,6 +916,18 @@ packages:
     peerDependencies:
       typescript: '>=5.4.0'
     peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/codecs-strings@6.10.0':
+    resolution: {integrity: sha512-zlaqkg7K6F6IN4V/Ec8TWkTn054gxv7ZLagvGkuEyAdPQ6BzzsehOm2TqCuyXgJJTCGPLY1bEk6yH9NxANe0kA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      fastestsmallesttextencoderdecoder: ^1.0.22
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      fastestsmallesttextencoderdecoder:
+        optional: true
       typescript:
         optional: true
 
@@ -912,11 +955,30 @@ packages:
       typescript:
         optional: true
 
+  '@solana/codecs@6.10.0':
+    resolution: {integrity: sha512-lLVuxod4ChWp9i7OvpgIykYG8Q9OGPVXKnHM9VlzDDLylsx7Y1FoQL00sHa7PqFkJVmkBufaA6dcGbQ7FU+lAQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/codecs@6.5.0':
     resolution: {integrity: sha512-WfqMqUXk4jcCJQ9nfKqjDcCJN2Pt8/AKe/E78z8OcblFGVJnTzcu2yZpE2gsqM+DJyCVKdQmOY+NS8Uckk5e5w==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/errors@6.10.0':
+    resolution: {integrity: sha512-KBLAxCtAXr357JNhCyIDQXWbuSj5vN6w+28FSfcYY6OOSiphmXLAV3V58jgV0C6iNbIzFJFi6yatFyDTdeJsNg==}
+    engines: {node: '>=20.18.0'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -941,11 +1003,38 @@ packages:
       typescript:
         optional: true
 
+  '@solana/fast-stable-stringify@6.10.0':
+    resolution: {integrity: sha512-iCNed27wk6PKSS3QUtHovRfMWF/jbVWogs2vB4tukKUCsqG4rDfDInIwZ6ur/nY6XTrgi2gMMdZq9GAUlWsbfw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/fast-stable-stringify@6.5.0':
     resolution: {integrity: sha512-5ATQDwBVZMoenX5KS23uFswtaAGoaZB9TthzUXle3tkU3tOfgQTuEWEoqEBYc7ct0sK6LtyE1XXT/NP5YvAkkQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/fixed-points@6.10.0':
+    resolution: {integrity: sha512-ZkKL0alXH3L7/wMiVG8YUuG8qBKunlM810+YBD7nUPRhifiGsX1zwADViHLYNqLr/jUk0mTYFUcKznTpB/K+Gg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/functional@6.10.0':
+    resolution: {integrity: sha512-P8cevu4mAqHTXC37h1TVoOh8zhWB2tlOI/R9vWjYPpcLwcyWf8p2qq4LEGHl5kY+1C+4PNX39HsmCocXOPCDkQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -959,11 +1048,29 @@ packages:
       typescript:
         optional: true
 
+  '@solana/instruction-plans@6.10.0':
+    resolution: {integrity: sha512-YG7mo4zykzdc6ZTV0BuN6pveK9qeBySzlYYerq578A4eQu3xcypMAYRGAvhMZtWTanjjmD6CKtM0M7kVp0TNxg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/instruction-plans@6.5.0':
     resolution: {integrity: sha512-zp2asevpyMwvhajHYM1aruYpO+xf3LSwHEI2FK6E2hddYZaEhuBy+bz+NZ1ixCyfx3iXcq7MamlFQc2ySHDyUQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/instructions@6.10.0':
+    resolution: {integrity: sha512-0TToYF+8LXQ3ofPMx+yF6yaM9l4YJvcAPMy0qV5JsrBUFlWXBSANRuudKBQLHMvb+a3OiUTq5X7omuorKMBB3A==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -977,11 +1084,29 @@ packages:
       typescript:
         optional: true
 
+  '@solana/keys@6.10.0':
+    resolution: {integrity: sha512-26IRfdm/hTUCmM7MeEeX0ULSbCM6OzkZTkfkrPircqmRM7xyNqP4hq7u0P7wjb9dl7NfgyG6K7cdvUxrj2e3mA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/keys@6.5.0':
     resolution: {integrity: sha512-CN5jmodX9j5CZKrWLM5XGaRlrLl/Ebl4vgqDXrnwC2NiSfUslLsthuORMuVUTDqkzBX/jd/tgVXFRH2NYNzREQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/kit@6.10.0':
+    resolution: {integrity: sha512-/WnnQp3uARh2JCFSfAakejTAqwmXVuMVTcRn5r2yDwY2yzZ4R6mt/Cl59VPimVLNSoTyN/KsEwhv9omr3ERazQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -995,11 +1120,29 @@ packages:
       typescript:
         optional: true
 
+  '@solana/nominal-types@6.10.0':
+    resolution: {integrity: sha512-9ykyBBvnkInH7fCacjJi7zu2PJyd+OCt+VTjIISv070fHzKIMFqZqJJ/dJ0SRH2aHwfB3n86iVsmtBtuxi4KKA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/nominal-types@6.5.0':
     resolution: {integrity: sha512-HngIM2nlaDPXk0EDX0PklFqpjGDKuOFnlEKS0bfr2F9CorFwiNhNjhb9lPH+FdgsogD1wJ8wgLMMk1LZWn5kgQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/offchain-messages@6.10.0':
+    resolution: {integrity: sha512-RiEgAueeMkFMC1suOXBIcmCZgtXRxy24yk0DldPB37bB4zwOF1SAaRjNRPjIkGK8RhCYrEpPosnzLyavw9ueRg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -1013,11 +1156,29 @@ packages:
       typescript:
         optional: true
 
+  '@solana/options@6.10.0':
+    resolution: {integrity: sha512-RO9UT3UYD8/Cu2uM6ZXbKvLeMnVD42+g9JRds7Pfs4AhiOyg4R4TJrQUAppTgavPTO3PBRlWtWOC05ZH/yAIbg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/options@6.5.0':
     resolution: {integrity: sha512-jdZjSKGCQpsMFK+3CiUEI7W9iGsndi46R4Abk66ULNLDoMsjvfqNy8kqktm0TN0++EX8dKEecpFwxFaA4VlY5g==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/plugin-core@6.10.0':
+    resolution: {integrity: sha512-JE70YTQOfFACVFGvoJon4Scc/eHUWjMu8Ovo35CcV2kHTAHYMCd4UkBd2gmlhK0vRMMomsQi1ZLPlAlTq0OoUQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -1031,11 +1192,29 @@ packages:
       typescript:
         optional: true
 
+  '@solana/plugin-interfaces@6.10.0':
+    resolution: {integrity: sha512-vr0/l9wcM4orwGr8cjkFWaJ9A4HvzuAv00jMFNMg0Spd0GZqnwnpW+D/fXa1lIJnTRaF3EeEjLh4VjKU037T0Q==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/plugin-interfaces@6.5.0':
     resolution: {integrity: sha512-/ZlybbMaR7P4ySersOe1huioMADWze0AzsHbzgkpt5dJUv2tz5cpaKdu7TEVQkUZAFhLdqXQULNGqAU5neOgzg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/program-client-core@6.10.0':
+    resolution: {integrity: sha512-4PPbTLdC1ylHIuvhOFDP8RnSkXPCFjNFWGslzc+UFKnoR4ajzBcByX94jmaruDMk5ncxgj7tr9pzJTvfGHIaMA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -1049,11 +1228,29 @@ packages:
       typescript:
         optional: true
 
+  '@solana/programs@6.10.0':
+    resolution: {integrity: sha512-qn/HeLP5KGUJXVub3fyGe69/rWaLX4jzwm6V/1pNxJDbdF+MBdgn18hP6F+VmhfdNmwK0lue3J/1HQ1UTMuQeQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/programs@6.5.0':
     resolution: {integrity: sha512-srn3nEROBxCnBpVz/bvLkVln1BZtk3bS3nuReu3yaeOLkKl8b0h1Zp0YmXVyXHzdMcYahsTvKKLR1ZtLZEyEPA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/promises@6.10.0':
+    resolution: {integrity: sha512-oJSIn+VBBMWDo8oqw7RV3tI6Jih+Ieup6FcQLYLDUriaeo7+8l1Zdezl8zh7SIfeU4lOfAbRg6mR0huaS/Lltg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -1067,11 +1264,29 @@ packages:
       typescript:
         optional: true
 
+  '@solana/rpc-api@6.10.0':
+    resolution: {integrity: sha512-RjPIVsAb/85P1ptoO3WpC0x7QG6gG/e4q/3lo6gbSznUZOcoM+8sSBnCX7BwP1ZkCDS6NK/ClXLnhhhYZx+OGg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/rpc-api@6.5.0':
     resolution: {integrity: sha512-b+kftroO8vZFzLHj7Nk/uATS3HOlBUsUqdGg3eTQrW1pFgkyq5yIoEYHeFF7ApUN/SJLTK86U8ofCaXabd2SXA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-parsed-types@6.10.0':
+    resolution: {integrity: sha512-5275mvSV1mxhwvrMVa+K7BU/nAetpHfcb+8Ql9rtA8RRf6DyiimFQFZUukE4Ez6XJihEpCHNy98yhkgai9wytQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -1085,11 +1300,29 @@ packages:
       typescript:
         optional: true
 
+  '@solana/rpc-spec-types@6.10.0':
+    resolution: {integrity: sha512-NDZrKyZrJk4HaMFhTE/lAiMB824cWAodKqDHyKi0UteHU9pyRmil3BN1jt7e+j08mwMWwfklSgyrTaq52g6DIQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/rpc-spec-types@6.5.0':
     resolution: {integrity: sha512-XasJp+sOW6PLfNoalzoLnm+j3LEZF8XOQmSrOqv9AGrGxQckkuOf6iXZucWTqeNKdstsOpU28BN2B6qOavfRzQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-spec@6.10.0':
+    resolution: {integrity: sha512-yQdbWw5mZEWrwsunHR9NHkuhMXIB9sPOObwm18D53v5tAJnxTB0IcHvO647XqFDLTK/yQ4AdDtlYD1vsY07AMQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -1103,11 +1336,29 @@ packages:
       typescript:
         optional: true
 
+  '@solana/rpc-subscriptions-api@6.10.0':
+    resolution: {integrity: sha512-CRPQoTtT1cOwOQUsqS7jgo7wYdAj7jB5ab/UmMPWVpecf2FNMhWhgvxP2s82M7VkDGTGl13qaQ0WySmi7Egrlg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/rpc-subscriptions-api@6.5.0':
     resolution: {integrity: sha512-smqNjT2C5Vf9nWGIwiYOLOP744gRWKi2i2g0i3ZVdsfoouvB0d/WTQ2bbWq47MrdV8FSuGnjAOM3dRIwYmYOWw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-subscriptions-channel-websocket@6.10.0':
+    resolution: {integrity: sha512-KkqP1186HELPlJftA88SNAT2znR8knCVzsUipXVzY4zfW8sN3LOa0ePMzh9VZ/V+J+raTt55laR87ovAO0n+zw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -1121,11 +1372,29 @@ packages:
       typescript:
         optional: true
 
+  '@solana/rpc-subscriptions-spec@6.10.0':
+    resolution: {integrity: sha512-nWMwGaG4ulzeX2sskY5TywXF3cwEd8FDmUpLe2JBWxE8XDAOGOKcsYPYFcBgb8ee9KqfPT2PTNdcz9jOhJf34w==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/rpc-subscriptions-spec@6.5.0':
     resolution: {integrity: sha512-Mi8g9rNS2lG7lyNkDhOVfQVfDC7hXKgH+BlI5qKGk+8cfyU7VDq6tVjDysu6kBWGOPHZxyCvcL6+xW/EkdVoAg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-subscriptions@6.10.0':
+    resolution: {integrity: sha512-6mfuHp/K7unFKCOTCCBC9ziEGnxe2tyJ74EbR51QUnBeCUdYD7Hhdpxic1WRSJ3UeNW/mG4OzFM6z8Wi64Eh9Q==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -1139,11 +1408,29 @@ packages:
       typescript:
         optional: true
 
+  '@solana/rpc-transformers@6.10.0':
+    resolution: {integrity: sha512-2nFUrVTiE720pJOY4XKx3HuYmishw0of/4oScu76YGm6O8wsmvFvPNAkrEinmieWXQkfpBfRvLZmpl8PaAy+ug==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/rpc-transformers@6.5.0':
     resolution: {integrity: sha512-kS0d+LuuSLfsod2cm2xp0mNj65PL1aomwu6VKtubmsdESwPXHIaI9XrpkPCBuhNSz1SwVp4OkfK5O/VOOHYHSw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc-transport-http@6.10.0':
+    resolution: {integrity: sha512-JrdNuYi0nBbD3X8JUtgX1dQJwIwz/WJvmigDdELysXfGB2bTJpfjqGDLhCLOz2sRl66FASIEqgG/LVa2C9VXcA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -1157,11 +1444,29 @@ packages:
       typescript:
         optional: true
 
+  '@solana/rpc-types@6.10.0':
+    resolution: {integrity: sha512-zaSecTfCPvz/vcoAmKD6XoRstGHTr1EKJBD8T9UcpEFFB6CtF6DxerDB+wrzkamuT6msmnR2DWXMrYOGDAsgIg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/rpc-types@6.5.0':
     resolution: {integrity: sha512-hxts27+Z2VNv4IjXGcXkqbj/MgrN9Xtw/4iE1qZk68T2OAb5vA4b8LHchsOHmHvrzZfo8XDvB9mModCdM3JPsQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/rpc@6.10.0':
+    resolution: {integrity: sha512-EwxsqoD+NXV+m+iobnWNtATD93gTgaNsOiQOzYB1/2e+8S6fl6obdNPB55yfXgtl4jt6GV6/ae4xuPhLv76vvg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -1175,11 +1480,29 @@ packages:
       typescript:
         optional: true
 
+  '@solana/signers@6.10.0':
+    resolution: {integrity: sha512-+vtCc+mT1FpGxrA5oL2aaMxSHiMJ2hH5PcDIfjo2XJkHz2klZiCZyT5F9+zpltc9vdi1QTElQq59Sfplmtd33A==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/signers@6.5.0':
     resolution: {integrity: sha512-AL75/DyDUhc+QQ+VGZT7aRwJNzIUTWvmLNXQRlCVhLRuyroXzZEL2WJBs8xOwbZXjY8weacfYT7UNM8qK6ucDg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/subscribable@6.10.0':
+    resolution: {integrity: sha512-VsR6XMwkiDBkZJUcoGkEOhf397pOV75gKCL9Bx8bpi2T3Bbs0CxUpMn4yaUgAnRba3eXmjbXMNCXjttfa6sKbw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -1193,11 +1516,29 @@ packages:
       typescript:
         optional: true
 
+  '@solana/sysvars@6.10.0':
+    resolution: {integrity: sha512-cG13p1+onxz+20iWjwWQr1Z1jQwPm0fnjoW75fqZq7p4rVCie3L2sXvaJsYPjWKrUvpOzOIEHnqZGkG05rCpjg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/sysvars@6.5.0':
     resolution: {integrity: sha512-iLSS5qj0MWNiGH1LN1E4jhGsXH9D3tWSjwaB6zK9LjhLdVYcPfkosBkj7s0EHHrH03QlwiuFdU0Y2kH8Jcp8kw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/transaction-confirmation@6.10.0':
+    resolution: {integrity: sha512-ULvtg65qfenh4T/GYcIlKSUv5EqDcng9UN0dxbHU4kuZdR2e0B8HN2xDC4WhcFQVeFJSbTZmaYFkeTY/Y4gfGQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -1211,11 +1552,29 @@ packages:
       typescript:
         optional: true
 
+  '@solana/transaction-messages@6.10.0':
+    resolution: {integrity: sha512-s7v8G3BTxGlKYIj3eWCG0g1296v+1LBt16mVnlRH5FuyaJ5AdhlhtRho5HUDpdwE8EXun+y1c48V6uhcZ8wdbQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@solana/transaction-messages@6.5.0':
     resolution: {integrity: sha512-ueXkm5xaRlqYBFAlABhaCKK/DuzIYSot0FybwSDeOQCDy2hvU9Zda16Iwa1n56M0fG+XUvFJz2woG3u9DhQh1g==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/transactions@6.10.0':
+    resolution: {integrity: sha512-VADSqP9OTYmhrox4pcgDd4+RjVmednXSE0+8Y7SPK4PN1pK5Az2RJ0nSsy0xcTnaOr8mF/crwFktqPrRQwSbQA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -1332,10 +1691,6 @@ packages:
 
   codama@1.10.0:
     resolution: {integrity: sha512-fH1wz1P6bbPOWNM23Sk4VzRSpqxRW1CpXNiWQY23vHT2tno/K1/JtaaUc7DS5ddl5rGFKtq9R2UFsegR96IxRQ==}
-    hasBin: true
-
-  codama@1.5.1:
-    resolution: {integrity: sha512-kZbYgesIxwGNZ1JsYIWFzAsLtBuLZy/S1pCxJZgYaE13NJwDzi+bsEYqRSOUQ9ISN7FJR3SCyAE+vgzvcJpg2A==}
     hasBin: true
 
   commander@14.0.3:
@@ -1769,6 +2124,9 @@ packages:
   undici-types@7.24.5:
     resolution: {integrity: sha512-kNh333UBSbgK35OIW7FwJTr9tTfVIG51Fm1tSVT7m8foPHfDVjsb7OIee/q/rs3bB2aV/3qOPgG5mHNWl1odiA==}
 
+  undici-types@8.10.0:
+    resolution: {integrity: sha512-ibvdovq3nCFs8Msrd95BW+zUOq+aOVbT+wpHUoPWhztbHEoPc6oof51iFDB6Es8lTKvNvVW9jNSAB8dwrKTMGg==}
+
   vite@7.3.1:
     resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1861,6 +2219,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
 snapshots:
 
   '@blueshift-gg/quasar-svm-darwin-arm64@0.1.5':
@@ -1901,15 +2271,6 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@codama/cli@1.5.0':
-    dependencies:
-      '@codama/nodes': 1.5.1
-      '@codama/visitors': 1.5.1
-      '@codama/visitors-core': 1.5.1
-      commander: 14.0.3
-      picocolors: 1.1.1
-      prompts: 2.4.2
-
   '@codama/cli@1.6.0':
     dependencies:
       '@codama/nodes': 1.10.0
@@ -1925,29 +2286,16 @@ snapshots:
       commander: 14.0.3
       picocolors: 1.1.1
 
-  '@codama/errors@1.5.1':
-    dependencies:
-      '@codama/node-types': 1.5.1
-      commander: 14.0.3
-      picocolors: 1.1.1
-
   '@codama/fragments@0.1.3':
     dependencies:
       '@codama/errors': 1.10.0
 
   '@codama/node-types@1.10.0': {}
 
-  '@codama/node-types@1.5.1': {}
-
   '@codama/nodes@1.10.0':
     dependencies:
       '@codama/errors': 1.10.0
       '@codama/node-types': 1.10.0
-
-  '@codama/nodes@1.5.1':
-    dependencies:
-      '@codama/errors': 1.5.1
-      '@codama/node-types': 1.5.1
 
   '@codama/renderers-core@1.3.11':
     dependencies:
@@ -1975,22 +2323,10 @@ snapshots:
       '@codama/nodes': 1.10.0
       '@codama/visitors-core': 1.10.0
 
-  '@codama/validators@1.5.1':
-    dependencies:
-      '@codama/errors': 1.5.1
-      '@codama/nodes': 1.5.1
-      '@codama/visitors-core': 1.5.1
-
   '@codama/visitors-core@1.10.0':
     dependencies:
       '@codama/errors': 1.10.0
       '@codama/nodes': 1.10.0
-      json-stable-stringify: 1.3.0
-
-  '@codama/visitors-core@1.5.1':
-    dependencies:
-      '@codama/errors': 1.5.1
-      '@codama/nodes': 1.5.1
       json-stable-stringify: 1.3.0
 
   '@codama/visitors@1.10.0':
@@ -1998,12 +2334,6 @@ snapshots:
       '@codama/errors': 1.10.0
       '@codama/nodes': 1.10.0
       '@codama/visitors-core': 1.10.0
-
-  '@codama/visitors@1.5.1':
-    dependencies:
-      '@codama/errors': 1.5.1
-      '@codama/nodes': 1.5.1
-      '@codama/visitors-core': 1.5.1
 
   '@esbuild/aix-ppc64@0.27.3':
     optional: true
@@ -2342,6 +2672,19 @@ snapshots:
       '@solana-program/system': 0.12.0(@solana/kit@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
       '@solana/kit': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
 
+  '@solana/accounts@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 6.10.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 6.10.0(typescript@5.9.3)
+      '@solana/rpc-spec': 6.10.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/accounts@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@solana/addresses': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -2350,6 +2693,18 @@ snapshots:
       '@solana/errors': 6.5.0(typescript@5.9.3)
       '@solana/rpc-spec': 6.5.0(typescript@5.9.3)
       '@solana/rpc-types': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/addresses@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/assertions': 6.10.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.10.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 6.10.0(typescript@5.9.3)
+      '@solana/nominal-types': 6.10.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -2367,9 +2722,21 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/assertions@6.10.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 6.10.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
   '@solana/assertions@6.5.0(typescript@5.9.3)':
     dependencies:
       '@solana/errors': 6.5.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/codecs-core@6.10.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 6.10.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -2385,11 +2752,26 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  '@solana/codecs-data-structures@6.10.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 6.10.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.10.0(typescript@5.9.3)
+      '@solana/errors': 6.10.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
   '@solana/codecs-data-structures@6.5.0(typescript@5.9.3)':
     dependencies:
       '@solana/codecs-core': 6.5.0(typescript@5.9.3)
       '@solana/codecs-numbers': 6.5.0(typescript@5.9.3)
       '@solana/errors': 6.5.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/codecs-numbers@6.10.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 6.10.0(typescript@5.9.3)
+      '@solana/errors': 6.10.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -2405,6 +2787,15 @@ snapshots:
       '@solana/codecs-core': 7.0.0(typescript@5.9.3)
       '@solana/errors': 7.0.0(typescript@5.9.3)
     optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/codecs-strings@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 6.10.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.10.0(typescript@5.9.3)
+      '@solana/errors': 6.10.0(typescript@5.9.3)
+    optionalDependencies:
+      fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.9.3
 
   '@solana/codecs-strings@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
@@ -2425,6 +2816,19 @@ snapshots:
       fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.9.3
 
+  '@solana/codecs@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 6.10.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 6.10.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.10.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/fixed-points': 6.10.0(typescript@5.9.3)
+      '@solana/options': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/codecs@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@solana/codecs-core': 6.5.0(typescript@5.9.3)
@@ -2436,6 +2840,13 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+
+  '@solana/errors@6.10.0(typescript@5.9.3)':
+    dependencies:
+      chalk: 5.6.2
+      commander: 15.0.0
+    optionalDependencies:
+      typescript: 5.9.3
 
   '@solana/errors@6.5.0(typescript@5.9.3)':
     dependencies:
@@ -2451,13 +2862,41 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  '@solana/fast-stable-stringify@6.10.0(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+
   '@solana/fast-stable-stringify@6.5.0(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/fixed-points@6.10.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 6.10.0(typescript@5.9.3)
+      '@solana/errors': 6.10.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/functional@6.10.0(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
 
   '@solana/functional@6.5.0(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
+
+  '@solana/instruction-plans@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 6.10.0(typescript@5.9.3)
+      '@solana/instructions': 6.10.0(typescript@5.9.3)
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/promises': 6.10.0(typescript@5.9.3)
+      '@solana/transaction-messages': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transactions': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
 
   '@solana/instruction-plans@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
@@ -2472,12 +2911,32 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/instructions@6.10.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 6.10.0(typescript@5.9.3)
+      '@solana/errors': 6.10.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
   '@solana/instructions@6.5.0(typescript@5.9.3)':
     dependencies:
       '@solana/codecs-core': 6.5.0(typescript@5.9.3)
       '@solana/errors': 6.5.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
+
+  '@solana/keys@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/assertions': 6.10.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.10.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 6.10.0(typescript@5.9.3)
+      '@solana/nominal-types': 6.10.0(typescript@5.9.3)
+      '@solana/promises': 6.10.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
 
   '@solana/keys@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
@@ -2490,6 +2949,40 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+
+  '@solana/kit@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/accounts': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 6.10.0(typescript@5.9.3)
+      '@solana/functional': 6.10.0(typescript@5.9.3)
+      '@solana/instruction-plans': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/instructions': 6.10.0(typescript@5.9.3)
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/offchain-messages': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/plugin-core': 6.10.0(typescript@5.9.3)
+      '@solana/plugin-interfaces': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/program-client-core': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/programs': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-api': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-parsed-types': 6.10.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 6.10.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-types': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/signers': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/subscribable': 6.10.0(typescript@5.9.3)
+      '@solana/sysvars': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-confirmation': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-messages': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transactions': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - fastestsmallesttextencoderdecoder
+      - utf-8-validate
 
   '@solana/kit@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
@@ -2524,9 +3017,28 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
+  '@solana/nominal-types@6.10.0(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+
   '@solana/nominal-types@6.5.0(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
+
+  '@solana/offchain-messages@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 6.10.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 6.10.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.10.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 6.10.0(typescript@5.9.3)
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/nominal-types': 6.10.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
 
   '@solana/offchain-messages@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
@@ -2538,6 +3050,18 @@ snapshots:
       '@solana/errors': 6.5.0(typescript@5.9.3)
       '@solana/keys': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/nominal-types': 6.5.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/options@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 6.10.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 6.10.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.10.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 6.10.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -2555,9 +3079,27 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/plugin-core@6.10.0(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+
   '@solana/plugin-core@6.5.0(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
+
+  '@solana/plugin-interfaces@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/instruction-plans': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-spec': 6.10.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions-spec': 6.10.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/signers': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
 
   '@solana/plugin-interfaces@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
@@ -2568,6 +3110,22 @@ snapshots:
       '@solana/rpc-subscriptions-spec': 6.5.0(typescript@5.9.3)
       '@solana/rpc-types': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/signers': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/program-client-core@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/accounts': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 6.10.0(typescript@5.9.3)
+      '@solana/errors': 6.10.0(typescript@5.9.3)
+      '@solana/instruction-plans': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/instructions': 6.10.0(typescript@5.9.3)
+      '@solana/plugin-interfaces': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-api': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/signers': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -2589,6 +3147,15 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/programs@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 6.10.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/programs@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@solana/addresses': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -2598,9 +3165,31 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/promises@6.10.0(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+
   '@solana/promises@6.5.0(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
+
+  '@solana/rpc-api@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 6.10.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 6.10.0(typescript@5.9.3)
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-parsed-types': 6.10.0(typescript@5.9.3)
+      '@solana/rpc-spec': 6.10.0(typescript@5.9.3)
+      '@solana/rpc-transformers': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-types': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-messages': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transactions': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
 
   '@solana/rpc-api@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
@@ -2620,11 +3209,27 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/rpc-parsed-types@6.10.0(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+
   '@solana/rpc-parsed-types@6.5.0(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
 
+  '@solana/rpc-spec-types@6.10.0(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+
   '@solana/rpc-spec-types@6.5.0(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/rpc-spec@6.10.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 6.10.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 6.10.0(typescript@5.9.3)
+      '@solana/subscribable': 6.10.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -2634,6 +3239,20 @@ snapshots:
       '@solana/rpc-spec-types': 6.5.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
+
+  '@solana/rpc-subscriptions-api@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-subscriptions-spec': 6.10.0(typescript@5.9.3)
+      '@solana/rpc-transformers': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-types': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-messages': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transactions': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
 
   '@solana/rpc-subscriptions-api@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
@@ -2649,6 +3268,19 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/rpc-subscriptions-channel-websocket@6.10.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 6.10.0(typescript@5.9.3)
+      '@solana/functional': 6.10.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions-spec': 6.10.0(typescript@5.9.3)
+      '@solana/subscribable': 6.10.0(typescript@5.9.3)
+      ws: 8.21.3
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@solana/rpc-subscriptions-channel-websocket@6.5.0(typescript@5.9.3)':
     dependencies:
       '@solana/errors': 6.5.0(typescript@5.9.3)
@@ -2662,6 +3294,15 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  '@solana/rpc-subscriptions-spec@6.10.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 6.10.0(typescript@5.9.3)
+      '@solana/promises': 6.10.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 6.10.0(typescript@5.9.3)
+      '@solana/subscribable': 6.10.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
   '@solana/rpc-subscriptions-spec@6.5.0(typescript@5.9.3)':
     dependencies:
       '@solana/errors': 6.5.0(typescript@5.9.3)
@@ -2670,6 +3311,26 @@ snapshots:
       '@solana/subscribable': 6.5.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
+
+  '@solana/rpc-subscriptions@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 6.10.0(typescript@5.9.3)
+      '@solana/fast-stable-stringify': 6.10.0(typescript@5.9.3)
+      '@solana/functional': 6.10.0(typescript@5.9.3)
+      '@solana/promises': 6.10.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 6.10.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions-api': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-subscriptions-channel-websocket': 6.10.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions-spec': 6.10.0(typescript@5.9.3)
+      '@solana/rpc-transformers': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-types': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/subscribable': 6.10.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - fastestsmallesttextencoderdecoder
+      - utf-8-validate
 
   '@solana/rpc-subscriptions@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
@@ -2691,6 +3352,18 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
+  '@solana/rpc-transformers@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 6.10.0(typescript@5.9.3)
+      '@solana/functional': 6.10.0(typescript@5.9.3)
+      '@solana/nominal-types': 6.10.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 6.10.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/rpc-transformers@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@solana/errors': 6.5.0(typescript@5.9.3)
@@ -2703,6 +3376,15 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/rpc-transport-http@6.10.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 6.10.0(typescript@5.9.3)
+      '@solana/rpc-spec': 6.10.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 6.10.0(typescript@5.9.3)
+      undici-types: 8.10.0
+    optionalDependencies:
+      typescript: 5.9.3
+
   '@solana/rpc-transport-http@6.5.0(typescript@5.9.3)':
     dependencies:
       '@solana/errors': 6.5.0(typescript@5.9.3)
@@ -2712,6 +3394,20 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  '@solana/rpc-types@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 6.10.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.10.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 6.10.0(typescript@5.9.3)
+      '@solana/fixed-points': 6.10.0(typescript@5.9.3)
+      '@solana/nominal-types': 6.10.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/rpc-types@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@solana/addresses': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -2720,6 +3416,22 @@ snapshots:
       '@solana/codecs-strings': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/errors': 6.5.0(typescript@5.9.3)
       '@solana/nominal-types': 6.5.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 6.10.0(typescript@5.9.3)
+      '@solana/fast-stable-stringify': 6.10.0(typescript@5.9.3)
+      '@solana/functional': 6.10.0(typescript@5.9.3)
+      '@solana/rpc-api': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-spec': 6.10.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 6.10.0(typescript@5.9.3)
+      '@solana/rpc-transformers': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-transport-http': 6.10.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -2741,6 +3453,22 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/signers@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 6.10.0(typescript@5.9.3)
+      '@solana/errors': 6.10.0(typescript@5.9.3)
+      '@solana/instructions': 6.10.0(typescript@5.9.3)
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/nominal-types': 6.10.0(typescript@5.9.3)
+      '@solana/offchain-messages': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-messages': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transactions': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/signers@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@solana/addresses': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -2757,11 +3485,31 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/subscribable@6.10.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 6.10.0(typescript@5.9.3)
+      '@solana/promises': 6.10.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
   '@solana/subscribable@6.5.0(typescript@5.9.3)':
     dependencies:
       '@solana/errors': 6.5.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
+
+  '@solana/sysvars@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/accounts': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 6.10.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 6.10.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.10.0(typescript@5.9.3)
+      '@solana/errors': 6.10.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
 
   '@solana/sysvars@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
@@ -2775,6 +3523,25 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+
+  '@solana/transaction-confirmation@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-strings': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 6.10.0(typescript@5.9.3)
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/promises': 6.10.0(typescript@5.9.3)
+      '@solana/rpc': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-subscriptions': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-types': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-messages': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transactions': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - fastestsmallesttextencoderdecoder
+      - utf-8-validate
 
   '@solana/transaction-confirmation@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
@@ -2795,6 +3562,22 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
+  '@solana/transaction-messages@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 6.10.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 6.10.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.10.0(typescript@5.9.3)
+      '@solana/errors': 6.10.0(typescript@5.9.3)
+      '@solana/functional': 6.10.0(typescript@5.9.3)
+      '@solana/instructions': 6.10.0(typescript@5.9.3)
+      '@solana/nominal-types': 6.10.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/transaction-messages@6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@solana/addresses': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -2806,6 +3589,25 @@ snapshots:
       '@solana/instructions': 6.5.0(typescript@5.9.3)
       '@solana/nominal-types': 6.5.0(typescript@5.9.3)
       '@solana/rpc-types': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/transactions@6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 6.10.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 6.10.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.10.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 6.10.0(typescript@5.9.3)
+      '@solana/functional': 6.10.0(typescript@5.9.3)
+      '@solana/instructions': 6.10.0(typescript@5.9.3)
+      '@solana/keys': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/nominal-types': 6.10.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-messages': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -2939,14 +3741,6 @@ snapshots:
       '@codama/nodes': 1.10.0
       '@codama/validators': 1.10.0
       '@codama/visitors': 1.10.0
-
-  codama@1.5.1:
-    dependencies:
-      '@codama/cli': 1.5.0
-      '@codama/errors': 1.5.1
-      '@codama/nodes': 1.5.1
-      '@codama/validators': 1.5.1
-      '@codama/visitors': 1.5.1
 
   commander@14.0.3: {}
 
@@ -3420,6 +4214,8 @@ snapshots:
 
   undici-types@7.24.5: {}
 
+  undici-types@8.10.0: {}
+
   vite@7.3.1(@types/node@25.5.0):
     dependencies:
       esbuild: 0.27.7
@@ -3465,3 +4261,5 @@ snapshots:
       stackback: 0.0.2
 
   ws@8.20.0: {}
+
+  ws@8.21.3: {}


### PR DESCRIPTION
## Summary

The workspace dependency tree was drifting: several direct dependencies were several major versions behind (codama-nodes `0.8`, mollusk-svm `0.11`, solana-account `3`, solana-system-interface `2`, syn `2`), the JS Codama toolchain was stale, and the lockfile carried a known vulnerability (`RUSTSEC-2026-0204` in crossbeam-epoch) plus unmaintained/unsound transitive crates. This PR refreshes everything to the latest compatible versions, including `syn` `3`.

### Dependency bumps

- **pinocchio-token `0.6` → `0.7`**, **pinocchio-token-2022 `0.3` → `0.4`** — the `token_program` field was removed from `TransferChecked`/`CloseAccount`; `escrow_program` now uses the `new()` constructors.
- **codama-nodes `0.8` → `0.11`** (IDL spec `1.0.0` → `1.8.0`) — migrated the renderer and CLI codegen to the new API (`Endianness`, `PdaValuePda`, `IsSigner`, boxed children, renamed `InstructionInputValueNode` variants).
- **syn `2` → `3`** — one API migration needed (`ItemImpl::trait_` dropped the unsafety element from its tuple). This also unblocked the latest releases of `clap` `4.6.6`, `thiserror` `2.0.20`, `serde` `1.0.229`, `tokio-macros` `2.7.2`, `bytemuck_derive` `1.12.0`, `enum-ordinalize-derive` `4.4.2`, `darling` `0.24`, `num-derive` `0.5`, and `prettyplease` `0.3` — no version pins remain.
- **mollusk-svm `0.11` → `0.15`**, **solana-account `3` → `4`**, **solana-system-interface `2` → `3`**, **insta-cmd `0.6` → `0.7`**, **object `0.39` → `0.40`**.
- **JS Codama toolchain**: `codama` `1.5.1` → `1.10`, `@codama/renderers-js` `2.0.2` → `2.3`, `@solana/kit` `6.5` → `6.10` (required for the new spec format and generated clients). All IDLs and Rust/JS clients regenerated.
- ~90 transitive crates updated within existing constraints.

### Security

- Resolves **`RUSTSEC-2026-0204`** (crossbeam-epoch invalid pointer dereference) — the only real vulnerability in the tree.
- Drops unmaintained `proc-macro-error2` and unsound `rand 0.7.3` from the dependency graph.
- `cargo audit`: 0 vulnerabilities. `cargo-deny` bans/licenses/sources: all pass.

## Testing

- `cargo build --all-features --workspace --tests` — passes
- `cargo test --all-features --workspace` — all pass (snapshots updated for the new IDL output)
- Feature matrix (`--no-default-features`, `token`-only, `--all-features`) — passes
- `cargo clippy --all-features --workspace --all-targets` — no new warnings in changed files
- `cargo-deny check bans licenses sources` — passes
- `cargo audit` — 0 vulnerabilities
- Miri loader guard tests — pass
- Custom dylint security lints (all 13) — pass on all example/security crates
- Codama IDL regeneration + drift tests — pass
- SBF compile for `escrow_program` succeeds; the local link step fails on an LLVM linker mismatch on this Mac (CI uses the pinned `nightly-2025-11-20` + sbpf-linker-21 combo on Linux)

## Linked issues

None.

_Created on behalf of Ifiok Jr. ([@ifiokjr](https://github.com/ifiokjr)) by pi using Claude at high thinking._
