### PR TITLE
ci: use GitHub-hosted ubuntu-24.04 runners instead of Blacksmith

### DIFF
--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   measure:
     timeout-minutes: 45
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   lint:
     timeout-minutes: 60
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout repository
         uses: actions/checkout@v6
@@ -32,7 +32,7 @@ jobs:
 
   security:
     timeout-minutes: 60
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout repository
         uses: actions/checkout@v6
@@ -48,7 +48,7 @@ jobs:
 
   test:
     timeout-minutes: 60
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout repository
         uses: actions/checkout@v6
@@ -66,7 +66,7 @@ jobs:
 
   miri:
     timeout-minutes: 90
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout repository
         uses: actions/checkout@v6
@@ -82,7 +82,7 @@ jobs:
 
   feature-matrix:
     timeout-minutes: 60
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -128,7 +128,7 @@ jobs:
 
   program-e2e:
     timeout-minutes: 120
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     env:
       XDG_CACHE_HOME: ${{ github.workspace }}/.cache
     steps:
@@ -146,7 +146,7 @@ jobs:
 
   idl:
     timeout-minutes: 60
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout repository
         uses: actions/checkout@v6
@@ -172,7 +172,7 @@ jobs:
 
   build:
     timeout-minutes: 60
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/compute-units.yml
+++ b/.github/workflows/compute-units.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   compare:
     timeout-minutes: 180
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     env:
       XDG_CACHE_HOME: ${{ github.workspace }}/.cache
       PINA_BPF_TOOLCHAIN: nightly-2025-11-20

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   coverage:
     timeout-minutes: 90
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   kani:
     timeout-minutes: 30
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/mutants-nightly.yml
+++ b/.github/workflows/mutants-nightly.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   mutants:
     timeout-minutes: 180
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/mutants-pr.yml
+++ b/.github/workflows/mutants-pr.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   detect-changed-crates:
     timeout-minutes: 5
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.changed.outputs.matrix }}
       any_changed: ${{ steps.changed.outputs.any_changed }}
@@ -69,7 +69,7 @@ jobs:
     needs: detect-changed-crates
     if: needs.detect-changed-crates.outputs.any_changed == 'true'
     timeout-minutes: 120
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.detect-changed-crates.outputs.matrix) }}

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   preview:
     timeout-minutes: 45
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   semver-checks:
     timeout-minutes: 45
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/surfpool.yml
+++ b/.github/workflows/surfpool.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   surfpool-idl-smoke:
     timeout-minutes: 120
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout repository
         uses: actions/checkout@v6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1094,9 +1094,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

Running every CI job on Blacksmith is expensive. This PR reverts all workflow jobs from Blacksmith runners (`blacksmith-2vcpu-ubuntu-2404` / `blacksmith-4vcpu-ubuntu-2404`) to the default GitHub-hosted `ubuntu-24.04` runner across all 10 workflow files.

It also fixes the pre-existing `security` CI failure: `cargo-audit` was failing on **RUSTSEC-2026-0204** (invalid pointer dereference in `crossbeam-epoch` < 0.9.20). The lockfile is bumped to `crossbeam-epoch 0.9.20` to clear it.

## Linked issues

None.

## Testing

- [x] CI runs the full lint/test/security suite on this PR
- [x] `cargo update -p crossbeam-epoch` verified locally (0.9.18 → 0.9.20)

## Title and history conventions

- [x] PR title uses Conventional Commits syntax
- [x] Commits in this PR use Conventional Commits syntax
- [x] Referenced issue titles are written in sentence case

_Created on behalf of Ifiok Jr. ([@ifiokjr](https://github.com/ifiokjr)) by pi using Claude at high thinking._