### PR TITLE
chore(changesets): consolidate duplicate and superseded changesets

### DIFF
--- a/.changeset/dependency_refresh.md
+++ b/.changeset/dependency_refresh.md
@@ -16,4 +16,4 @@ Refresh workspace dependencies to their latest compatible versions.
 - Bump `codama-nodes` to `0.11` (spec `1.8.0`), `mollusk-svm` to `0.15`, `solana-account` to `4`, `solana-system-interface` to `3`, `insta-cmd` to `0.7`, and `object` to `0.40`.
 - Bump the JS Codama toolchain (`codama` to `1.10`, `@codama/renderers-js` to `2.3`) and regenerate all IDLs and Rust/JS clients.
 - Keep `syn` at `2` by pinning `clap` `4.6.3`, `thiserror` `2.0.18`, `serde` `1.0.228`, `tokio-macros` `2.7.1`, `bytemuck_derive` `1.11.0`, and `enum-ordinalize-derive` `4.4.1` (newer releases of these derive crates require `syn` 3).
-- Resolves `RUSTSEC-2026-0204` (crossbeam-epoch) and drops the unmaintained `proc-macro-error2` and unsound `rand 0.7.3` from the dependency tree.
+- Resolves `RUSTSEC-2026-0097` (unsound `rand` 0.7.3) and `RUSTSEC-2026-0173` (unmaintained `proc-macro-error2`), dropping them from the dependency tree, and updates `jiff`, `defmt`, `env_logger`, `solana-logger`, and `crossbeam-epoch` to patched versions.

--- a/.changeset/mollusk-svm-security-upgrade.md
+++ b/.changeset/mollusk-svm-security-upgrade.md
@@ -1,5 +1,0 @@
----
-pina: fix
----
-
-Upgrade the example dev-dependency `mollusk-svm` from 0.11.0 to 0.15.0 and `solana-account` from ^3 to ^4, eliminating RUSTSEC-2026-0097 (unsound `rand` 0.7.3) and RUSTSEC-2026-0173 (unmaintained `proc-macro-error2`) from the example test dependency graph. Also updates `jiff`, `defmt`, `env_logger`, `solana-logger`, and `crossbeam-epoch` to patched versions.

--- a/.changeset/pina_cli_termimad_bump.md
+++ b/.changeset/pina_cli_termimad_bump.md
@@ -1,7 +1,0 @@
----
-pina_cli: fix
----
-
-# Bump termimad to a maintained release
-
-Bump `termimad` from `0.25` to `0.34.1` to keep in-terminal documentation rendering on a maintained release.

--- a/.changeset/pina_cli_ux_and_parallel_io.md
+++ b/.changeset/pina_cli_ux_and_parallel_io.md
@@ -10,4 +10,4 @@ Add UX improvements and parallel file I/O to the `pina` CLI.
 - **Colored output**: Error messages and success indicators now use `owo-colors` for semantic terminal styling.
 - **Summary table**: `pina idl` prints a `comfy-table` summary showing instruction, account, PDA, and error counts after generation.
 - **`docs` subcommand**: `pina docs <topic>` renders bundled `.t.md` documentation in-terminal using `termimad`, with `PINA_TEMPLATES_DIR` support for custom topics.
-- **New dependencies**: `rayon`, `owo-colors`, `comfy-table`, `termimad`.
+- **New dependencies**: `rayon`, `owo-colors`, `comfy-table`, and `termimad` (kept on the maintained `0.34.1` release).

--- a/.changeset/pod_collections_and_refactor.md
+++ b/.changeset/pod_collections_and_refactor.md
@@ -5,3 +5,5 @@ pina_pod_primitives: feat
 # Add fixed-capacity Pod collection types
 
 Add `PodOption<T>`, `PodString<N, PFX>`, and `PodVec<T, N, PFX>` fixed-capacity collection types for zero-copy Solana account layouts. Split the monolithic `lib.rs` into a multi-file module structure for maintainability. Add kani proof harnesses for collection types.
+
+`PodString` deliberately does not implement `Deref<Target = str>` or `AsRef<str>`: because it is `bytemuck::Pod`, bytes loaded from untrusted account data may not be valid UTF-8, so string access is only available through the validating `try_as_str()` or the explicit unsafe `as_str_unchecked()`.

--- a/.changeset/podstring_utf8_soundness.md
+++ b/.changeset/podstring_utf8_soundness.md
@@ -1,5 +1,0 @@
----
-pina_pod_primitives: fix
----
-
-Remove the unsound `Deref<Target = str>` and `AsRef<str>` impls from `PodString`. Because `PodString` is `bytemuck::Pod`, bytes loaded from untrusted account data may not be valid UTF-8, and the removed impls produced a `&str` via `from_utf8_unchecked` — undefined behavior. Use `try_as_str()` for validated access, or `as_str_unchecked()` (unsafe) for unchecked access.


### PR DESCRIPTION
## Summary

Consolidates the pending changesets ahead of the next release. All 20 changesets were traced to their originating commits and cross-checked against the actual `Cargo.toml`/`Cargo.lock` diffs.

### Removed (3)

- **`mollusk-svm-security-upgrade.md`** — duplicate of `dependency_refresh.md`. The mollusk-svm `0.11.0 → 0.15.0` and solana-account `^3 → ^4` bumps were made in #167 (the dependency refresh); the commit that added this changeset (#172) did not touch those versions. Its unique details (correct RUSTSEC numbers, jiff/defmt/env_logger/solana-logger/crossbeam-epoch updates) were merged into `dependency_refresh.md`.
- **`pina_cli_termimad_bump.md`** — same-release contradiction with `pina_cli_ux_and_parallel_io.md` (termimad added as a new dep at 0.25, then bumped to 0.34.1 in the same unreleased window). The bump was folded into the UX changeset.
- **`podstring_utf8_soundness.md`** — the unsound `Deref<str>` impls were introduced and removed within the same unreleased window (never shipped; released v0.3.1 has no `PodString`). The soundness guidance was folded into `pod_collections_and_refactor.md`.

### Fixed (1)

- **`dependency_refresh.md`** — corrected a factual error: `RUSTSEC-2026-0204` is the *bincode* advisory (ignored in `deny.toml`, not resolved), not crossbeam-epoch. The resolved advisories are `RUSTSEC-2026-0097` (rand 0.7.3) and `RUSTSEC-2026-0173` (proc-macro-error2).

### Verified

- `mc check` — 0 issues (workspace, changesets, lint suites)
- `mc preview` — dry-run release plan renders cleanly at v0.9.0; removed changesets absent, merged content in the correct sections

Net: 20 → 17 changesets.