### PR TITLE
refactor(ci): simplify release-pr workflow

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -12,11 +12,12 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
 
 jobs:
   create:
     if: github.repository_owner == 'pina-rs'
+    outputs:
+      is_release_commit: ${{ steps.release_record.outputs.is_release_commit }}
     timeout-minutes: 20
     runs-on: ubuntu-24.04
     permissions:
@@ -115,7 +116,7 @@ jobs:
         run: echo "HEAD is already a merged release commit; skipping release PR refresh."
 
   tag:
-    if: github.repository_owner == 'pina-rs'
+    if: github.repository_owner == 'pina-rs' && needs.create.outputs.is_release_commit == 'true'
     needs: create
     timeout-minutes: 10
     runs-on: ubuntu-24.04
@@ -148,40 +149,23 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh auth setup-git
 
-      - name: detect release commit and create tags
-        id: tag_release
+      - name: create release tags
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: devenv shell -- bash -e {0}
         run: |
           set -euo pipefail
-
-          if is_release_commit="$(monochange --log-level=debug step release-record --from HEAD --format json --jq '.resolved_commit == .record_commit')"; then
-            echo "is_release_commit=${is_release_commit}" >> "$GITHUB_OUTPUT"
-            if [ "${is_release_commit}" = "true" ]; then
-              monochange --log-level=debug step tag-release --from HEAD --push=true --format json | tee /tmp/tag-report.json
-            fi
-          else
-            subject="$(git log -1 --pretty=%s)"
-            if [[ "$subject" == chore\(release\):\ prepare\ release* ]]; then
-              echo "Release-looking commit could not be read as a release record; failing instead of silently skipping release automation."
-              monochange --log-level=debug step release-record --from HEAD --format json
-              exit 1
-            fi
-            echo "is_release_commit=false" >> "$GITHUB_OUTPUT"
-          fi
+          monochange --log-level=debug step tag-release --from HEAD --push=true --format json | tee /tmp/tag-report.json
+        shell: devenv shell -- bash -e {0}
 
       - name: create draft releases
-        if: steps.tag_release.outputs.is_release_commit == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          monochange --log-level=debug step publish-release --from-ref="HEAD" --draft --format json | tee /tmp/publish-release.json
+          monochange --log-level=debug step publish-release --from-ref="HEAD" --draft --format json
         shell: devenv shell -- bash -e {0}
 
       - name: comment on released issues
-        if: steps.tag_release.outputs.is_release_commit == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## What

Ports the release-pr simplification from [monosecret#39](https://github.com/ifiokjr/monosecret/commit/1d0ef2228cf644f08aa6bde60f0c20d647917674) to pina:

- remove redundant `cancel-in-progress: false` (matches the default)
- expose `is_release_commit` from the create job's `release_record` step as a job output
- gate the tag job on `needs.create.outputs.is_release_commit == 'true'`
- drop the tag job's duplicate release-record detection — `create release tags` now just runs `tag-release`
- drop the per-step `is_release_commit` conditions on draft release creation and issue comments (the whole job only runs for release commits)

## Why

The tag job re-ran the same `monochange step release-record` detection the create job already performed (it re-reads the commit graph to resolve the release record). The create job's output is authoritative and already gates the `refresh release pull request` step — the tag job's duplicate detection only added runtime and duplicated the fail-loud release-commit guard.

The create job keeps the fail-loud behavior: a release-looking commit that can't be parsed as a release record still fails the workflow instead of silently skipping release automation.

Created on behalf of Ifiok Jr. (`@ifiokjr`), using Claude Sonnet 4.5, high thinking level.