### PR TITLE
fix(ci): configure git credentials for release PR branch push

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -79,6 +79,11 @@ jobs:
           echo "has_changesets=${has_changesets}" >> "$GITHUB_OUTPUT"
         shell: bash
 
+      - name: configure git authentication
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh auth setup-git
+
       - name: refresh release pull request
         if: steps.release_record.outputs.is_release_commit != 'true' && steps.pending_changesets.outputs.has_changesets == 'true'
         env:
@@ -137,6 +142,11 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
         shell: bash
+
+      - name: configure git authentication
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh auth setup-git
 
       - name: detect release commit and create tags
         id: tag_release


### PR DESCRIPTION
## Problem

The second release-pr failure (after the `GH_TOKEN` fix): `monochange run release` gets through prepare → format → commit, but `OpenReleaseRequest` fails pushing the release branch:

```
✖ [4/4] open release request (OpenReleaseRequest) 563ms
  └─ config error: failed to push release pull request branch: fatal: could not read Username for 'https://github.com': No such device or address
```

`GH_TOKEN` lets monochange talk to the GitHub API, but the branch push uses plain `git push`, and the checkout uses `persist-credentials: false` — so git has no credentials at all.

## Fix

Run `gh auth setup-git` in both jobs before the monochange steps that push, with `GH_TOKEN` set. This installs a git credential helper that reads `GH_TOKEN` from the environment at push time and authenticates as `x-access-token`:

- **create job** — before `refresh release pull request`: the release branch push + PR creation
- **tag job** — before `detect release commit and create tags`: the tag push (`tag-release --push=true`)

Verified locally: `gh auth setup-git` runs non-interactively with `GH_TOKEN` set, and the installed helper emits `username=x-access-token / password=<GH_TOKEN>` when git asks for credentials.

Created on behalf of Ifiok Jr. (`@ifiokjr`), using Claude Sonnet 4.5, high thinking level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release automation reliability.
  * Release-related changes can now complete more consistently with automated repository authentication.
  * No changes to product functionality or the end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->