### PR TITLE
docs: codify issue title and PR title conventions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,15 +1,15 @@
 name: Bug report
 description: Report a defect or regression in Pina.
-title: "Sentence case summary of the bug"
+title: "Title case summary of the bug"
 labels:
   - bug
 body:
   - type: markdown
     attributes:
       value: |
-        Please write the issue title in **sentence case**.
+        Please write the issue title in **title case**.
 
-        Good: `Account loaders should preserve the borrow guard lifetime`
+        Good: `Account Loaders Should Preserve the Borrow Guard Lifetime`
         Avoid: `fix: account loaders preserve borrow guard lifetime`
   - type: textarea
     id: summary

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,15 +1,15 @@
 name: Feature request
 description: Propose a new feature or workflow improvement for Pina.
-title: "Sentence case summary of the feature"
+title: "Title case summary of the feature"
 labels:
   - enhancement
 body:
   - type: markdown
     attributes:
       value: |
-        Please write the issue title in **sentence case**.
+        Please write the issue title in **title case**.
 
-        Good: `Add Miri coverage for account loader aliasing rules`
+        Good: `Add Miri Coverage for Account Loader Aliasing Rules`
         Avoid: `feat: add miri coverage for account loader aliasing rules`
   - type: textarea
     id: problem

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+<!-- Pull request titles must follow Conventional Commits, e.g. `feat(loaders): preserve borrow guard lifetime`. Prefer using the eventual squash-merge commit title as the PR title. -->
+
 ## Summary
 
 <!-- Describe the change and why it is needed. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,11 @@ Pina is a Rust workspace for building performant, `no_std` Solana programs on to
 - Workspace code must preserve `no_std` compatibility where applicable.
 - `unsafe_code` and `unstable_features` are denied workspace-wide.
 
+## Contribution conventions
+
+- GitHub issue titles must be written in title case (e.g. `Add Miri Coverage for Account Loader Aliasing Rules`). Do not use commit-style prefixes like `fix:` / `feat:` / `docs:` in issue titles.
+- Pull request titles must follow Conventional Commits (e.g. `feat(loaders): preserve borrow guard lifetime`).
+
 ## Common commands
 
 - `devenv shell` — enter the dev environment

--- a/docs/agents/git-workflow.md
+++ b/docs/agents/git-workflow.md
@@ -13,6 +13,6 @@
 - Do not use the `codex/` branch prefix.
 - Commit messages must follow Conventional Commits, for example `fix(loaders): preserve borrow guard lifetime`.
 - Pull request titles must also follow Conventional Commits. Prefer using the eventual squash-merge commit title as the PR title.
-- GitHub issue titles must be written in sentence case. Do not use commit-style prefixes like `fix:` / `feat:` / `docs:` in issue titles.
+- GitHub issue titles must be written in title case. Do not use commit-style prefixes like `fix:` / `feat:` / `docs:` in issue titles.
 - Open a pull request for review before merging.
 - Link pull requests to the relevant issue(s).


### PR DESCRIPTION
## Summary

Codifies the contribution conventions for issue and PR titles across the repo:

- **Issue titles** must be written in **title case** (no conventional commit prefixes like `fix:` / `feat:` / `docs:`)
- **PR titles** must follow **Conventional Commits** (e.g. `feat(loaders): preserve borrow guard lifetime`)

### Changes

- `.github/ISSUE_TEMPLATE/bug_report.yml` — title guidance flipped from sentence case to title case, with updated examples
- `.github/ISSUE_TEMPLATE/feature_request.yml` — same
- `.github/pull_request_template.md` — added a comment noting PR titles must follow Conventional Commits
- `AGENTS.md` — new "Contribution conventions" section documenting both rules
- `docs/agents/git-workflow.md` — issue title rule updated from sentence case to title case (PR rule already present)

Note: `Cargo.toml` has unrelated local modifications (dependency moves/version bumps) that were intentionally left out of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated issue templates and contribution guidance to require title-case issue titles.
  * Added guidance for using Conventional Commit formatting in pull request titles.
  * Clarified recommended squash-merge commit title conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->