### PR TITLE
chore(ci): pin all GitHub Actions to full commit SHAs and bump to latest versions

### DIFF
--- a/.github/actions/devenv/action.yml
+++ b/.github/actions/devenv/action.yml
@@ -17,14 +17,14 @@ runs:
   using: composite
   steps:
     - name: cache rust dependencies
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       with:
         # Include the devenv/toolchain wiring in the cache key so cached build
         # scripts don't outlive the Nix environment that produced them.
         prefix-key: "${{ inputs.cache-version }}-${{ hashFiles('devenv.nix', 'rust-toolchain.toml', '.github/actions/devenv/action.yml') }}"
 
     - name: cache cargo binaries
-      uses: actions/cache@v4
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ./.bin
         key: ${{ runner.os }}-cargo-bin-${{ inputs.cache-version }}-${{ env.RUSTUP_TOOLCHAIN }}-${{ hashFiles('devenv.nix', 'rust-toolchain.toml', '.github/actions/devenv/action.yml', 'Cargo.toml') }}
@@ -32,7 +32,7 @@ runs:
           ${{ runner.os }}-cargo-bin-${{ inputs.cache-version }}-
 
     - name: install nix
-      uses: cachix/install-nix-action@v31
+      uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
       with:
         github_access_token: ${{ inputs.github-token }}
 

--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: setup
         uses: ./.github/actions/devenv

--- a/.github/workflows/changeset-policy.yml
+++ b/.github/workflows/changeset-policy.yml
@@ -26,7 +26,7 @@ jobs:
       pull-requests: read
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: setup
@@ -35,7 +35,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: collect changed files
         id: changed
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
       - name: run changeset policy
         env:
           CHANGED_FILES: ${{ steps.changed.outputs.all_changed_files }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: setup
         uses: ./.github/actions/devenv
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: setup
         uses: ./.github/actions/devenv
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: setup
         uses: ./.github/actions/devenv
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: setup
         uses: ./.github/actions/devenv
@@ -106,7 +106,7 @@ jobs:
     name: feature-matrix (${{ matrix.label }})
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: setup
         uses: ./.github/actions/devenv
@@ -133,7 +133,7 @@ jobs:
       XDG_CACHE_HOME: ${{ github.workspace }}/.cache
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: setup
         uses: ./.github/actions/devenv
@@ -149,7 +149,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: setup
         uses: ./.github/actions/devenv
@@ -175,7 +175,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: setup
         uses: ./.github/actions/devenv

--- a/.github/workflows/compute-units.yml
+++ b/.github/workflows/compute-units.yml
@@ -19,7 +19,7 @@ jobs:
       PINA_BPF_TOOLCHAIN: nightly-2025-11-20
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -82,7 +82,7 @@ jobs:
 
       - name: upload compute-unit artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: compute-unit-report
           path: target/cu

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: setup
         uses: ./.github/actions/devenv
@@ -32,13 +32,13 @@ jobs:
         shell: devenv shell -c -- bash -e {0}
 
       - name: upload lcov artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-lcov
           path: target/coverage/lcov.info
 
       - name: upload codecov report
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: target/coverage/lcov.info
           fail_ci_if_error: false

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: setup
         uses: ./.github/actions/devenv
@@ -38,7 +38,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: configure github pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: verify docs
         run: verify:docs
@@ -49,7 +49,7 @@ jobs:
         shell: devenv shell -c -- bash -e {0}
 
       - name: upload pages artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: docs/book
 
@@ -63,4 +63,4 @@ jobs:
     steps:
       - name: deploy to github pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: setup
         uses: ./.github/actions/devenv

--- a/.github/workflows/mutants-nightly.yml
+++ b/.github/workflows/mutants-nightly.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -35,7 +35,7 @@ jobs:
 
       - name: upload mutants report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: mutants-report
           path: target/mutants

--- a/.github/workflows/mutants-pr.yml
+++ b/.github/workflows/mutants-pr.yml
@@ -25,7 +25,7 @@ jobs:
       any_changed: ${{ steps.changed.outputs.any_changed }}
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -75,7 +75,7 @@ jobs:
       matrix: ${{ fromJson(needs.detect-changed-crates.outputs.matrix) }}
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -90,7 +90,7 @@ jobs:
 
       - name: upload mutants report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: mutants-report-${{ matrix.package }}
           path: target/mutants

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,22 +86,22 @@ jobs:
           echo "::error::Release $RELEASE_TAG was not created within the wait window. Check the release-pr tag job." >&2
           exit 1
       - name: checkout release tag
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ env.RELEASE_TAG }}
           fetch-depth: 0
       - name: install rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: stable
       - name: setup cross toolchain
         if: startsWith(matrix.os, 'ubuntu') && !contains(matrix.target, '-musl')
