### PR TITLE
docs: add LoadedAccount, AccountsCursor, pina init, PINA_TEMPLATES_DIR docs

### DIFF
--- a/docs/src/core-concepts.md
+++ b/docs/src/core-concepts.md
@@ -102,7 +102,11 @@ A chain that starts with `&AccountView` stays shared, while a chain that starts 
 
 ## Typed account conversions
 
-Traits in `crates/pina/src/impls.rs` provide typed conversion paths from raw `AccountView` values into strongly typed account states. `as_account()` returns `Ref<T>` and `as_account_mut()` returns `RefMut<T>` borrow guards.
+Traits in `crates/pina/src/impls.rs` provide typed conversion paths from raw `AccountView` values into strongly typed account states. `as_account()` returns `Ref<T>` and `as_account_mut()` returns `RefMut<T>` borrow guards. The type aliases `LoadedAccount<'a, T>` and `LoadedAccountMut<'a, T>` are provided for `Ref<'a, T>` and `RefMut<'a, T>` respectively, offering a more descriptive name for guard-backed typed account access.
+
+## Account cursors
+
+`AccountsCursor` is the runtime layer used by `#[derive(Accounts)]`. It advances through the account slice from left to right, supports explicit trailing-account capture via `#[pina(remaining)]`, and centralises duplicate mutable-account checks without heap allocation.
 
 ## Instruction authoring tips
 

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -17,6 +17,14 @@ install:all
 
 <!-- {/devEnvironmentSetupCommands} -->
 
+You can also scaffold a new project directly with the CLI:
+
+```bash
+pina init my_program
+```
+
+See `pina init --help` for options like `--path` and `--force`.
+
 If `pnpm-workspace.yaml` sets `useNodeVersion`, `devenv shell` activates the matching pnpm-managed `node`/`npm`/`npx`/`corepack` toolchain automatically.
 
 ## Build and test

--- a/readme.md
+++ b/readme.md
@@ -216,6 +216,14 @@ Use `verify:docs` to validate documentation structure and build output in CI. Us
 
 <br>
 
+You can scaffold a new project with the CLI:
+
+```sh
+pina init my_program
+```
+
+Or add Pina to an existing crate:
+
 ```rust
 use pina::*;
 
@@ -498,7 +506,7 @@ Available assertions:
 
 <br>
 
-On deserialized account data, chain assertions using the `AccountValidation` trait. `as_account()` returns a guard-backed `Ref<T>` and `as_account_mut()` returns `RefMut<T>`:
+On deserialized account data, chain assertions using the `AccountValidation` trait. `as_account()` returns a guard-backed `Ref<T>` (also available as the `LoadedAccount<T>` alias) and `as_account_mut()` returns `RefMut<T>` (also available as the `LoadedAccountMut<T>` alias):
 
 ```rust
 let state = account.as_account::<Config>(&program_id)?;
@@ -523,7 +531,7 @@ pub struct MyAccounts<'a> {
 }
 ```
 
-The derive generates `TryFromAccountInfos` and `TryFrom<&mut [AccountView]>` implementations. It validates that the exact number of accounts is provided, and it supports `&'a AccountView`, `&'a mut AccountView`, `&'a [AccountView]`, and `&'a mut [AccountView]` fields.
+The derive generates `TryFromAccountInfos` and `TryFrom<&mut [AccountView]>` implementations. Internally it uses `AccountsCursor` to walk the account slice left-to-right, which centralises duplicate-mutable-account checks without heap allocation. It validates that the exact number of accounts is provided, and it supports `&'a AccountView`, `&'a mut AccountView`, `&'a [AccountView]`, and `&'a mut [AccountView]` fields.
 
 Use the `#[pina(remaining)]` attribute on the last field to capture trailing accounts:
 
@@ -769,6 +777,10 @@ pina profile target/deploy/my_program.so -o r.json # write to file
 The profiler decodes each SBF instruction opcode and assigns costs: regular instructions cost 1 CU, syscalls cost 100 CU.
 
 <!-- {/pinaProfileDescription} -->
+
+### CLI configuration
+
+The `pina docs` subcommand renders built-in reference topics. Set the `PINA_TEMPLATES_DIR` environment variable to a directory containing `<topic>.t.md` template files to override or extend the default topics with your own content.
 
 ## Crates
 


### PR DESCRIPTION

## Problem

The verification audit (R1/R2) found documentation gaps:
- `LoadedAccount`/`LoadedAccountMut` type aliases not mentioned in readme or core-concepts (only in ADR 0003)
- `AccountsCursor` not mentioned in readme despite being fully implemented
- `pina init` command missing from readme and getting-started
- `PINA_TEMPLATES_DIR` env var only documented in changeset and source code

## Implementation

Added missing documentation for all four items across readme.md, docs/src/core-concepts.md, and docs/src/getting-started.md.

_Created on behalf of Ifiok Jr. ([@ifiokjr](https://github.com/ifiokjr)) by pi using GPT-5.6 at medium thinking._