### PR TITLE
fix(security): ignore bincode advisory (RUSTSEC-2026-0204)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -4,7 +4,11 @@ all-features = true
 [advisories]
 db-path = "target/advisory-db"
 db-urls = ["https://github.com/RustSec/advisory-db.git"]
-ignore = []
+ignore = [
+	# RUSTSEC-2026-0204: bincode is unmaintained. Transitive dev-dependency
+	# (mollusk-svm, solana-account) — not shipped in any on-chain program.
+	"RUSTSEC-2026-0204",
+]
 
 [licenses]
 allow = [


### PR DESCRIPTION

## Problem

A new advisory RUSTSEC-2026-0204 (bincode unmaintained, published 2026-08-14) breaks CI on every open PR. bincode 1.x is a transitive dev-dependency through mollusk-svm and solana-account — it is not shipped in any on-chain program.

## Solution

Add the advisory to deny.toml's ignore list with justification.

_Created on behalf of Ifiok Jr. ([@ifiokjr](https://github.com/ifiokjr)) by pi using GPT-5.6 at medium thinking._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security advisory configuration to ignore a transitive dependency advisory that does not affect shipped on-chain programs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->