-        uses: taiki-e/setup-cross-toolchain-action@v1
+        uses: taiki-e/setup-cross-toolchain-action@12b7ad4acfa95a1476779d6c06699b96ec1691f8 # v1.42.0
         with:
           target: ${{ matrix.target }}
       - name: install cross
         if: contains(matrix.target, '-musl')
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@288e746965032cfcc232e09af2daf5f23c14d780 # v2.86.1
         with:
           tool: cross
       - name: set static crt linkage
@@ -109,7 +109,7 @@ jobs:
         shell: bash
         run: echo "RUSTFLAGS=${RUSTFLAGS:-} -C target-feature=+crt-static" >> "$GITHUB_ENV"
       - name: upload binaries
-        uses: taiki-e/upload-rust-binary-action@v1
+        uses: taiki-e/upload-rust-binary-action@f0d45ae91ee7b8ee928de7a9d04d893a08bcbec6 # v1.30.2
         with:
           bin: pina
           manifest-path: crates/pina_cli/Cargo.toml
@@ -135,7 +135,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: checkout release tag
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ env.RELEASE_TAG }}
           persist-credentials: false
@@ -159,7 +159,7 @@ jobs:
           fi
           sha256sum "$asset_dir"/*
       - name: attest all release archives
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: ${{ runner.temp }}/release-asset-attestations/*
       - name: verify all release archive attestations
@@ -205,7 +205,7 @@ jobs:
           fi
         shell: bash
       - name: checkout release tag
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ env.RELEASE_TAG }}
           fetch-depth: 0
@@ -214,14 +214,14 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: get crates oidc auth token
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
         id: crates-oidc
       - name: setup cargo stable for publish
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: stable
       - name: setup node for publish
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
       - name: check publish readiness

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -25,7 +25,7 @@ jobs:
       pull-requests: write
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -126,7 +126,7 @@ jobs:
       issues: write
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/surfpool.yml
+++ b/.github/workflows/surfpool.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: setup
         uses: ./.github/actions/devenv


### PR DESCRIPTION
## What

Pins every third-party GitHub Action to its full 40-character commit SHA with a version comment (`uses: owner/repo@<sha> # vX.Y.Z`), per zizmor's `pinned-actions` rule — the mutable tag refs (`@v6`, `@stable`, ...) were untrusted and could be retargeted. Also bumps each action to its latest release:

| Action | Before | After |
|---|---|---|
| actions/checkout | v6 | v7.0.1 |
| actions/upload-artifact | v7 | v7.0.1 |
| actions/cache | v4 | v6.1.0 |
| actions/setup-node | v6 | v7.0.0 |
| actions/configure-pages | v6 | v6.0.0 |
| actions/deploy-pages | v5 | v5.0.0 |
| actions/upload-pages-artifact | v5 | v5.0.0 |
| actions/attest-build-provenance | v3 | v4.2.2 |
| codecov/codecov-action | v6 | v7.0.0 |
| dtolnay/rust-toolchain | stable | v1 |
| rust-lang/crates-io-auth-action | v1 | v1.0.5 |
| taiki-e/install-action | v2 | v2.86.1 |
| taiki-e/setup-cross-toolchain-action | v1 | v1.42.0 |
| taiki-e/upload-rust-binary-action | v1 | v1.30.2 |
| tj-actions/changed-files | v46 | v47.0.6 |
| Swatinem/rust-cache | v2 | v2.9.2 |
| cachix/install-nix-action | v31 | v31.11.1 |

## Security verification

Checked every target version against the GitHub Advisory Database:

- `tj-actions/changed-files` v47.0.6 is outside the affected ranges of GHSA-mrrh-fwg8-r2c3 (secrets leak, <= 45.0.7) and GHSA-mcph-m25j-8j63 (command injection, < 41)
- `actions/upload-artifact` v7.0.1 bundles `@actions/artifact` ^6.2.0 — outside GHSA-6q32-hq47-5qq3 (arbitrary file write, < 2.1.2)
- No open advisories in the actions or npm ecosystems affect any of the other pinned versions (checkout, cache, setup-node, pages actions, attest-build-provenance, codecov, rust-toolchain, crates-io-auth, taiki-e/*, rust-cache, install-nix-action)

`zizmor` reports **zero** `pinned-actions` findings after this change (the remaining zizmor findings — template-injection in the devenv action, excessive-permissions, cache-poisoning, artipacked — are pre-existing and untouched by this PR).

Created on behalf of Ifiok Jr. (`@ifiokjr`), using Claude Sonnet 4.5, high thinking level.