### PR TITLE
fix(pina): harden token account loader length validation

### DIFF
--- a/.changeset/token_loader_hardening.md
+++ b/.changeset/token_loader_hardening.md
@@ -1,5 +1,5 @@
 ---
-pina: patch
+pina: fix
 ---
 
 Harden the token account loaders: SPL token accounts and mints are now required to be exactly `LEN` bytes (matching the token program's own validation), while token-2022 accounts keep the minimum-length check so extension data is accepted. The length requirement is now expressed as an explicit `LengthRequirement::Exact`/`AtLeast` enum instead of a bare `minimum_len` parameter, and the unsafe `from_bytes` call's SAFETY comment documents the validated invariant precisely. Adds tests for overlong/short SPL token accounts, token-2022 extension data, and overlong associated token accounts.

--- a/.changeset/token_loader_hardening.md
+++ b/.changeset/token_loader_hardening.md
@@ -1,0 +1,5 @@
+---
+pina: patch
+---
+
+Harden the token account loaders: SPL token accounts and mints are now required to be exactly `LEN` bytes (matching the token program's own validation), while token-2022 accounts keep the minimum-length check so extension data is accepted. The length requirement is now expressed as an explicit `LengthRequirement::Exact`/`AtLeast` enum instead of a bare `minimum_len` parameter, and the unsafe `from_bytes` call's SAFETY comment documents the validated invariant precisely. Adds tests for overlong/short SPL token accounts, token-2022 extension data, and overlong associated token accounts.

--- a/crates/pina/src/impls.rs
+++ b/crates/pina/src/impls.rs
@@ -600,17 +600,33 @@ impl_account_validation!(
 	"Token account data is invalid"
 );
 
+/// Length requirement for token account data.
+#[cfg(feature = "token")]
+#[derive(Clone, Copy)]
+enum LengthRequirement {
+	/// The account data must be exactly this length (SPL token).
+	Exact(usize),
+	/// The account data must be at least this length (token-2022, which
+	/// appends extension data after the base layout).
+	AtLeast(usize),
+}
+
 #[cfg(feature = "token")]
 #[track_caller]
 fn load_token_state<'a, T: ?Sized>(
 	account: &'a AccountView,
 	owners: &[Address],
-	minimum_len: usize,
+	length: LengthRequirement,
 	from_bytes: unsafe fn(&[u8]) -> &T,
 ) -> Result<Ref<'a, T>, ProgramError> {
 	account.assert_owners(owners)?;
 
-	if account.data_len() < minimum_len {
+	let data_len = account.data_len();
+	let valid_len = match length {
+		LengthRequirement::Exact(len) => data_len == len,
+		LengthRequirement::AtLeast(len) => data_len >= len,
+	};
+	if !valid_len {
 		log!(
 			"address: {} has an incorrect length",
 			account.address().as_ref()
@@ -622,10 +638,10 @@ fn load_token_state<'a, T: ?Sized>(
 
 	let bytes = account.try_borrow()?;
 	let state = AccountRef::map(bytes, |data| {
-		// SAFETY: the base layout length was validated above, the allowed owner
-		// set was validated above, and the returned borrow guard keeps the
-		// underlying runtime borrow alive for the entire lifetime of the typed
-		// access.
+		// SAFETY: the length requirement was validated above (exact for SPL
+		// token, minimum for token-2022), the allowed owner set was validated
+		// above, and the returned borrow guard keeps the underlying runtime
+		// borrow alive for the entire lifetime of the typed access.
 		unsafe { from_bytes(data) }
 	});
 
@@ -652,7 +668,7 @@ impl AsTokenAccount for AccountView {
 		load_token_state(
 			self,
 			owners,
-			crate::token::state::Mint::LEN,
+			LengthRequirement::Exact(crate::token::state::Mint::LEN),
 			crate::token::state::Mint::from_bytes_unchecked,
 		)
 	}
@@ -677,7 +693,7 @@ impl AsTokenAccount for AccountView {
 		load_token_state(
 			self,
 			owners,
-			crate::token::state::TokenAccount::LEN,
+			LengthRequirement::Exact(crate::token::state::TokenAccount::LEN),
 			crate::token::state::TokenAccount::from_bytes_unchecked,
 		)
 	}
@@ -702,7 +718,7 @@ impl AsTokenAccount for AccountView {
 		load_token_state(
 			self,
 			owners,
-			crate::token_2022::state::Mint::BASE_LEN,
+			LengthRequirement::AtLeast(crate::token_2022::state::Mint::BASE_LEN),
 			crate::token_2022::state::Mint::from_bytes_unchecked,
 		)
 	}
@@ -729,7 +745,7 @@ impl AsTokenAccount for AccountView {
 		load_token_state(
 			self,
 			owners,
-			crate::token_2022::state::TokenAccount::BASE_LEN,
+			LengthRequirement::AtLeast(crate::token_2022::state::TokenAccount::BASE_LEN),
 			crate::token_2022::state::TokenAccount::from_bytes_unchecked,
 		)
 	}
@@ -744,10 +760,13 @@ impl AsTokenAccount for AccountView {
 		let owners = [*token_program];
 		let account = self.assert_associated_token_address(owner, mint, token_program)?;
 
+		// The associated token account may be owned by either the SPL token
+		// program or token-2022; token-2022 accounts can carry extension data
+		// after the base layout, so only a minimum length is enforced.
 		load_token_state(
 			account,
 			&owners,
-			crate::token::state::TokenAccount::LEN,
+			LengthRequirement::AtLeast(crate::token::state::TokenAccount::LEN),
 			crate::token::state::TokenAccount::from_bytes_unchecked,
 		)
 	}

--- a/crates/pina/tests/integration.rs
+++ b/crates/pina/tests/integration.rs
@@ -1838,6 +1838,180 @@ fn as_associated_token_account_checked_accepts_token_2022_owner() {
 	assert!(shadow.try_borrow_mut().is_ok());
 }
 
+#[cfg(feature = "token")]
+#[test]
+fn as_token_account_checked_rejects_overlong_account() {
+	let token_account_key: Address = address!("6QWeT6FpJrm8AF1btu6WH2k2Xhq6t5vbheKVfQavmeoZ");
+	let mint: Address = address!("4hT5gDpr9HMmXzttW2Kz7LxyzKDn5XxhxL7sRKqGZo4x");
+	let owner: Address = address!("BHvLHF6mJpWxywWY5S2tsHdDtHirHyeRxoS6uF6T5FoY");
+	let mut token_account_data = build_token_account_bytes(&mint, &owner, 88);
+	// SPL token accounts are fixed-size; extra bytes are rejected.
+	token_account_data.push(0);
+
+	let accounts = [AccountBuilder::new()
+		.address(token_account_key)
+		.owner(token::ID)
+		.lamports(1_000_000)
+		.data(&token_account_data)
+		.is_writable(true)];
+
+	let dummy_data: &[u8] = &[0u8];
+	let mut input = unsafe { create_test_input(&accounts, dummy_data) };
+	let mut accts = [UNINIT; 10];
+	let (_, account_views, ..) = unsafe { deserialize_test_input::<10>(&mut input, &mut accts) };
+
+	let account = account_views[0];
+	assert!(matches!(
+		account.as_token_account_checked(),
+		Err(ProgramError::InvalidAccountData)
+	));
+}
+
+#[cfg(feature = "token")]
+#[test]
+fn as_token_account_checked_rejects_short_account() {
+	let token_account_key: Address = address!("6QWeT6FpJrm8AF1btu6WH2k2Xhq6t5vbheKVfQavmeoZ");
+	let mint: Address = address!("4hT5gDpr9HMmXzttW2Kz7LxyzKDn5XxhxL7sRKqGZo4x");
+	let owner: Address = address!("BHvLHF6mJpWxywWY5S2tsHdDtHirHyeRxoS6uF6T5FoY");
+	let mut token_account_data = build_token_account_bytes(&mint, &owner, 88);
+	token_account_data.pop();
+
+	let accounts = [AccountBuilder::new()
+		.address(token_account_key)
+		.owner(token::ID)
+		.lamports(1_000_000)
+		.data(&token_account_data)
+		.is_writable(true)];
+
+	let dummy_data: &[u8] = &[0u8];
+	let mut input = unsafe { create_test_input(&accounts, dummy_data) };
+	let mut accts = [UNINIT; 10];
+	let (_, account_views, ..) = unsafe { deserialize_test_input::<10>(&mut input, &mut accts) };
+
+	let account = account_views[0];
+	assert!(matches!(
+		account.as_token_account_checked(),
+		Err(ProgramError::InvalidAccountData)
+	));
+}
+
+#[cfg(feature = "token")]
+#[test]
+fn as_token_mint_checked_rejects_overlong_mint() {
+	let mint_key: Address = address!("8qbHbw2BbbTHBW1sK7d7Yx4Z4DccnE9vrFica8FWHQrP");
+	let mut mint_data = build_token_mint_bytes(9, 42);
+	// SPL token mints are fixed-size; extra bytes are rejected.
+	mint_data.push(0);
+
+	let accounts = [AccountBuilder::new()
+		.address(mint_key)
+		.owner(token::ID)
+		.lamports(1_000_000)
+		.data(&mint_data)
+		.is_writable(true)];
+
+	let dummy_data: &[u8] = &[0u8];
+	let mut input = unsafe { create_test_input(&accounts, dummy_data) };
+	let mut accts = [UNINIT; 10];
+	let (_, account_views, ..) = unsafe { deserialize_test_input::<10>(&mut input, &mut accts) };
+
+	let account = account_views[0];
+	assert!(matches!(
+		account.as_token_mint_checked(),
+		Err(ProgramError::InvalidAccountData)
+	));
+}
+
+#[cfg(feature = "token")]
+#[test]
+fn as_token_2022_account_checked_accepts_extension_data() {
+	let token_account_key: Address = address!("4vJ9JU1bJJE96FWSJKv9J5xBqHkM7SspGq2pZ7uS5k4x");
+	let mint: Address = address!("CktRuQ2mttxyPjdvVSxGJySLjeRGna43E77gzHu6HotE");
+	let owner: Address = address!("4Nd1mL5g7dUvNbKQjnYQgQki71RJKVQ1BM8DT6vKrrf5");
+	let mut token_account_data = build_token_account_bytes(&mint, &owner, 123);
+	// token-2022 accounts may carry extension data after the base layout.
+	token_account_data.extend_from_slice(&[0u8; 8]);
+
+	let accounts = [AccountBuilder::new()
+		.address(token_account_key)
+		.owner(token_2022::ID)
+		.lamports(1_000_000)
+		.data(&token_account_data)
+		.is_writable(true)];
+
+	let dummy_data: &[u8] = &[0u8];
+	let mut input = unsafe { create_test_input(&accounts, dummy_data) };
+	let mut accts = [UNINIT; 10];
+	let (_, account_views, ..) = unsafe { deserialize_test_input::<10>(&mut input, &mut accts) };
+
+	let account = account_views[0];
+	let token_account = account
+		.as_token_2022_account_checked()
+		.unwrap_or_else(|e| panic!("token-2022 account load failed: {e:?}"));
+	assert_eq!(token_account.amount(), 123);
+	assert_eq!(token_account.mint(), &mint);
+	assert_eq!(token_account.owner(), &owner);
+}
+
+#[cfg(feature = "token")]
+#[test]
+fn as_token_2022_account_checked_rejects_short_account() {
+	let token_account_key: Address = address!("4vJ9JU1bJJE96FWSJKv9J5xBqHkM7SspGq2pZ7uS5k4x");
+	let mint: Address = address!("CktRuQ2mttxyPjdvVSxGJySLjeRGna43E77gzHu6HotE");
+	let owner: Address = address!("4Nd1mL5g7dUvNbKQjnYQgQki71RJKVQ1BM8DT6vKrrf5");
+	let mut token_account_data = build_token_account_bytes(&mint, &owner, 123);
+	token_account_data.pop();
+
+	let accounts = [AccountBuilder::new()
+		.address(token_account_key)
+		.owner(token_2022::ID)
+		.lamports(1_000_000)
+		.data(&token_account_data)
+		.is_writable(true)];
+
+	let dummy_data: &[u8] = &[0u8];
+	let mut input = unsafe { create_test_input(&accounts, dummy_data) };
+	let mut accts = [UNINIT; 10];
+	let (_, account_views, ..) = unsafe { deserialize_test_input::<10>(&mut input, &mut accts) };
+
+	let account = account_views[0];
+	assert!(matches!(
+		account.as_token_2022_account_checked(),
+		Err(ProgramError::InvalidAccountData)
+	));
+}
+
+#[cfg(feature = "token")]
+#[test]
+fn as_associated_token_account_accepts_overlong_data() {
+	let wallet: Address = address!("4Nd1mL5g7dUvNbKQjnYQgQki71RJKVQ1BM8DT6vKrrf5");
+	let mint: Address = address!("CktRuQ2mttxyPjdvVSxGJySLjeRGna43E77gzHu6HotE");
+	let (ata_address, _bump) = try_get_associated_token_address(&wallet, &mint, &token_2022::ID)
+		.unwrap_or_else(|| panic!("failed to derive ata"));
+	let mut token_account_data = build_token_account_bytes(&mint, &wallet, 99);
+	// token-2022 ATAs may carry extension data after the base layout.
+	token_account_data.extend_from_slice(&[0u8; 8]);
+
+	let accounts = [AccountBuilder::new()
+		.address(ata_address)
+		.owner(token_2022::ID)
+		.lamports(1_000_000)
+		.data(&token_account_data)
+		.is_writable(true)];
+
+	let dummy_data: &[u8] = &[0u8];
+	let mut input = unsafe { create_test_input(&accounts, dummy_data) };
+	let mut accts = [UNINIT; 10];
+	let (_, account_views, ..) = unsafe { deserialize_test_input::<10>(&mut input, &mut accts) };
+
+	let account = account_views[0];
+	let token_account = account
+		.as_associated_token_account_checked(&wallet, &mint, &token_2022::ID)
+		.unwrap_or_else(|e| panic!("associated token account load failed: {e:?}"));
+	assert_eq!(token_account.amount(), 99);
+	assert_eq!(token_account.owner(), &wallet);
+}
+
 // ---------------------------------------------------------------------------
 // Test: TryFromAccountInfos derive
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`load_token_state` validated account data with only a **minimum** length check (`data_len() >= minimum_len`) for every caller. SPL token accounts and mints are fixed-size — the token program itself requires `input.len() == Account::LEN` / `Mint::LEN` — so pina was accepting malformed accounts with trailing garbage bytes that the token program would reject. A program using pina's loaders could process an account the token program considers invalid, leading to inconsistent state.

The bare `minimum_len: usize` parameter was also a footgun: nothing in the signature distinguished "exactly this length" from "at least this length", and the SAFETY comment on the `unsafe { from_bytes(data) }` call claimed "the base layout length was validated above" without stating which invariant actually held.

## Fix

Introduce an explicit `LengthRequirement` enum and enforce it per caller:

- `LengthRequirement::Exact(len)` — SPL token accounts and mints (`as_token_account_checked`, `as_token_mint_checked`). Overlong data is now rejected with `InvalidAccountData`, matching the token program.
- `LengthRequirement::AtLeast(len)` — token-2022 accounts and mints (`as_token_2022_account_checked`, `as_token_2022_mint_checked`), which are variable-length (base layout + extension data), and associated token accounts, which may be owned by token-2022 and carry extensions.

The SAFETY comment on the `from_bytes` call now states the validated invariant precisely (exact for SPL token, minimum for token-2022).

## Tests

- `as_token_account_checked_rejects_overlong_account` — SPL token account with `LEN + 1` bytes → `InvalidAccountData`
- `as_token_account_checked_rejects_short_account` — `LEN - 1` bytes → `InvalidAccountData`
- `as_token_mint_checked_rejects_overlong_mint` — mint with `LEN + 1` bytes → `InvalidAccountData`
- `as_token_2022_account_checked_accepts_extension_data` — base layout + 8 extension bytes loads correctly
- `as_token_2022_account_checked_rejects_short_account` — `BASE_LEN - 1` bytes → `InvalidAccountData`
- `as_associated_token_account_accepts_overlong_data` — token-2022 ATA with extension data loads correctly

Full `pina` test suite passes with the `token` feature; clippy and fmt clean.

---
Created on behalf of Ifiok Jr. (@ifiokjr) — model: claude, thinking level: high
