### PR TITLE
feat(macros): add typed #[pda] attribute for PDA seeds

### DIFF
--- a/.changeset/typed_pda_seeds.md
+++ b/.changeset/typed_pda_seeds.md
@@ -1,8 +1,8 @@
 ---
-"pina": minor
-"pina_macros": minor
-"pina_cli": minor
-"pina_codama_renderer": minor
+pina: feat
+pina_macros: feat
+pina_cli: feat
+pina_codama_renderer: feat
 ---
 
 feat: add typed `#[pda]` attribute for PDA seed declarations

--- a/.changeset/typed_pda_seeds.md
+++ b/.changeset/typed_pda_seeds.md
@@ -7,16 +7,6 @@
 
 feat: add typed `#[pda]` attribute for PDA seed declarations
 
-Adds a `#[pda(seeds = [...], bump = <field>)]` attribute macro for
-`#[account]` structs, inspired by Quasar's typed seed declarations. The
-macro generates owned seed structs (`XxxSeeds` / `XxxSeedsWithBump`),
-`seeds()` / `as_slices()` / `with_bump()` helpers, `try_find_pda()` /
-`find_pda()` derivation helpers, and `assert_seeds()` stored-bump
-verification when a bump field is declared.
+Adds a `#[pda(seeds = [...], bump = <field>)]` attribute macro for `#[account]` structs, inspired by Quasar's typed seed declarations. The macro generates owned seed structs (`XxxSeeds` / `XxxSeedsWithBump`), `seeds()` / `as_slices()` / `with_bump()` helpers, `try_find_pda()` / `find_pda()` derivation helpers, and `assert_seeds()` stored-bump verification when a bump field is declared.
 
-Supported seed types: `Address`, `u8`, `u16`, `u32`, `u64`, `[u8; N]`,
-and `const &[u8]` references. The CLI parses the attribute for IDL
-generation with accurate seed types (fixing the escrow `u64` seed being
-mis-typed as an address in generated clients), and the renderer emits
-`find_pda` / `create_pda` helpers for linked accounts. All examples now
-use the attribute instead of manual seed macros.
+Supported seed types: `Address`, `u8`, `u16`, `u32`, `u64`, `[u8; N]`, and `const &[u8]` references. The CLI parses the attribute for IDL generation with accurate seed types (fixing the escrow `u64` seed being mis-typed as an address in generated clients), and the renderer emits `find_pda` / `create_pda` helpers for linked accounts. All examples now use the attribute instead of manual seed macros.

--- a/.changeset/typed_pda_seeds.md
+++ b/.changeset/typed_pda_seeds.md
@@ -1,0 +1,22 @@
+---
+"pina": minor
+"pina_macros": minor
+"pina_cli": minor
+"pina_codama_renderer": minor
+---
+
+feat: add typed `#[pda]` attribute for PDA seed declarations
+
+Adds a `#[pda(seeds = [...], bump = <field>)]` attribute macro for
+`#[account]` structs, inspired by Quasar's typed seed declarations. The
+macro generates owned seed structs (`XxxSeeds` / `XxxSeedsWithBump`),
+`seeds()` / `as_slices()` / `with_bump()` helpers, `try_find_pda()` /
+`find_pda()` derivation helpers, and `assert_seeds()` stored-bump
+verification when a bump field is declared.
+
+Supported seed types: `Address`, `u8`, `u16`, `u32`, `u64`, `[u8; N]`,
+and `const &[u8]` references. The CLI parses the attribute for IDL
+generation with accurate seed types (fixing the escrow `u64` seed being
+mis-typed as an address in generated clients), and the renderer emits
+`find_pda` / `create_pda` helpers for linked accounts. All examples now
+use the attribute instead of manual seed macros.

--- a/codama/clients/js/counter_program/src/generated/accounts/counterState.ts
+++ b/codama/clients/js/counter_program/src/generated/accounts/counterState.ts
@@ -31,6 +31,7 @@ import {
 	type MaybeEncodedAccount,
 	type ReadonlyUint8Array,
 } from "@solana/kit";
+import { CounterSeeds, findCounterPda } from "../pdas";
 
 export const COUNTER_STATE_DISCRIMINATOR = 1;
 
@@ -153,4 +154,28 @@ export async function fetchAllMaybeCounterState(
 ): Promise<MaybeAccount<CounterState>[]> {
 	const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
 	return maybeAccounts.map((maybeAccount) => decodeCounterState(maybeAccount));
+}
+
+export async function fetchCounterStateFromSeeds(
+	rpc: Parameters<typeof fetchEncodedAccount>[0],
+	seeds: CounterSeeds,
+	config: FetchAccountConfig & { programAddress?: Address } = {},
+): Promise<Account<CounterState>> {
+	const maybeAccount = await fetchMaybeCounterStateFromSeeds(
+		rpc,
+		seeds,
+		config,
+	);
+	assertAccountExists(maybeAccount);
+	return maybeAccount;
+}
+
+export async function fetchMaybeCounterStateFromSeeds(
+	rpc: Parameters<typeof fetchEncodedAccount>[0],
+	seeds: CounterSeeds,
+	config: FetchAccountConfig & { programAddress?: Address } = {},
+): Promise<MaybeAccount<CounterState>> {
+	const { programAddress, ...fetchConfig } = config;
+	const [address] = await findCounterPda(seeds, { programAddress });
+	return await fetchMaybeCounterState(rpc, address, fetchConfig);
 }

--- a/codama/clients/js/escrow_program/src/generated/accounts/escrowState.ts
+++ b/codama/clients/js/escrow_program/src/generated/accounts/escrowState.ts
@@ -33,6 +33,7 @@ import {
 	type MaybeEncodedAccount,
 	type ReadonlyUint8Array,
 } from "@solana/kit";
+import { EscrowSeeds, findEscrowPda } from "../pdas";
 
 export const ESCROW_STATE_DISCRIMINATOR = 1;
 
@@ -149,4 +150,24 @@ export async function fetchAllMaybeEscrowState(
 ): Promise<MaybeAccount<EscrowState>[]> {
 	const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
 	return maybeAccounts.map((maybeAccount) => decodeEscrowState(maybeAccount));
+}
+
+export async function fetchEscrowStateFromSeeds(
+	rpc: Parameters<typeof fetchEncodedAccount>[0],
+	seeds: EscrowSeeds,
+	config: FetchAccountConfig & { programAddress?: Address } = {},
+): Promise<Account<EscrowState>> {
+	const maybeAccount = await fetchMaybeEscrowStateFromSeeds(rpc, seeds, config);
+	assertAccountExists(maybeAccount);
+	return maybeAccount;
+}
+
+export async function fetchMaybeEscrowStateFromSeeds(
+	rpc: Parameters<typeof fetchEncodedAccount>[0],
+	seeds: EscrowSeeds,
+	config: FetchAccountConfig & { programAddress?: Address } = {},
+): Promise<MaybeAccount<EscrowState>> {
+	const { programAddress, ...fetchConfig } = config;
+	const [address] = await findEscrowPda(seeds, { programAddress });
+	return await fetchMaybeEscrowState(rpc, address, fetchConfig);
 }

--- a/codama/clients/js/escrow_program/src/generated/pdas/escrow.ts
+++ b/codama/clients/js/escrow_program/src/generated/pdas/escrow.ts
@@ -10,13 +10,14 @@ import {
 	type Address,
 	getAddressEncoder,
 	getProgramDerivedAddress,
+	getU64Encoder,
 	getUtf8Encoder,
 	type ProgramDerivedAddress,
 } from "@solana/kit";
 
 export type EscrowSeeds = {
 	maker: Address;
-	seed: Address;
+	seed: number | bigint;
 };
 
 export async function findEscrowPda(
@@ -33,7 +34,7 @@ export async function findEscrowPda(
 		seeds: [
 			getUtf8Encoder().encode("escrow"),
 			getAddressEncoder().encode(seeds.maker),
-			getAddressEncoder().encode(seeds.seed),
+			getU64Encoder().encode(seeds.seed),
 		],
 	});
 }

--- a/codama/clients/js/profile_program/src/generated/accounts/profileState.ts
+++ b/codama/clients/js/profile_program/src/generated/accounts/profileState.ts
@@ -35,6 +35,7 @@ import {
 	type MaybeEncodedAccount,
 	type ReadonlyUint8Array,
 } from "@solana/kit";
+import { findProfilePda, ProfileSeeds } from "../pdas";
 
 export const PROFILE_STATE_DISCRIMINATOR = 1;
 
@@ -170,4 +171,28 @@ export async function fetchAllMaybeProfileState(
 ): Promise<MaybeAccount<ProfileState>[]> {
 	const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
 	return maybeAccounts.map((maybeAccount) => decodeProfileState(maybeAccount));
+}
+
+export async function fetchProfileStateFromSeeds(
+	rpc: Parameters<typeof fetchEncodedAccount>[0],
+	seeds: ProfileSeeds,
+	config: FetchAccountConfig & { programAddress?: Address } = {},
+): Promise<Account<ProfileState>> {
+	const maybeAccount = await fetchMaybeProfileStateFromSeeds(
+		rpc,
+		seeds,
+		config,
+	);
+	assertAccountExists(maybeAccount);
+	return maybeAccount;
+}
+
+export async function fetchMaybeProfileStateFromSeeds(
+	rpc: Parameters<typeof fetchEncodedAccount>[0],
+	seeds: ProfileSeeds,
+	config: FetchAccountConfig & { programAddress?: Address } = {},
+): Promise<MaybeAccount<ProfileState>> {
+	const { programAddress, ...fetchConfig } = config;
+	const [address] = await findProfilePda(seeds, { programAddress });
+	return await fetchMaybeProfileState(rpc, address, fetchConfig);
 }

--- a/codama/clients/js/role_registry_program/src/generated/accounts/registryConfig.ts
+++ b/codama/clients/js/role_registry_program/src/generated/accounts/registryConfig.ts
@@ -33,6 +33,7 @@ import {
 	type MaybeEncodedAccount,
 	type ReadonlyUint8Array,
 } from "@solana/kit";
+import { findRegistryConfigPda, RegistryConfigSeeds } from "../pdas";
 
 export const REGISTRY_CONFIG_DISCRIMINATOR = 1;
 
@@ -137,4 +138,28 @@ export async function fetchAllMaybeRegistryConfig(
 	return maybeAccounts.map((maybeAccount) =>
 		decodeRegistryConfig(maybeAccount)
 	);
+}
+
+export async function fetchRegistryConfigFromSeeds(
+	rpc: Parameters<typeof fetchEncodedAccount>[0],
+	seeds: RegistryConfigSeeds,
+	config: FetchAccountConfig & { programAddress?: Address } = {},
+): Promise<Account<RegistryConfig>> {
+	const maybeAccount = await fetchMaybeRegistryConfigFromSeeds(
+		rpc,
+		seeds,
+		config,
+	);
+	assertAccountExists(maybeAccount);
+	return maybeAccount;
+}
+
+export async function fetchMaybeRegistryConfigFromSeeds(
+	rpc: Parameters<typeof fetchEncodedAccount>[0],
+	seeds: RegistryConfigSeeds,
+	config: FetchAccountConfig & { programAddress?: Address } = {},
+): Promise<MaybeAccount<RegistryConfig>> {
+	const { programAddress, ...fetchConfig } = config;
+	const [address] = await findRegistryConfigPda(seeds, { programAddress });
+	return await fetchMaybeRegistryConfig(rpc, address, fetchConfig);
 }

--- a/codama/clients/js/role_registry_program/src/generated/accounts/roleEntry.ts
+++ b/codama/clients/js/role_registry_program/src/generated/accounts/roleEntry.ts
@@ -35,6 +35,7 @@ import {
 	type MaybeEncodedAccount,
 	type ReadonlyUint8Array,
 } from "@solana/kit";
+import { findRoleEntryPda, RoleEntrySeeds } from "../pdas";
 
 export const ROLE_ENTRY_DISCRIMINATOR = 2;
 
@@ -140,4 +141,24 @@ export async function fetchAllMaybeRoleEntry(
 ): Promise<MaybeAccount<RoleEntry>[]> {
 	const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
 	return maybeAccounts.map((maybeAccount) => decodeRoleEntry(maybeAccount));
+}
+
+export async function fetchRoleEntryFromSeeds(
+	rpc: Parameters<typeof fetchEncodedAccount>[0],
+	seeds: RoleEntrySeeds,
+	config: FetchAccountConfig & { programAddress?: Address } = {},
+): Promise<Account<RoleEntry>> {
+	const maybeAccount = await fetchMaybeRoleEntryFromSeeds(rpc, seeds, config);
+	assertAccountExists(maybeAccount);
+	return maybeAccount;
+}
+
+export async function fetchMaybeRoleEntryFromSeeds(
+	rpc: Parameters<typeof fetchEncodedAccount>[0],
+	seeds: RoleEntrySeeds,
+	config: FetchAccountConfig & { programAddress?: Address } = {},
+): Promise<MaybeAccount<RoleEntry>> {
+	const { programAddress, ...fetchConfig } = config;
+	const [address] = await findRoleEntryPda(seeds, { programAddress });
+	return await fetchMaybeRoleEntry(rpc, address, fetchConfig);
 }

--- a/codama/clients/js/role_registry_program/src/generated/pdas/roleEntry.ts
+++ b/codama/clients/js/role_registry_program/src/generated/pdas/roleEntry.ts
@@ -10,13 +10,14 @@ import {
 	type Address,
 	getAddressEncoder,
 	getProgramDerivedAddress,
+	getU64Encoder,
 	getUtf8Encoder,
 	type ProgramDerivedAddress,
 } from "@solana/kit";
 
 export type RoleEntrySeeds = {
 	registry: Address;
-	roleId: Address;
+	roleId: number | bigint;
 };
 
 export async function findRoleEntryPda(
@@ -33,7 +34,7 @@ export async function findRoleEntryPda(
 		seeds: [
 			getUtf8Encoder().encode("role-entry"),
 			getAddressEncoder().encode(seeds.registry),
-			getAddressEncoder().encode(seeds.roleId),
+			getU64Encoder().encode(seeds.roleId),
 		],
 	});
 }

--- a/codama/clients/js/staking_rewards_program/src/generated/accounts/poolState.ts
+++ b/codama/clients/js/staking_rewards_program/src/generated/accounts/poolState.ts
@@ -35,6 +35,7 @@ import {
 	type MaybeEncodedAccount,
 	type ReadonlyUint8Array,
 } from "@solana/kit";
+import { findPoolPda, PoolSeeds } from "../pdas";
 
 export const POOL_STATE_DISCRIMINATOR = 1;
 
@@ -144,4 +145,24 @@ export async function fetchAllMaybePoolState(
 ): Promise<MaybeAccount<PoolState>[]> {
 	const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
 	return maybeAccounts.map((maybeAccount) => decodePoolState(maybeAccount));
+}
+
+export async function fetchPoolStateFromSeeds(
+	rpc: Parameters<typeof fetchEncodedAccount>[0],
+	seeds: PoolSeeds,
+	config: FetchAccountConfig & { programAddress?: Address } = {},
+): Promise<Account<PoolState>> {
+	const maybeAccount = await fetchMaybePoolStateFromSeeds(rpc, seeds, config);
+	assertAccountExists(maybeAccount);
+	return maybeAccount;
+}
+
+export async function fetchMaybePoolStateFromSeeds(
+	rpc: Parameters<typeof fetchEncodedAccount>[0],
+	seeds: PoolSeeds,
+	config: FetchAccountConfig & { programAddress?: Address } = {},
+): Promise<MaybeAccount<PoolState>> {
+	const { programAddress, ...fetchConfig } = config;
+	const [address] = await findPoolPda(seeds, { programAddress });
+	return await fetchMaybePoolState(rpc, address, fetchConfig);
 }

--- a/codama/clients/js/staking_rewards_program/src/generated/accounts/positionState.ts
+++ b/codama/clients/js/staking_rewards_program/src/generated/accounts/positionState.ts
@@ -33,6 +33,7 @@ import {
 	type MaybeEncodedAccount,
 	type ReadonlyUint8Array,
 } from "@solana/kit";
+import { findPositionPda, PositionSeeds } from "../pdas";
 
 export const POSITION_STATE_DISCRIMINATOR = 2;
 
@@ -145,4 +146,28 @@ export async function fetchAllMaybePositionState(
 ): Promise<MaybeAccount<PositionState>[]> {
 	const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
 	return maybeAccounts.map((maybeAccount) => decodePositionState(maybeAccount));
+}
+
+export async function fetchPositionStateFromSeeds(
+	rpc: Parameters<typeof fetchEncodedAccount>[0],
+	seeds: PositionSeeds,
+	config: FetchAccountConfig & { programAddress?: Address } = {},
+): Promise<Account<PositionState>> {
+	const maybeAccount = await fetchMaybePositionStateFromSeeds(
+		rpc,
+		seeds,
+		config,
+	);
+	assertAccountExists(maybeAccount);
+	return maybeAccount;
+}
+
+export async function fetchMaybePositionStateFromSeeds(
+	rpc: Parameters<typeof fetchEncodedAccount>[0],
+	seeds: PositionSeeds,
+	config: FetchAccountConfig & { programAddress?: Address } = {},
+): Promise<MaybeAccount<PositionState>> {
+	const { programAddress, ...fetchConfig } = config;
+	const [address] = await findPositionPda(seeds, { programAddress });
+	return await fetchMaybePositionState(rpc, address, fetchConfig);
 }

--- a/codama/clients/js/todo_program/src/generated/accounts/todoState.ts
+++ b/codama/clients/js/todo_program/src/generated/accounts/todoState.ts
@@ -37,6 +37,7 @@ import {
 	type MaybeEncodedAccount,
 	type ReadonlyUint8Array,
 } from "@solana/kit";
+import { findTodoPda, TodoSeeds } from "../pdas";
 
 export const TODO_STATE_DISCRIMINATOR = 1;
 
@@ -129,4 +130,24 @@ export async function fetchAllMaybeTodoState(
 ): Promise<MaybeAccount<TodoState>[]> {
 	const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
 	return maybeAccounts.map((maybeAccount) => decodeTodoState(maybeAccount));
+}
+
+export async function fetchTodoStateFromSeeds(
+	rpc: Parameters<typeof fetchEncodedAccount>[0],
+	seeds: TodoSeeds,
+	config: FetchAccountConfig & { programAddress?: Address } = {},
+): Promise<Account<TodoState>> {
+	const maybeAccount = await fetchMaybeTodoStateFromSeeds(rpc, seeds, config);
+	assertAccountExists(maybeAccount);
+	return maybeAccount;
+}
+
+export async function fetchMaybeTodoStateFromSeeds(
+	rpc: Parameters<typeof fetchEncodedAccount>[0],
+	seeds: TodoSeeds,
+	config: FetchAccountConfig & { programAddress?: Address } = {},
+): Promise<MaybeAccount<TodoState>> {
+	const { programAddress, ...fetchConfig } = config;
+	const [address] = await findTodoPda(seeds, { programAddress });
+	return await fetchMaybeTodoState(rpc, address, fetchConfig);
 }

--- a/codama/clients/js/vesting_program/src/generated/accounts/vestingState.ts
+++ b/codama/clients/js/vesting_program/src/generated/accounts/vestingState.ts
@@ -35,6 +35,7 @@ import {
 	type MaybeEncodedAccount,
 	type ReadonlyUint8Array,
 } from "@solana/kit";
+import { findVestingPda, VestingSeeds } from "../pdas";
 
 export const VESTING_STATE_DISCRIMINATOR = 1;
 
@@ -159,4 +160,28 @@ export async function fetchAllMaybeVestingState(
 ): Promise<MaybeAccount<VestingState>[]> {
 	const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
 	return maybeAccounts.map((maybeAccount) => decodeVestingState(maybeAccount));
+}
+
+export async function fetchVestingStateFromSeeds(
+	rpc: Parameters<typeof fetchEncodedAccount>[0],
+	seeds: VestingSeeds,
+	config: FetchAccountConfig & { programAddress?: Address } = {},
+): Promise<Account<VestingState>> {
+	const maybeAccount = await fetchMaybeVestingStateFromSeeds(
+		rpc,
+		seeds,
+		config,
+	);
+	assertAccountExists(maybeAccount);
+	return maybeAccount;
+}
+
+export async function fetchMaybeVestingStateFromSeeds(
+	rpc: Parameters<typeof fetchEncodedAccount>[0],
+	seeds: VestingSeeds,
+	config: FetchAccountConfig & { programAddress?: Address } = {},
+): Promise<MaybeAccount<VestingState>> {
+	const { programAddress, ...fetchConfig } = config;
+	const [address] = await findVestingPda(seeds, { programAddress });
+	return await fetchMaybeVestingState(rpc, address, fetchConfig);
 }

--- a/codama/clients/rust/counter_program/src/generated/accounts/counter_state.rs
+++ b/codama/clients/rust/counter_program/src/generated/accounts/counter_state.rs
@@ -83,3 +83,22 @@ impl<'a> TryFrom<&solana_account_info::AccountInfo<'a>> for CounterState {
 		Ok(*account)
 	}
 }
+
+impl CounterState {
+	pub fn find_pda(authority: &solana_pubkey::Pubkey) -> (solana_pubkey::Pubkey, u8) {
+		solana_pubkey::Pubkey::find_program_address(
+			&["counter".as_bytes(), authority.as_ref()],
+			&crate::COUNTER_PROGRAM_ID,
+		)
+	}
+
+	pub fn create_pda(
+		authority: &solana_pubkey::Pubkey,
+		bump: u8,
+	) -> Result<solana_pubkey::Pubkey, solana_pubkey::PubkeyError> {
+		solana_pubkey::Pubkey::create_program_address(
+			&["counter".as_bytes(), authority.as_ref(), &[bump]],
+			&crate::COUNTER_PROGRAM_ID,
+		)
+	}
+}

--- a/codama/clients/rust/escrow_program/src/generated/accounts/escrow_state.rs
+++ b/codama/clients/rust/escrow_program/src/generated/accounts/escrow_state.rs
@@ -82,3 +82,28 @@ impl<'a> TryFrom<&solana_account_info::AccountInfo<'a>> for EscrowState {
 		Ok(*account)
 	}
 }
+
+impl EscrowState {
+	pub fn find_pda(maker: &solana_pubkey::Pubkey, seed: u64) -> (solana_pubkey::Pubkey, u8) {
+		solana_pubkey::Pubkey::find_program_address(
+			&["escrow".as_bytes(), maker.as_ref(), &seed.to_le_bytes()],
+			&crate::ESCROW_PROGRAM_ID,
+		)
+	}
+
+	pub fn create_pda(
+		maker: &solana_pubkey::Pubkey,
+		seed: u64,
+		bump: u8,
+	) -> Result<solana_pubkey::Pubkey, solana_pubkey::PubkeyError> {
+		solana_pubkey::Pubkey::create_program_address(
+			&[
+				"escrow".as_bytes(),
+				maker.as_ref(),
+				&seed.to_le_bytes(),
+				&[bump],
+			],
+			&crate::ESCROW_PROGRAM_ID,
+		)
+	}
+}

--- a/codama/clients/rust/profile_program/src/generated/accounts/profile_state.rs
+++ b/codama/clients/rust/profile_program/src/generated/accounts/profile_state.rs
@@ -103,3 +103,22 @@ impl<'a> TryFrom<&solana_account_info::AccountInfo<'a>> for ProfileState {
 		Ok(*account)
 	}
 }
+
+impl ProfileState {
+	pub fn find_pda(authority: &solana_pubkey::Pubkey) -> (solana_pubkey::Pubkey, u8) {
+		solana_pubkey::Pubkey::find_program_address(
+			&["profile".as_bytes(), authority.as_ref()],
+			&crate::PROFILE_PROGRAM_ID,
+		)
+	}
+
+	pub fn create_pda(
+		authority: &solana_pubkey::Pubkey,
+		bump: u8,
+	) -> Result<solana_pubkey::Pubkey, solana_pubkey::PubkeyError> {
+		solana_pubkey::Pubkey::create_program_address(
+			&["profile".as_bytes(), authority.as_ref(), &[bump]],
+			&crate::PROFILE_PROGRAM_ID,
+		)
+	}
+}

--- a/codama/clients/rust/role_registry_program/src/generated/accounts/registry_config.rs
+++ b/codama/clients/rust/role_registry_program/src/generated/accounts/registry_config.rs
@@ -68,3 +68,22 @@ impl<'a> TryFrom<&solana_account_info::AccountInfo<'a>> for RegistryConfig {
 		Ok(*account)
 	}
 }
+
+impl RegistryConfig {
+	pub fn find_pda(admin: &solana_pubkey::Pubkey) -> (solana_pubkey::Pubkey, u8) {
+		solana_pubkey::Pubkey::find_program_address(
+			&["registry".as_bytes(), admin.as_ref()],
+			&crate::ROLE_REGISTRY_PROGRAM_ID,
+		)
+	}
+
+	pub fn create_pda(
+		admin: &solana_pubkey::Pubkey,
+		bump: u8,
+	) -> Result<solana_pubkey::Pubkey, solana_pubkey::PubkeyError> {
+		solana_pubkey::Pubkey::create_program_address(
+			&["registry".as_bytes(), admin.as_ref(), &[bump]],
+			&crate::ROLE_REGISTRY_PROGRAM_ID,
+		)
+	}
+}

--- a/codama/clients/rust/role_registry_program/src/generated/accounts/role_entry.rs
+++ b/codama/clients/rust/role_registry_program/src/generated/accounts/role_entry.rs
@@ -77,3 +77,32 @@ impl<'a> TryFrom<&solana_account_info::AccountInfo<'a>> for RoleEntry {
 		Ok(*account)
 	}
 }
+
+impl RoleEntry {
+	pub fn find_pda(registry: &solana_pubkey::Pubkey, role_id: u64) -> (solana_pubkey::Pubkey, u8) {
+		solana_pubkey::Pubkey::find_program_address(
+			&[
+				"role-entry".as_bytes(),
+				registry.as_ref(),
+				&role_id.to_le_bytes(),
+			],
+			&crate::ROLE_REGISTRY_PROGRAM_ID,
+		)
+	}
+
+	pub fn create_pda(
+		registry: &solana_pubkey::Pubkey,
+		role_id: u64,
+		bump: u8,
+	) -> Result<solana_pubkey::Pubkey, solana_pubkey::PubkeyError> {
+		solana_pubkey::Pubkey::create_program_address(
+			&[
+				"role-entry".as_bytes(),
+				registry.as_ref(),
+				&role_id.to_le_bytes(),
+				&[bump],
+			],
+			&crate::ROLE_REGISTRY_PROGRAM_ID,
+		)
+	}
+}

--- a/codama/clients/rust/staking_rewards_program/src/generated/accounts/pool_state.rs
+++ b/codama/clients/rust/staking_rewards_program/src/generated/accounts/pool_state.rs
@@ -80,3 +80,31 @@ impl<'a> TryFrom<&solana_account_info::AccountInfo<'a>> for PoolState {
 		Ok(*account)
 	}
 }
+
+impl PoolState {
+	pub fn find_pda(
+		stake_mint: &solana_pubkey::Pubkey,
+		reward_mint: &solana_pubkey::Pubkey,
+	) -> (solana_pubkey::Pubkey, u8) {
+		solana_pubkey::Pubkey::find_program_address(
+			&["pool".as_bytes(), stake_mint.as_ref(), reward_mint.as_ref()],
+			&crate::STAKING_REWARDS_PROGRAM_ID,
+		)
+	}
+
+	pub fn create_pda(
+		stake_mint: &solana_pubkey::Pubkey,
+		reward_mint: &solana_pubkey::Pubkey,
+		bump: u8,
+	) -> Result<solana_pubkey::Pubkey, solana_pubkey::PubkeyError> {
+		solana_pubkey::Pubkey::create_program_address(
+			&[
+				"pool".as_bytes(),
+				stake_mint.as_ref(),
+				reward_mint.as_ref(),
+				&[bump],
+			],
+			&crate::STAKING_REWARDS_PROGRAM_ID,
+		)
+	}
+}

--- a/codama/clients/rust/staking_rewards_program/src/generated/accounts/position_state.rs
+++ b/codama/clients/rust/staking_rewards_program/src/generated/accounts/position_state.rs
@@ -77,3 +77,31 @@ impl<'a> TryFrom<&solana_account_info::AccountInfo<'a>> for PositionState {
 		Ok(*account)
 	}
 }
+
+impl PositionState {
+	pub fn find_pda(
+		pool: &solana_pubkey::Pubkey,
+		owner: &solana_pubkey::Pubkey,
+	) -> (solana_pubkey::Pubkey, u8) {
+		solana_pubkey::Pubkey::find_program_address(
+			&["position".as_bytes(), pool.as_ref(), owner.as_ref()],
+			&crate::STAKING_REWARDS_PROGRAM_ID,
+		)
+	}
+
+	pub fn create_pda(
+		pool: &solana_pubkey::Pubkey,
+		owner: &solana_pubkey::Pubkey,
+		bump: u8,
+	) -> Result<solana_pubkey::Pubkey, solana_pubkey::PubkeyError> {
+		solana_pubkey::Pubkey::create_program_address(
+			&[
+				"position".as_bytes(),
+				pool.as_ref(),
+				owner.as_ref(),
+				&[bump],
+			],
+			&crate::STAKING_REWARDS_PROGRAM_ID,
+		)
+	}
+}

--- a/codama/clients/rust/todo_program/src/generated/accounts/todo_state.rs
+++ b/codama/clients/rust/todo_program/src/generated/accounts/todo_state.rs
@@ -71,3 +71,22 @@ impl<'a> TryFrom<&solana_account_info::AccountInfo<'a>> for TodoState {
 		Ok(*account)
 	}
 }
+
+impl TodoState {
+	pub fn find_pda(owner: &solana_pubkey::Pubkey) -> (solana_pubkey::Pubkey, u8) {
+		solana_pubkey::Pubkey::find_program_address(
+			&["todo".as_bytes(), owner.as_ref()],
+			&crate::TODO_PROGRAM_ID,
+		)
+	}
+
+	pub fn create_pda(
+		owner: &solana_pubkey::Pubkey,
+		bump: u8,
+	) -> Result<solana_pubkey::Pubkey, solana_pubkey::PubkeyError> {
+		solana_pubkey::Pubkey::create_program_address(
+			&["todo".as_bytes(), owner.as_ref(), &[bump]],
+			&crate::TODO_PROGRAM_ID,
+		)
+	}
+}

--- a/codama/clients/rust/vesting_program/src/generated/accounts/vesting_state.rs
+++ b/codama/clients/rust/vesting_program/src/generated/accounts/vesting_state.rs
@@ -89,3 +89,39 @@ impl<'a> TryFrom<&solana_account_info::AccountInfo<'a>> for VestingState {
 		Ok(*account)
 	}
 }
+
+impl VestingState {
+	pub fn find_pda(
+		admin: &solana_pubkey::Pubkey,
+		beneficiary: &solana_pubkey::Pubkey,
+		mint: &solana_pubkey::Pubkey,
+	) -> (solana_pubkey::Pubkey, u8) {
+		solana_pubkey::Pubkey::find_program_address(
+			&[
+				"vesting".as_bytes(),
+				admin.as_ref(),
+				beneficiary.as_ref(),
+				mint.as_ref(),
+			],
+			&crate::VESTING_PROGRAM_ID,
+		)
+	}
+
+	pub fn create_pda(
+		admin: &solana_pubkey::Pubkey,
+		beneficiary: &solana_pubkey::Pubkey,
+		mint: &solana_pubkey::Pubkey,
+		bump: u8,
+	) -> Result<solana_pubkey::Pubkey, solana_pubkey::PubkeyError> {
+		solana_pubkey::Pubkey::create_program_address(
+			&[
+				"vesting".as_bytes(),
+				admin.as_ref(),
+				beneficiary.as_ref(),
+				mint.as_ref(),
+				&[bump],
+			],
+			&crate::VESTING_PROGRAM_ID,
+		)
+	}
+}

--- a/codama/idls/counter_program.json
+++ b/codama/idls/counter_program.json
@@ -61,6 +61,10 @@
 						}
 					]
 				},
+				"pda": {
+					"kind": "pdaLinkNode",
+					"name": "counter"
+				},
 				"discriminators": [
 					{
 						"kind": "constantDiscriminatorNode",

--- a/codama/idls/escrow_program.json
+++ b/codama/idls/escrow_program.json
@@ -79,6 +79,10 @@
 						}
 					]
 				},
+				"pda": {
+					"kind": "pdaLinkNode",
+					"name": "escrow"
+				},
 				"discriminators": [
 					{
 						"kind": "constantDiscriminatorNode",
@@ -355,7 +359,9 @@
 						"kind": "variablePdaSeedNode",
 						"name": "seed",
 						"type": {
-							"kind": "publicKeyTypeNode"
+							"kind": "numberTypeNode",
+							"format": "u64",
+							"endian": "le"
 						}
 					}
 				]

--- a/codama/idls/profile_program.json
+++ b/codama/idls/profile_program.json
@@ -111,6 +111,10 @@
 						}
 					]
 				},
+				"pda": {
+					"kind": "pdaLinkNode",
+					"name": "profile"
+				},
 				"discriminators": [
 					{
 						"kind": "constantDiscriminatorNode",

--- a/codama/idls/role_registry_program.json
+++ b/codama/idls/role_registry_program.json
@@ -41,6 +41,10 @@
 						}
 					]
 				},
+				"pda": {
+					"kind": "pdaLinkNode",
+					"name": "registryConfig"
+				},
 				"discriminators": [
 					{
 						"kind": "constantDiscriminatorNode",
@@ -120,6 +124,10 @@
 							}
 						}
 					]
+				},
+				"pda": {
+					"kind": "pdaLinkNode",
+					"name": "roleEntry"
 				},
 				"discriminators": [
 					{
@@ -509,7 +517,9 @@
 						"kind": "variablePdaSeedNode",
 						"name": "roleId",
 						"type": {
-							"kind": "publicKeyTypeNode"
+							"kind": "numberTypeNode",
+							"format": "u64",
+							"endian": "le"
 						}
 					}
 				]

--- a/codama/idls/staking_rewards_program.json
+++ b/codama/idls/staking_rewards_program.json
@@ -76,6 +76,10 @@
 						}
 					]
 				},
+				"pda": {
+					"kind": "pdaLinkNode",
+					"name": "pool"
+				},
 				"discriminators": [
 					{
 						"kind": "constantDiscriminatorNode",
@@ -152,6 +156,10 @@
 							}
 						}
 					]
+				},
+				"pda": {
+					"kind": "pdaLinkNode",
+					"name": "position"
 				},
 				"discriminators": [
 					{

--- a/codama/idls/todo_program.json
+++ b/codama/idls/todo_program.json
@@ -55,6 +55,10 @@
 						}
 					]
 				},
+				"pda": {
+					"kind": "pdaLinkNode",
+					"name": "todo"
+				},
 				"discriminators": [
 					{
 						"kind": "constantDiscriminatorNode",

--- a/codama/idls/vesting_program.json
+++ b/codama/idls/vesting_program.json
@@ -103,6 +103,10 @@
 						}
 					]
 				},
+				"pda": {
+					"kind": "pdaLinkNode",
+					"name": "vesting"
+				},
 				"discriminators": [
 					{
 						"kind": "constantDiscriminatorNode",

--- a/crates/pina/tests/pda_macro.rs
+++ b/crates/pina/tests/pda_macro.rs
@@ -1,0 +1,631 @@
+//! Integration tests for the `#[pda(...)]` attribute macro.
+//!
+//! These tests exercise the generated seed structs, derivation helpers, and
+//! the stored-bump verification method against real `AccountView` instances
+//! built from SVM-format input buffers.
+
+#![allow(unsafe_code, dead_code)]
+
+use core::alloc::Layout;
+use core::mem::MaybeUninit;
+use core::mem::size_of;
+use core::ptr::copy_nonoverlapping;
+use std::alloc::alloc;
+use std::alloc::dealloc;
+use std::vec;
+use std::vec::Vec;
+
+use pina::*;
+use pinocchio::account::MAX_PERMITTED_DATA_INCREASE;
+
+// ---------------------------------------------------------------------------
+// Test program definitions
+// ---------------------------------------------------------------------------
+
+const TEST_PROGRAM_ID: Address = address!("GJQcuWrT2f3f4KNuJcXhhwUa1ZQTYbxzzJ1hotzKu8hS");
+
+/// Create a unique `Address` for tests (avoids the `atomic` feature).
+fn unique_address(counter: u64) -> Address {
+	let mut bytes = [0u8; 32];
+	bytes[..8].copy_from_slice(&counter.to_le_bytes());
+	Address::new_from_array(bytes)
+}
+
+/// Account discriminator for the test program.
+#[discriminator(crate = ::pina)]
+pub enum TestAccountType {
+	TestState = 1,
+	CounterState = 2,
+}
+
+/// On-chain state exercising every supported seed type.
+///
+/// Layout (58 bytes total):
+/// | offset | size | field         |
+/// |--------|------|---------------|
+/// | 0      | 1    | discriminator |
+/// | 1      | 32   | authority     |
+/// | 33     | 8    | amount        |
+/// | 41     | 1    | side          |
+/// | 42     | 8    | tag           |
+/// | 50     | 2    | width         |
+/// | 52     | 4    | height        |
+/// | 56     | 1    | bump          |
+/// | 57     | 1    | padding       |
+#[account(crate = ::pina, discriminator = TestAccountType)]
+#[pda(
+	crate = ::pina,
+	seeds = [
+		b"test",
+		authority: Address,
+		amount: u64,
+		side: u8,
+		tag: [u8; 8],
+		width: u16,
+		height: u32,
+	],
+	bump = bump,
+)]
+pub struct TestState {
+	pub authority: Address,
+	pub amount: PodU64,
+	pub side: u8,
+	pub tag: [u8; 8],
+	pub width: PodU16,
+	pub height: PodU32,
+	pub bump: u8,
+	pub _padding: u8,
+}
+
+/// A simple account with a single `Address` seed (mirrors `counter_program`).
+#[account(crate = ::pina, discriminator = TestAccountType, variant = CounterState)]
+#[pda(crate = ::pina, seeds = [b"counter", authority: Address], bump = bump)]
+pub struct CounterState {
+	pub authority: Address,
+	pub bump: u8,
+}
+
+// ---------------------------------------------------------------------------
+// Seed struct and derivation tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn seeds_as_slices_matches_manual_seed_bytes() {
+	let authority = unique_address(1);
+	let seeds = TestState::seeds(&authority, 42, 1, [0xAB; 8], 7, 99);
+
+	let slices = seeds.as_slices();
+	assert_eq!(slices.len(), 7);
+	assert_eq!(slices[0], b"test");
+	assert_eq!(slices[1], authority.as_ref());
+	assert_eq!(slices[2], &42u64.to_le_bytes());
+	assert_eq!(slices[3], &[1u8]);
+	assert_eq!(slices[4], &[0xAB; 8]);
+	assert_eq!(slices[5], &7u16.to_le_bytes());
+	assert_eq!(slices[6], &99u32.to_le_bytes());
+}
+
+#[test]
+fn seeds_with_bump_appends_bump_seed() {
+	let authority = unique_address(2);
+	let seeds = TestState::seeds(&authority, 42, 1, [0xAB; 8], 7, 99).with_bump(5);
+
+	let slices = seeds.as_slices();
+	assert_eq!(slices.len(), 8);
+	assert_eq!(slices[0], b"test");
+	assert_eq!(slices[1], authority.as_ref());
+	assert_eq!(slices[2], &42u64.to_le_bytes());
+	assert_eq!(slices[3], &[1u8]);
+	assert_eq!(slices[4], &[0xAB; 8]);
+	assert_eq!(slices[5], &7u16.to_le_bytes());
+	assert_eq!(slices[6], &99u32.to_le_bytes());
+	assert_eq!(slices[7], &[5u8]);
+}
+
+#[test]
+fn seeds_with_bump_keeps_seed_order() {
+	let authority = unique_address(3);
+	let seeds = TestState::seeds(&authority, 42, 1, [0xAB; 8], 7, 99);
+	let with_bump = seeds.with_bump(5);
+	let slices = with_bump.as_slices();
+
+	assert_eq!(slices.len(), 8);
+	assert_eq!(
+		slices[..7],
+		[
+			b"test",
+			authority.as_ref(),
+			&42u64.to_le_bytes(),
+			&[1u8],
+			&[0xAB; 8],
+			&7u16.to_le_bytes(),
+			&99u32.to_le_bytes(),
+		],
+		"the bump must be appended, not inserted"
+	);
+	assert_eq!(slices[7], &[5u8]);
+}
+
+#[test]
+fn try_find_pda_matches_manual_derivation() {
+	let authority = unique_address(4);
+	let manual_seeds: &[&[u8]] = &[
+		b"test",
+		authority.as_ref(),
+		&42u64.to_le_bytes(),
+		&[1u8],
+		&[0xAB; 8],
+		&7u16.to_le_bytes(),
+		&99u32.to_le_bytes(),
+	];
+
+	let expected = try_find_program_address(manual_seeds, &TEST_PROGRAM_ID)
+		.unwrap_or_else(|| panic!("expected to derive a PDA"));
+	let actual = TestState::try_find_pda(&authority, 42, 1, [0xAB; 8], 7, 99, &TEST_PROGRAM_ID)
+		.unwrap_or_else(|| panic!("expected to derive a PDA"));
+
+	assert_eq!(
+		actual, expected,
+		"generated derivation must match manual derivation"
+	);
+}
+
+#[test]
+fn find_pda_matches_try_find_pda() {
+	let authority = unique_address(5);
+	let (expected, _) =
+		TestState::try_find_pda(&authority, 42, 1, [0xAB; 8], 7, 99, &TEST_PROGRAM_ID)
+			.unwrap_or_else(|| panic!("expected to derive a PDA"));
+
+	let (actual, _bump) =
+		TestState::find_pda(&authority, 42, 1, [0xAB; 8], 7, 99, &TEST_PROGRAM_ID);
+	assert_eq!(actual, expected);
+}
+
+#[test]
+fn try_find_pda_is_deterministic() {
+	let authority = unique_address(6);
+	let first = TestState::try_find_pda(&authority, 42, 1, [0xAB; 8], 7, 99, &TEST_PROGRAM_ID)
+		.unwrap_or_else(|| panic!("expected to derive a PDA"));
+	let second = TestState::try_find_pda(&authority, 42, 1, [0xAB; 8], 7, 99, &TEST_PROGRAM_ID)
+		.unwrap_or_else(|| panic!("expected to derive a PDA"));
+
+	assert_eq!(first, second);
+}
+
+#[test]
+fn try_find_pda_differs_across_seed_values() {
+	let authority = unique_address(7);
+	let first = TestState::try_find_pda(&authority, 42, 1, [0xAB; 8], 7, 99, &TEST_PROGRAM_ID)
+		.unwrap_or_else(|| panic!("expected to derive a PDA"));
+	let second = TestState::try_find_pda(&authority, 43, 1, [0xAB; 8], 7, 99, &TEST_PROGRAM_ID)
+		.unwrap_or_else(|| panic!("expected to derive a PDA"));
+
+	assert_ne!(
+		first, second,
+		"different seed values must produce different PDAs"
+	);
+}
+
+#[test]
+fn counter_seeds_single_address_seed() {
+	let authority = unique_address(8);
+	let seeds = CounterState::seeds(&authority);
+
+	let slices = seeds.as_slices();
+	assert_eq!(slices.len(), 2);
+	assert_eq!(slices[0], b"counter");
+	assert_eq!(slices[1], authority.as_ref());
+
+	let with_bump = seeds.with_bump(9);
+	assert_eq!(with_bump.as_slices().len(), 3);
+	assert_eq!(with_bump.as_slices()[2], &[9u8]);
+}
+
+#[test]
+fn counter_try_find_pda_matches_manual_derivation() {
+	let authority = unique_address(9);
+	let expected = try_find_program_address(&[b"counter", authority.as_ref()], &TEST_PROGRAM_ID)
+		.unwrap_or_else(|| panic!("expected to derive a PDA"));
+	let actual = CounterState::try_find_pda(&authority, &TEST_PROGRAM_ID)
+		.unwrap_or_else(|| panic!("expected to derive a PDA"));
+
+	assert_eq!(actual, expected);
+}
+
+// ---------------------------------------------------------------------------
+// Stored-bump verification tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn assert_seeds_accepts_correct_account() {
+	let authority = unique_address(10);
+	let (pda, bump) = TestState::find_pda(&authority, 42, 1, [0xAB; 8], 7, 99, &TEST_PROGRAM_ID);
+	let _ = bump;
+
+	let state = TestState::builder()
+		.authority(authority)
+		.amount(PodU64::from_primitive(42))
+		.side(1)
+		.tag([0xAB; 8])
+		.width(PodU16::from_primitive(7))
+		.height(PodU32::from_primitive(99))
+		.bump(bump)
+		._padding(0)
+		.build();
+
+	let test_account = build_account_view(pda, bytemuck::bytes_of(&state));
+	let account = test_account.view;
+	let result = TestState::assert_seeds(
+		&account,
+		&authority,
+		42,
+		1,
+		[0xAB; 8],
+		7,
+		99,
+		&TEST_PROGRAM_ID,
+	);
+
+	assert!(
+		result.is_ok(),
+		"expected assert_seeds to accept the correct account: {result:?}"
+	);
+}
+
+#[test]
+fn assert_seeds_rejects_wrong_address() {
+	let authority = unique_address(11);
+	let (pda, bump) = TestState::find_pda(&authority, 42, 1, [0xAB; 8], 7, 99, &TEST_PROGRAM_ID);
+	let _ = bump;
+
+	let state = TestState::builder()
+		.authority(authority)
+		.amount(PodU64::from_primitive(42))
+		.side(1)
+		.tag([0xAB; 8])
+		.width(PodU16::from_primitive(7))
+		.height(PodU32::from_primitive(99))
+		.bump(bump)
+		._padding(0)
+		.build();
+
+	// Same data, but at a different address.
+	let wrong_address = unique_address(12);
+	let test_account = build_account_view(wrong_address, bytemuck::bytes_of(&state));
+	let account = test_account.view;
+	let result = TestState::assert_seeds(
+		&account,
+		&authority,
+		42,
+		1,
+		[0xAB; 8],
+		7,
+		99,
+		&TEST_PROGRAM_ID,
+	);
+
+	assert!(
+		result.is_err(),
+		"expected assert_seeds to reject a wrong address"
+	);
+}
+
+#[test]
+fn assert_seeds_rejects_wrong_stored_bump() {
+	let authority = unique_address(13);
+	let (pda, bump) = TestState::find_pda(&authority, 42, 1, [0xAB; 8], 7, 99, &TEST_PROGRAM_ID);
+
+	// Correct address, but the stored bump does not match the derived one.
+	let state = TestState::builder()
+		.authority(authority)
+		.amount(PodU64::from_primitive(42))
+		.side(1)
+		.tag([0xAB; 8])
+		.width(PodU16::from_primitive(7))
+		.height(PodU32::from_primitive(99))
+		.bump(bump.wrapping_add(1))
+		._padding(0)
+		.build();
+
+	let test_account = build_account_view(pda, bytemuck::bytes_of(&state));
+	let account = test_account.view;
+	let result = TestState::assert_seeds(
+		&account,
+		&authority,
+		42,
+		1,
+		[0xAB; 8],
+		7,
+		99,
+		&TEST_PROGRAM_ID,
+	);
+
+	assert!(
+		result.is_err(),
+		"expected assert_seeds to reject a wrong stored bump"
+	);
+}
+
+#[test]
+fn assert_seeds_rejects_wrong_owner() {
+	let authority = unique_address(14);
+	let (pda, bump) = TestState::find_pda(&authority, 42, 1, [0xAB; 8], 7, 99, &TEST_PROGRAM_ID);
+	let _ = bump;
+
+	let state = TestState::builder()
+		.authority(authority)
+		.amount(PodU64::from_primitive(42))
+		.side(1)
+		.tag([0xAB; 8])
+		.width(PodU16::from_primitive(7))
+		.height(PodU32::from_primitive(99))
+		.bump(bump)
+		._padding(0)
+		.build();
+
+	// Correct address and data, but owned by a different program.
+	let test_account =
+		build_account_view_with_owner(pda, bytemuck::bytes_of(&state), unique_address(15));
+	let account = test_account.view;
+	let result = TestState::assert_seeds(
+		&account,
+		&authority,
+		42,
+		1,
+		[0xAB; 8],
+		7,
+		99,
+		&TEST_PROGRAM_ID,
+	);
+
+	assert!(
+		result.is_err(),
+		"expected assert_seeds to reject a wrong owner"
+	);
+}
+
+#[test]
+fn assert_seeds_rejects_wrong_seed_value() {
+	let authority = unique_address(16);
+	let (pda, bump) = TestState::find_pda(&authority, 42, 1, [0xAB; 8], 7, 99, &TEST_PROGRAM_ID);
+	let _ = bump;
+
+	let state = TestState::builder()
+		.authority(authority)
+		.amount(PodU64::from_primitive(42))
+		.side(1)
+		.tag([0xAB; 8])
+		.width(PodU16::from_primitive(7))
+		.height(PodU32::from_primitive(99))
+		.bump(bump)
+		._padding(0)
+		.build();
+
+	// The account is the PDA for `amount = 42`, so asserting with a
+	// different seed value must fail even though the address matches the
+	// stored bump.
+	let test_account = build_account_view(pda, bytemuck::bytes_of(&state));
+	let account = test_account.view;
+	let result = TestState::assert_seeds(
+		&account,
+		&authority,
+		43,
+		1,
+		[0xAB; 8],
+		7,
+		99,
+		&TEST_PROGRAM_ID,
+	);
+
+	assert!(
+		result.is_err(),
+		"expected assert_seeds to reject a wrong seed value"
+	);
+}
+
+// ---------------------------------------------------------------------------
+// AccountView construction helpers (SVM input format)
+// ---------------------------------------------------------------------------
+
+const BPF_ALIGN_OF_U128: usize = 16;
+const STATIC_ACCOUNT_DATA: usize = 88 + MAX_PERMITTED_DATA_INCREASE;
+
+/// Builder for a raw account in the SVM loader input format.
+struct AccountBuilder {
+	address: Address,
+	owner: Address,
+	lamports: u64,
+	data: Vec<u8>,
+	is_signer: bool,
+	is_writable: bool,
+	executable: bool,
+}
+
+impl AccountBuilder {
+	fn new(address: Address) -> Self {
+		Self {
+			address,
+			owner: TEST_PROGRAM_ID,
+			lamports: 1_000_000_000,
+			data: Vec::new(),
+			is_signer: false,
+			is_writable: true,
+			executable: false,
+		}
+	}
+
+	fn owner(mut self, owner: Address) -> Self {
+		self.owner = owner;
+		self
+	}
+
+	fn data(mut self, data: &[u8]) -> Self {
+		self.data = data.to_vec();
+		self
+	}
+}
+
+/// Struct representing a memory region with a specific alignment.
+struct AlignedMemory {
+	ptr: *mut u8,
+	layout: Layout,
+}
+
+impl AlignedMemory {
+	fn new(len: usize) -> Self {
+		let layout = Layout::from_size_align(len, BPF_ALIGN_OF_U128)
+			.unwrap_or_else(|e| panic!("invalid layout: {e:?}"));
+		unsafe {
+			let ptr = alloc(layout);
+			if ptr.is_null() {
+				std::alloc::handle_alloc_error(layout);
+			}
+			AlignedMemory { ptr, layout }
+		}
+	}
+
+	unsafe fn write(&mut self, data: &[u8], offset: usize) {
+		unsafe {
+			copy_nonoverlapping(data.as_ptr(), self.ptr.add(offset), data.len());
+		}
+	}
+
+	fn as_mut_ptr(&mut self) -> *mut u8 {
+		self.ptr
+	}
+}
+
+impl Drop for AlignedMemory {
+	fn drop(&mut self) {
+		unsafe {
+			dealloc(self.ptr, self.layout);
+		}
+	}
+}
+
+/// Creates a serialized input buffer with a single account, mimicking the
+/// SVM loader input format exactly as `pinocchio::entrypoint::deserialize`
+/// expects.
+///
+/// # Safety
+///
+/// The returned `AlignedMemory` must outlive any `AccountView` created from it.
+unsafe fn create_test_input(account: &AccountBuilder, instruction_data: &[u8]) -> AlignedMemory {
+	let data_len = account.data.len();
+	let account_buf_size = STATIC_ACCOUNT_DATA + size_of::<u64>();
+	let padding = (data_len + (BPF_ALIGN_OF_U128 - 1)) & !(BPF_ALIGN_OF_U128 - 1);
+	let total_size = size_of::<u64>()
+		+ account_buf_size
+		+ padding
+		+ size_of::<u64>()
+		+ instruction_data.len()
+		+ 32;
+
+	let mut input = AlignedMemory::new(total_size);
+
+	// Number of accounts.
+	unsafe {
+		input.write(&1u64.to_le_bytes(), 0);
+	}
+	let mut offset = size_of::<u64>();
+
+	// The account buffer: RuntimeAccount header (88 bytes) + spare
+	// (MAX_PERMITTED_DATA_INCREASE) + rent epoch (8 bytes).
+	let mut account_buf = vec![0u8; account_buf_size];
+
+	// RuntimeAccount header fields:
+	// borrow_state = NON_DUP_MARKER (not borrowed)
+	account_buf[0] = entrypoint::NON_DUP_MARKER;
+	// is_signer
+	account_buf[1] = u8::from(account.is_signer);
+	// is_writable
+	account_buf[2] = u8::from(account.is_writable);
+	// executable
+	account_buf[3] = u8::from(account.executable);
+	// resize_delta = 0 (bytes 4-7 already zeroed)
+	// address (bytes 8-39)
+	account_buf[8..40].copy_from_slice(account.address.as_ref());
+	// owner (bytes 40-71)
+	account_buf[40..72].copy_from_slice(account.owner.as_ref());
+	// lamports (bytes 72-79)
+	account_buf[72..80].copy_from_slice(&account.lamports.to_le_bytes());
+	// data_len (bytes 80-87)
+	account_buf[80..88].copy_from_slice(&(data_len as u64).to_le_bytes());
+	// Account data starts at byte 88 within the buffer.
+	if !account.data.is_empty() {
+		account_buf[88..88 + data_len].copy_from_slice(&account.data);
+	}
+
+	unsafe {
+		input.write(&account_buf, offset);
+	}
+	offset += account_buf_size;
+
+	// Alignment padding based on data_len.
+	if padding > 0 {
+		unsafe {
+			input.write(&vec![0u8; padding], offset);
+		}
+		offset += padding;
+	}
+
+	// Instruction data length.
+	unsafe {
+		input.write(&instruction_data.len().to_le_bytes(), offset);
+	}
+	offset += size_of::<u64>();
+	// Instruction data.
+	unsafe {
+		input.write(instruction_data, offset);
+	}
+	offset += instruction_data.len();
+	// Program ID.
+	unsafe {
+		input.write(TEST_PROGRAM_ID.as_ref(), offset);
+	}
+
+	input
+}
+
+/// Deserialize a single-account test input into an `AccountView`.
+///
+/// # Safety
+///
+/// `input` must be created by `create_test_input` and must outlive the
+/// returned `AccountView`.
+unsafe fn deserialize_test_input(input: &mut AlignedMemory) -> AccountView {
+	let mut accounts = [MaybeUninit::<AccountView>::uninit(); 1];
+	let (_program_id, account_views, _ix_data, _count) = unsafe {
+		let (program_id, count, ix_data) =
+			unsafe { entrypoint::deserialize::<1>(input.as_mut_ptr(), &mut accounts) };
+		let account_views: &mut [AccountView] =
+			unsafe { core::slice::from_raw_parts_mut(accounts.as_mut_ptr().cast(), count) };
+		(program_id, account_views, ix_data, count)
+	};
+	account_views[0]
+}
+
+/// A test account: an `AccountView` plus the aligned memory it borrows.
+///
+/// The memory must outlive the view, so both are kept together.
+struct TestAccount {
+	view: AccountView,
+	_memory: AlignedMemory,
+}
+
+/// Build a test account owned by `TEST_PROGRAM_ID`.
+fn build_account_view(address: Address, data: &[u8]) -> TestAccount {
+	build_account_view_with_owner(address, data, TEST_PROGRAM_ID)
+}
+
+/// Build a test account with a custom owner.
+fn build_account_view_with_owner(address: Address, data: &[u8], owner: Address) -> TestAccount {
+	let builder = AccountBuilder::new(address).owner(owner).data(data);
+	let mut input = unsafe { create_test_input(&builder, &[]) };
+	let view = unsafe { deserialize_test_input(&mut input) };
+	TestAccount {
+		view,
+		_memory: input,
+	}
+}

--- a/crates/pina_cli/src/codegen/mod.rs
+++ b/crates/pina_cli/src/codegen/mod.rs
@@ -69,6 +69,10 @@ fn build_account_node(account: &AccountIr) -> AccountNode {
 	let data = StructTypeNode::new(fields);
 	let mut node = AccountNode::new(account.name.as_str(), data);
 	node.discriminators = vec![build_discriminator_node(&account.discriminator)];
+	node.pda = account
+		.pda_name
+		.as_ref()
+		.map(|name| PdaLinkNode::new(name.as_str()));
 
 	if !account.docs.is_empty() {
 		node.docs = account.docs.clone().into();

--- a/crates/pina_cli/src/ir/mod.rs
+++ b/crates/pina_cli/src/ir/mod.rs
@@ -21,6 +21,8 @@ pub struct AccountIr {
 	pub fields: Vec<FieldIr>,
 	pub discriminator: DiscriminatorIr,
 	pub docs: Vec<String>,
+	/// The name of the PDA declared for this account via `#[pda(...)]`.
+	pub pda_name: Option<String>,
 }
 
 /// An instruction assembled from `#[instruction]`, `#[derive(Accounts)]`, the

--- a/crates/pina_cli/src/parse/account_state.rs
+++ b/crates/pina_cli/src/parse/account_state.rs
@@ -1,3 +1,4 @@
+use heck::ToSnakeCase;
 use syn::File;
 use syn::Item;
 
@@ -12,6 +13,8 @@ pub struct AccountStruct {
 	pub discriminator_enum: String,
 	pub fields: Vec<FieldIr>,
 	pub docs: Vec<String>,
+	/// The name of the PDA declared for this account via `#[pda(...)]`.
+	pub pda_name: Option<String>,
 }
 
 /// Extract all `#[account(...)]` structs from a file.
@@ -29,16 +32,36 @@ pub fn extract_account_structs(file: &File) -> Vec<AccountStruct> {
 
 		let fields = extract_named_fields(&item_struct.fields);
 		let docs = extract_docs(&item_struct.attrs);
+		let pda_name = extract_pda_name(&item_struct.attrs, &item_struct.ident.to_string());
 
 		result.push(AccountStruct {
 			name: item_struct.ident.to_string(),
 			discriminator_enum: disc_enum,
 			fields,
 			docs,
+			pda_name,
 		});
 	}
 
 	result
+}
+
+/// Derive the IDL PDA name for a struct with a `#[pda(...)]` attribute.
+///
+/// The `State` suffix is stripped so `CounterState` produces the `counter`
+/// PDA, matching the naming convention used by the example programs.
+fn extract_pda_name(attrs: &[syn::Attribute], struct_name: &str) -> Option<String> {
+	let has_pda_attr = attrs.iter().any(|attr| attr.path().is_ident("pda"));
+	if !has_pda_attr {
+		return None;
+	}
+
+	Some(
+		struct_name
+			.strip_suffix("State")
+			.unwrap_or(struct_name)
+			.to_snake_case(),
+	)
 }
 
 /// Parse the `discriminator = EnumType` from `#[account(discriminator =

--- a/crates/pina_cli/src/parse/collision.rs
+++ b/crates/pina_cli/src/parse/collision.rs
@@ -174,6 +174,7 @@ mod tests {
 				repr_size,
 			},
 			docs: vec![],
+			pda_name: None,
 		}
 	}
 

--- a/crates/pina_cli/src/parse/mod.rs
+++ b/crates/pina_cli/src/parse/mod.rs
@@ -7,6 +7,7 @@ pub mod entrypoint;
 pub mod error_enum;
 pub mod instruction_data;
 pub mod module_resolver;
+pub mod pda_attr;
 pub mod program_id;
 pub mod seeds;
 pub mod types;
@@ -91,9 +92,11 @@ pub fn assemble_program_ir_multi(
 
 		let file_seed_constants = seeds::extract_seed_constants(file);
 		let file_pdas = seeds::extract_pda_from_seed_macros(file, &file_seed_constants);
+		let file_attr_pdas = pda_attr::extract_pda_from_attributes(file, &file_seed_constants);
 
 		all_seed_constants.extend(file_seed_constants);
 		pdas_ir.extend(file_pdas);
+		pdas_ir.extend(file_attr_pdas);
 	}
 
 	let public_key = public_key.ok_or(IdlError::NoProgramId)?;
@@ -149,6 +152,7 @@ fn assemble_from_extracted(
 					fields: acct.fields.clone(),
 					discriminator: disc_value,
 					docs: acct.docs.clone(),
+					pda_name: acct.pda_name.clone(),
 				}
 			})
 		})

--- a/crates/pina_cli/src/parse/pda_attr.rs
+++ b/crates/pina_cli/src/parse/pda_attr.rs
@@ -161,7 +161,7 @@ fn parse_seed_list(input: syn::parse::ParseStream) -> syn::Result<Vec<PdaAttrSee
 		if content.peek(syn::LitByteStr) {
 			let lit: syn::LitByteStr = content.parse()?;
 			seeds.push(PdaAttrSeed::Constant(lit.value()));
-		} else if content.peek2(syn::Token![:]) {
+		} else if content.peek2(syn::Token![:]) && !content.peek3(syn::Token![:]) {
 			let name: syn::Ident = content.parse()?;
 			content.parse::<syn::Token![:]>()?;
 			let ty: syn::Type = content.parse()?;
@@ -367,6 +367,148 @@ mod tests {
 			&pdas[0].seeds[1],
 			PdaSeedIr::Variable { name, rust_type }
 				if name == "authority" && rust_type == "NotAType"
+		));
+	}
+
+	#[test]
+	fn skips_malformed_pda_attributes() {
+		let source = r#"
+			#[account(discriminator = BrokenAccount)]
+			#[pda(seeds)]
+			pub struct BrokenState {
+				pub bump: u8,
+			}
+		"#;
+		let file = syn::parse_file(source).unwrap_or_else(|e| panic!("parse failed: {e}"));
+		let pdas = extract_pda_from_attributes(&file, &[]);
+
+		assert!(pdas.is_empty(), "malformed attributes must skip the PDA");
+	}
+
+	#[test]
+	fn skips_pda_with_multi_segment_constant_path() {
+		let source = r#"
+			#[account(discriminator = BrokenAccount)]
+			#[pda(seeds = [crate::SEED, authority: Address], bump = bump)]
+			pub struct BrokenState {
+				pub authority: Address,
+				pub bump: u8,
+			}
+		"#;
+		let file = syn::parse_file(source).unwrap_or_else(|e| panic!("parse failed: {e}"));
+		let pdas = extract_pda_from_attributes(&file, &[]);
+
+		assert!(
+			pdas.is_empty(),
+			"multi-segment constant paths must skip the PDA"
+		);
+	}
+
+	#[test]
+	fn parses_bump_and_crate_arguments() {
+		let source = r#"
+			#[account(discriminator = CounterAccount)]
+			#[pda(seeds = [b"counter", authority: Address], bump = bump, crate = ::pina)]
+			pub struct CounterState {
+				pub authority: Address,
+				pub bump: u8,
+			}
+		"#;
+		let file = syn::parse_file(source).unwrap_or_else(|e| panic!("parse failed: {e}"));
+		let pdas = extract_pda_from_attributes(&file, &[]);
+
+		assert_eq!(pdas.len(), 1);
+		assert_eq!(pdas[0].name, "counter");
+	}
+
+	#[test]
+	fn skips_pda_with_duplicate_seeds_argument() {
+		let source = r#"
+			#[account(discriminator = BrokenAccount)]
+			#[pda(seeds = [b"broken"], seeds = [b"again"])]
+			pub struct BrokenState {}
+		"#;
+		let file = syn::parse_file(source).unwrap_or_else(|e| panic!("parse failed: {e}"));
+		let pdas = extract_pda_from_attributes(&file, &[]);
+
+		assert!(
+			pdas.is_empty(),
+			"duplicate `seeds` arguments must skip the PDA"
+		);
+	}
+
+	#[test]
+	fn skips_pda_with_unknown_argument() {
+		let source = r#"
+			#[account(discriminator = BrokenAccount)]
+			#[pda(seeds = [b"broken"], unknown = 5)]
+			pub struct BrokenState {}
+		"#;
+		let file = syn::parse_file(source).unwrap_or_else(|e| panic!("parse failed: {e}"));
+		let pdas = extract_pda_from_attributes(&file, &[]);
+
+		assert!(pdas.is_empty(), "unknown arguments must skip the PDA");
+	}
+
+	#[test]
+	fn extracts_pda_with_const_length_byte_array_seed() {
+		let source = r#"
+			#[account(discriminator = PositionAccount)]
+			#[pda(seeds = [b"position", owner: Address, tag: [u8; SIZE]], bump = bump)]
+			pub struct PositionState {
+				pub owner: Address,
+				pub tag: [u8; 8],
+				pub bump: u8,
+			}
+		"#;
+		let file = syn::parse_file(source).unwrap_or_else(|e| panic!("parse failed: {e}"));
+		let pdas = extract_pda_from_attributes(&file, &[]);
+
+		assert!(matches!(
+			&pdas[0].seeds[2],
+			PdaSeedIr::Variable { name, rust_type }
+				if name == "tag" && rust_type == "[u8; 0]"
+		));
+	}
+
+	#[test]
+	fn extracts_pda_with_char_literal_array_length() {
+		let source = r#"
+			#[account(discriminator = PositionAccount)]
+			#[pda(seeds = [b"position", owner: Address, tag: [u8; 'a']], bump = bump)]
+			pub struct PositionState {
+				pub owner: Address,
+				pub tag: [u8; 8],
+				pub bump: u8,
+			}
+		"#;
+		let file = syn::parse_file(source).unwrap_or_else(|e| panic!("parse failed: {e}"));
+		let pdas = extract_pda_from_attributes(&file, &[]);
+
+		assert!(matches!(
+			&pdas[0].seeds[2],
+			PdaSeedIr::Variable { name, rust_type }
+				if name == "tag" && rust_type == "[u8; 0]"
+		));
+	}
+
+	#[test]
+	fn extracts_pda_with_reference_seed_type() {
+		let source = r#"
+			#[account(discriminator = PositionAccount)]
+			#[pda(seeds = [b"position", owner: &[u8]], bump = bump)]
+			pub struct PositionState {
+				pub owner: Address,
+				pub bump: u8,
+			}
+		"#;
+		let file = syn::parse_file(source).unwrap_or_else(|e| panic!("parse failed: {e}"));
+		let pdas = extract_pda_from_attributes(&file, &[]);
+
+		assert!(matches!(
+			&pdas[0].seeds[1],
+			PdaSeedIr::Variable { name, rust_type }
+				if name == "owner" && rust_type == "Address"
 		));
 	}
 

--- a/crates/pina_cli/src/parse/pda_attr.rs
+++ b/crates/pina_cli/src/parse/pda_attr.rs
@@ -1,0 +1,381 @@
+//! Extract PDA declarations from `#[pda(...)]` attributes on account structs.
+//!
+//! The attribute declares the typed PDA seeds for an `#[account]` struct:
+//!
+//! ```ignore
+//! #[account(discriminator = CounterAccount)]
+//! #[pda(seeds = [COUNTER_SEED, authority: Address], bump = bump)]
+//! pub struct CounterState { ... }
+//! ```
+//!
+//! Unlike the `macro_rules!` heuristic in [`super::seeds`], this extraction
+//! reads the seed types directly from the attribute, so the generated IDL
+//! always matches the on-chain derivation. Constant seed references (e.g.
+//! `COUNTER_SEED`) are resolved through the file's `const &[u8]`
+//! declarations.
+
+use heck::ToSnakeCase;
+use syn::File;
+use syn::Item;
+use syn::parse::Parse;
+
+use super::seeds::SeedConstant;
+use crate::ir::PdaIr;
+use crate::ir::PdaSeedIr;
+/// Extract PDA declarations from `#[pda(...)]` attributes on account structs.
+///
+/// Constant seed references (e.g. `COUNTER_SEED`) are resolved through the
+/// file's `const &[u8]` declarations. A PDA whose constant cannot be resolved
+/// is skipped so IDL generation can still proceed for other accounts.
+pub fn extract_pda_from_attributes(file: &File, seed_constants: &[SeedConstant]) -> Vec<PdaIr> {
+	let mut pdas = Vec::new();
+
+	for item in &file.items {
+		let Item::Struct(item_struct) = item else {
+			continue;
+		};
+
+		let Some(attr) = item_struct
+			.attrs
+			.iter()
+			.find(|attr| attr.path().is_ident("pda"))
+		else {
+			continue;
+		};
+
+		let Ok(args) = attr.parse_args_with(PdaAttrArgs::parse) else {
+			// Malformed attributes are rejected by the compiler; skip them
+			// here so IDL generation can still proceed for other accounts.
+			continue;
+		};
+
+		let name = pda_name_for_struct(&item_struct.ident.to_string());
+		let mut seeds = Vec::with_capacity(args.seeds.len());
+		let mut resolved = true;
+
+		for seed in args.seeds {
+			match seed {
+				PdaAttrSeed::Constant(value) => seeds.push(PdaSeedIr::Constant { value }),
+				PdaAttrSeed::ConstantRef(path) => {
+					let Some(ident) = path.get_ident() else {
+						resolved = false;
+						break;
+					};
+					let Some(constant) =
+						seed_constants.iter().find(|c| c.name == ident.to_string())
+					else {
+						resolved = false;
+						break;
+					};
+					seeds.push(PdaSeedIr::Constant {
+						value: constant.value.clone(),
+					});
+				}
+				PdaAttrSeed::Variable { name, rust_type } => {
+					seeds.push(PdaSeedIr::Variable { name, rust_type });
+				}
+			}
+		}
+
+		if resolved {
+			pdas.push(PdaIr { name, seeds });
+		}
+	}
+
+	pdas
+}
+
+/// The IDL name for a PDA declared on a struct.
+///
+/// The `State` suffix is stripped so `CounterState` produces the `counter`
+/// PDA, matching the naming convention used by the example programs.
+fn pda_name_for_struct(struct_name: &str) -> String {
+	let stripped = struct_name.strip_suffix("State").unwrap_or(struct_name);
+	if stripped.is_empty() {
+		return struct_name.to_snake_case();
+	}
+	stripped.to_snake_case()
+}
+
+/// Parsed `#[pda(...)]` attribute arguments.
+struct PdaAttrArgs {
+	seeds: Vec<PdaAttrSeed>,
+}
+
+/// A single element of a `#[pda(seeds = [...])]` list.
+enum PdaAttrSeed {
+	Constant(Vec<u8>),
+	ConstantRef(syn::Path),
+	Variable { name: String, rust_type: String },
+}
+
+impl syn::parse::Parse for PdaAttrArgs {
+	fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+		let mut seeds = None;
+
+		while !input.is_empty() {
+			let key: syn::Ident = input.call(syn::ext::IdentExt::parse_any)?;
+			input.parse::<syn::Token![=]>()?;
+
+			if key == "seeds" {
+				if seeds.is_some() {
+					return Err(syn::Error::new(key.span(), "duplicate `seeds` argument"));
+				}
+				seeds = Some(parse_seed_list(input)?);
+			} else if key == "bump" {
+				// The bump field name does not affect the IDL.
+				let _: syn::Ident = input.call(syn::ext::IdentExt::parse_any)?;
+			} else if key == "crate" {
+				// The crate path does not affect the IDL.
+				let _: syn::Path = input.parse()?;
+			} else {
+				return Err(syn::Error::new(
+					key.span(),
+					format!("unknown `#[pda]` argument `{key}`"),
+				));
+			}
+
+			if input.is_empty() {
+				break;
+			}
+			input.parse::<syn::Token![,]>()?;
+		}
+
+		let seeds = seeds
+			.ok_or_else(|| syn::Error::new(input.span(), "`seeds` is required in `#[pda(...)]`"))?;
+
+		Ok(Self { seeds })
+	}
+}
+
+/// Parse a `[b"literal", name: Type, ...]` seed list.
+///
+/// The list is parsed from raw tokens because `name: Type` type ascriptions
+/// are not valid Rust expressions.
+fn parse_seed_list(input: syn::parse::ParseStream) -> syn::Result<Vec<PdaAttrSeed>> {
+	let content;
+	syn::bracketed!(content in input);
+
+	let mut seeds = Vec::new();
+	while !content.is_empty() {
+		if content.peek(syn::LitByteStr) {
+			let lit: syn::LitByteStr = content.parse()?;
+			seeds.push(PdaAttrSeed::Constant(lit.value()));
+		} else if content.peek2(syn::Token![:]) {
+			let name: syn::Ident = content.parse()?;
+			content.parse::<syn::Token![:]>()?;
+			let ty: syn::Type = content.parse()?;
+			let rust_type = seed_type_to_string(&ty);
+			seeds.push(PdaAttrSeed::Variable {
+				name: name.to_string(),
+				rust_type,
+			});
+		} else {
+			// A path to a `const &[u8]` seed (e.g. `COUNTER_SEED`).
+			let path: syn::Path = content.parse()?;
+			seeds.push(PdaAttrSeed::ConstantRef(path));
+		}
+
+		if content.is_empty() {
+			break;
+		}
+		content.parse::<syn::Token![,]>()?;
+	}
+
+	Ok(seeds)
+}
+
+/// Convert a typed seed parameter type to its IDL Rust type name.
+fn seed_type_to_string(ty: &syn::Type) -> String {
+	match ty {
+		syn::Type::Path(type_path) => {
+			type_path
+				.path
+				.get_ident()
+				.map_or_else(|| "Address".to_string(), |ident| ident.to_string())
+		}
+		syn::Type::Array(array) => {
+			let len = match &array.len {
+				syn::Expr::Lit(lit) => {
+					match &lit.lit {
+						syn::Lit::Int(int) => int.base10_parse::<usize>().unwrap_or(0),
+						_ => 0,
+					}
+				}
+				_ => 0,
+			};
+			format!("[u8; {len}]")
+		}
+		_ => "Address".to_string(),
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn extracts_pda_with_address_seed() {
+		let source = r#"
+			const COUNTER_SEED: &[u8] = b"counter";
+
+			#[account(discriminator = CounterAccount)]
+			#[pda(seeds = [COUNTER_SEED, authority: Address], bump = bump)]
+			pub struct CounterState {
+				pub authority: Address,
+				pub bump: u8,
+			}
+		"#;
+		let file = syn::parse_file(source).unwrap_or_else(|e| panic!("parse failed: {e}"));
+		let constants = super::super::seeds::extract_seed_constants(&file);
+		let pdas = extract_pda_from_attributes(&file, &constants);
+
+		assert_eq!(pdas.len(), 1);
+		assert_eq!(pdas[0].name, "counter");
+		assert_eq!(pdas[0].seeds.len(), 2);
+		assert!(matches!(
+			&pdas[0].seeds[0],
+			PdaSeedIr::Constant { value } if value == b"counter"
+		));
+		assert!(matches!(
+			&pdas[0].seeds[1],
+			PdaSeedIr::Variable { name, rust_type }
+				if name == "authority" && rust_type == "Address"
+		));
+	}
+
+	#[test]
+	fn extracts_pda_with_numeric_seeds() {
+		let source = r#"
+			#[account(discriminator = EscrowAccount)]
+			#[pda(seeds = [b"escrow", maker: Address, seed: u64], bump = bump)]
+			pub struct EscrowState {
+				pub maker: Address,
+				pub seed: PodU64,
+				pub bump: u8,
+			}
+		"#;
+		let file = syn::parse_file(source).unwrap_or_else(|e| panic!("parse failed: {e}"));
+		let pdas = extract_pda_from_attributes(&file, &[]);
+
+		assert_eq!(pdas.len(), 1);
+		assert_eq!(pdas[0].name, "escrow");
+		assert!(matches!(
+			&pdas[0].seeds[2],
+			PdaSeedIr::Variable { name, rust_type }
+				if name == "seed" && rust_type == "u64"
+		));
+	}
+
+	#[test]
+	fn extracts_pda_with_byte_array_seed() {
+		let source = r#"
+			#[account(discriminator = PositionAccount)]
+			#[pda(seeds = [b"position", owner: Address, tag: [u8; 8]], bump = bump)]
+			pub struct PositionState {
+				pub owner: Address,
+				pub tag: [u8; 8],
+				pub bump: u8,
+			}
+		"#;
+		let file = syn::parse_file(source).unwrap_or_else(|e| panic!("parse failed: {e}"));
+		let pdas = extract_pda_from_attributes(&file, &[]);
+
+		assert!(matches!(
+			&pdas[0].seeds[2],
+			PdaSeedIr::Variable { name, rust_type }
+				if name == "tag" && rust_type == "[u8; 8]"
+		));
+	}
+
+	#[test]
+	fn extracts_multiple_pdas() {
+		let source = r#"
+			#[account(discriminator = RegistryAccount)]
+			#[pda(seeds = [b"registry", admin: Address], bump = bump)]
+			pub struct RegistryConfig {
+				pub admin: Address,
+				pub bump: u8,
+			}
+
+			#[account(discriminator = RoleEntryAccount)]
+			#[pda(seeds = [b"role-entry", registry: Address, role_id: u64], bump = bump)]
+			pub struct RoleEntry {
+				pub registry: Address,
+				pub role_id: PodU64,
+				pub bump: u8,
+			}
+		"#;
+		let file = syn::parse_file(source).unwrap_or_else(|e| panic!("parse failed: {e}"));
+		let pdas = extract_pda_from_attributes(&file, &[]);
+
+		assert_eq!(pdas.len(), 2);
+		assert_eq!(pdas[0].name, "registry_config");
+		assert_eq!(pdas[1].name, "role_entry");
+	}
+
+	#[test]
+	fn skips_pda_with_unresolved_constant_seed() {
+		let source = r#"
+			#[account(discriminator = CounterAccount)]
+			#[pda(seeds = [MISSING_SEED, authority: Address], bump = bump)]
+			pub struct CounterState {
+				pub authority: Address,
+				pub bump: u8,
+			}
+		"#;
+		let file = syn::parse_file(source).unwrap_or_else(|e| panic!("parse failed: {e}"));
+		let pdas = extract_pda_from_attributes(&file, &[]);
+
+		assert!(
+			pdas.is_empty(),
+			"unresolved constant seeds must skip the PDA"
+		);
+	}
+
+	#[test]
+	fn skips_structs_without_pda_attribute() {
+		let source = r#"
+			#[account(discriminator = PlainAccount)]
+			pub struct PlainState {
+				pub value: PodU64,
+			}
+		"#;
+		let file = syn::parse_file(source).unwrap_or_else(|e| panic!("parse failed: {e}"));
+		let pdas = extract_pda_from_attributes(&file, &[]);
+
+		assert!(pdas.is_empty());
+	}
+
+	#[test]
+	fn extracts_pda_with_unknown_seed_type() {
+		// The compiler rejects unknown seed types; the CLI passes the type
+		// string through so the IDL still reflects the declaration.
+		let source = r#"
+			#[account(discriminator = BrokenAccount)]
+			#[pda(seeds = [b"broken", authority: NotAType], bump = bump)]
+			pub struct BrokenState {
+				pub authority: Address,
+				pub bump: u8,
+			}
+		"#;
+		let file = syn::parse_file(source).unwrap_or_else(|e| panic!("parse failed: {e}"));
+		let pdas = extract_pda_from_attributes(&file, &[]);
+
+		assert_eq!(pdas.len(), 1);
+		assert!(matches!(
+			&pdas[0].seeds[1],
+			PdaSeedIr::Variable { name, rust_type }
+				if name == "authority" && rust_type == "NotAType"
+		));
+	}
+
+	#[test]
+	fn pda_name_strips_state_suffix() {
+		assert_eq!(pda_name_for_struct("CounterState"), "counter");
+		assert_eq!(pda_name_for_struct("EscrowState"), "escrow");
+		assert_eq!(pda_name_for_struct("RegistryConfig"), "registry_config");
+		assert_eq!(pda_name_for_struct("RoleEntry"), "role_entry");
+		assert_eq!(pda_name_for_struct("State"), "state");
+	}
+}

--- a/crates/pina_cli/src/parse/validation.rs
+++ b/crates/pina_cli/src/parse/validation.rs
@@ -159,19 +159,18 @@ fn collect_assertions_from_expr(expr: &Expr, props: &mut HashMap<String, Account
 
 		Expr::Call(call) => {
 			// Recognize generated `Type::assert_seeds(self.<field>, ...)`
-			// static calls from the `#[pda]` attribute macro.
+			// static calls from the `#[pda]` attribute macro. All three
+			// generated methods mark the account as a PDA.
 			if let Expr::Path(path) = &*call.func {
-				if let Some(method) = path.path.segments.last() {
-					let method = method.ident.to_string();
-					if matches!(
-						method.as_str(),
-						"assert_seeds" | "assert_seeds_with_bump" | "assert_canonical_bump"
-					) {
-						if let Some(first_arg) = call.args.first() {
-							if let Some(field_name) = resolve_self_field(first_arg) {
-								let entry = props.entry(field_name).or_default();
-								apply_assertion(&method, &call.args, entry);
-							}
+				let method = path.path.segments.last().map(|s| s.ident.to_string());
+				if matches!(
+					method.as_deref(),
+					Some("assert_seeds" | "assert_seeds_with_bump" | "assert_canonical_bump")
+				) {
+					if let Some(first_arg) = call.args.first() {
+						if let Some(field_name) = resolve_self_field(first_arg) {
+							let entry = props.entry(field_name).or_default();
+							apply_assertion("assert_seeds", &call.args, entry);
 						}
 					}
 				}
@@ -382,6 +381,82 @@ mod tests {
 		let all = extract_validation_properties(&file);
 		let props = &all["MyAccounts"];
 		assert!(props["counter"].is_pda);
+	}
+
+	#[test]
+	fn ignores_static_assert_with_non_self_first_arg() {
+		let source = r#"
+			impl<'a> ProcessAccountInfos<'a> for MyAccounts<'a> {
+				fn process(self, data: &[u8]) -> ProgramResult {
+					CounterState::assert_seeds(&other_account, authority_key, &ID)?;
+					Ok(())
+				}
+			}
+		"#;
+		let file = syn::parse_file(source).unwrap_or_else(|e| panic!("parse failed: {e}"));
+		let all = extract_validation_properties(&file);
+		let props = &all["MyAccounts"];
+		assert!(
+			props.values().all(|p| !p.is_pda),
+			"static asserts on non-self accounts must not mark fields as PDAs"
+		);
+	}
+
+	#[test]
+	fn ignores_static_assert_with_no_args() {
+		let source = r#"
+			impl<'a> ProcessAccountInfos<'a> for MyAccounts<'a> {
+				fn process(self, data: &[u8]) -> ProgramResult {
+					CounterState::assert_seeds()?;
+					Ok(())
+				}
+			}
+		"#;
+		let file = syn::parse_file(source).unwrap_or_else(|e| panic!("parse failed: {e}"));
+		let all = extract_validation_properties(&file);
+		let props = &all["MyAccounts"];
+		assert!(
+			props.values().all(|p| !p.is_pda),
+			"arg-less static asserts must not mark accounts as PDAs"
+		);
+	}
+
+	#[test]
+	fn ignores_calls_with_non_path_func() {
+		let source = r#"
+			impl<'a> ProcessAccountInfos<'a> for MyAccounts<'a> {
+				fn process(self, data: &[u8]) -> ProgramResult {
+					(|| Ok(()))()?;
+					Ok(())
+				}
+			}
+		"#;
+		let file = syn::parse_file(source).unwrap_or_else(|e| panic!("parse failed: {e}"));
+		let all = extract_validation_properties(&file);
+		let props = &all["MyAccounts"];
+		assert!(
+			props.values().all(|p| !p.is_pda),
+			"non-path call funcs must not mark accounts as PDAs"
+		);
+	}
+
+	#[test]
+	fn ignores_non_assert_static_calls() {
+		let source = r#"
+			impl<'a> ProcessAccountInfos<'a> for MyAccounts<'a> {
+				fn process(self, data: &[u8]) -> ProgramResult {
+					let seeds = CounterState::seeds(authority_key);
+					Ok(())
+				}
+			}
+		"#;
+		let file = syn::parse_file(source).unwrap_or_else(|e| panic!("parse failed: {e}"));
+		let all = extract_validation_properties(&file);
+		let props = &all["MyAccounts"];
+		assert!(
+			props.values().all(|p| !p.is_pda),
+			"non-assert static calls must not mark accounts as PDAs"
+		);
 	}
 
 	#[test]

--- a/crates/pina_cli/src/parse/validation.rs
+++ b/crates/pina_cli/src/parse/validation.rs
@@ -158,6 +158,25 @@ fn collect_assertions_from_expr(expr: &Expr, props: &mut HashMap<String, Account
 		}
 
 		Expr::Call(call) => {
+			// Recognize generated `Type::assert_seeds(self.<field>, ...)`
+			// static calls from the `#[pda]` attribute macro.
+			if let Expr::Path(path) = &*call.func {
+				if let Some(method) = path.path.segments.last() {
+					let method = method.ident.to_string();
+					if matches!(
+						method.as_str(),
+						"assert_seeds" | "assert_seeds_with_bump" | "assert_canonical_bump"
+					) {
+						if let Some(first_arg) = call.args.first() {
+							if let Some(field_name) = resolve_self_field(first_arg) {
+								let entry = props.entry(field_name).or_default();
+								apply_assertion(&method, &call.args, entry);
+							}
+						}
+					}
+				}
+			}
+
 			collect_assertions_from_expr(&call.func, props);
 
 			for arg in &call.args {
@@ -191,6 +210,7 @@ fn resolve_self_field(expr: &Expr) -> Option<String> {
 		Expr::Try(t) => resolve_self_field(&t.expr),
 		Expr::MethodCall(mc) => resolve_self_field(&mc.receiver),
 		Expr::Paren(p) => resolve_self_field(&p.expr),
+		Expr::Reference(r) => resolve_self_field(&r.expr),
 		_ => None,
 	}
 }
@@ -346,6 +366,38 @@ mod tests {
 		let props = &all["MyAccounts"];
 		assert!(props["counter"].is_pda);
 		assert!(props["counter"].is_writable);
+	}
+
+	#[test]
+	fn extracts_pda_from_generated_static_assert() {
+		let source = r#"
+			impl<'a> ProcessAccountInfos<'a> for MyAccounts<'a> {
+				fn process(self, data: &[u8]) -> ProgramResult {
+					CounterState::assert_seeds(self.counter, authority_key, &ID)?;
+					Ok(())
+				}
+			}
+		"#;
+		let file = syn::parse_file(source).unwrap_or_else(|e| panic!("parse failed: {e}"));
+		let all = extract_validation_properties(&file);
+		let props = &all["MyAccounts"];
+		assert!(props["counter"].is_pda);
+	}
+
+	#[test]
+	fn extracts_pda_from_generated_static_assert_with_reference() {
+		let source = r#"
+			impl<'a> ProcessAccountInfos<'a> for MyAccounts<'a> {
+				fn process(self, data: &[u8]) -> ProgramResult {
+					VestingState::assert_seeds(&self.vesting_state, &admin, &beneficiary, &mint, &ID)?;
+					Ok(())
+				}
+			}
+		"#;
+		let file = syn::parse_file(source).unwrap_or_else(|e| panic!("parse failed: {e}"));
+		let all = extract_validation_properties(&file);
+		let props = &all["MyAccounts"];
+		assert!(props["vesting_state"].is_pda);
 	}
 
 	#[test]

--- a/crates/pina_cli/tests/snapshots/examples__counter_program.snap
+++ b/crates/pina_cli/tests/snapshots/examples__counter_program.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/pina_cli/tests/examples.rs
-assertion_line: 43
 expression: idl
 ---
 {
@@ -65,6 +64,10 @@ expression: idl
               }
             }
           ]
+        },
+        "pda": {
+          "kind": "pdaLinkNode",
+          "name": "counter"
         },
         "discriminators": [
           {

--- a/crates/pina_cli/tests/snapshots/examples__escrow_program.snap
+++ b/crates/pina_cli/tests/snapshots/examples__escrow_program.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/pina_cli/tests/examples.rs
-assertion_line: 49
 expression: idl
 ---
 {
@@ -83,6 +82,10 @@ expression: idl
               }
             }
           ]
+        },
+        "pda": {
+          "kind": "pdaLinkNode",
+          "name": "escrow"
         },
         "discriminators": [
           {
@@ -360,7 +363,9 @@ expression: idl
             "kind": "variablePdaSeedNode",
             "name": "seed",
             "type": {
-              "kind": "publicKeyTypeNode"
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
             }
           }
         ]

--- a/crates/pina_cli/tests/snapshots/examples__todo_program.snap
+++ b/crates/pina_cli/tests/snapshots/examples__todo_program.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/pina_cli/tests/examples.rs
-assertion_line: 55
 expression: idl
 ---
 {
@@ -59,6 +58,10 @@ expression: idl
               }
             }
           ]
+        },
+        "pda": {
+          "kind": "pdaLinkNode",
+          "name": "todo"
         },
         "discriminators": [
           {

--- a/crates/pina_codama_renderer/src/snapshots/pina_codama_renderer__tests__counter_state_account_rs.snap
+++ b/crates/pina_codama_renderer/src/snapshots/pina_codama_renderer__tests__counter_state_account_rs.snap
@@ -85,3 +85,26 @@ impl<'a> TryFrom<&solana_account_info::AccountInfo<'a>> for CounterState {
 		Ok(*account)
 	}
 }
+
+impl CounterState {
+	pub fn find_pda(authority: &solana_pubkey::Pubkey) -> (solana_pubkey::Pubkey, u8) {
+		solana_pubkey::Pubkey::find_program_address(
+			&[
+				"counter".as_bytes(),
+				authority.as_ref(),
+			],
+			&crate::COUNTER_PROGRAM_ID,
+		)
+	}
+
+	pub fn create_pda(authority: &solana_pubkey::Pubkey, bump: u8) -> Result<solana_pubkey::Pubkey, solana_pubkey::PubkeyError> {
+		solana_pubkey::Pubkey::create_program_address(
+			&[
+				"counter".as_bytes(),
+				authority.as_ref(),
+				&[bump],
+			],
+			&crate::COUNTER_PROGRAM_ID,
+		)
+	}
+}

--- a/crates/pina_macros/src/args.rs
+++ b/crates/pina_macros/src/args.rs
@@ -249,7 +249,7 @@ fn parse_seed_list(input: syn::parse::ParseStream) -> syn::Result<Vec<PdaSeedArg
 				));
 			}
 			seeds.push(PdaSeedArg::Constant(value));
-		} else if content.peek2(syn::Token![:]) {
+		} else if content.peek2(syn::Token![:]) && !content.peek3(syn::Token![:]) {
 			let name: syn::Ident = content.parse()?;
 			content.parse::<syn::Token![:]>()?;
 			let ty: syn::Type = content.parse()?;

--- a/crates/pina_macros/src/args.rs
+++ b/crates/pina_macros/src/args.rs
@@ -6,6 +6,7 @@ use darling::FromField;
 use darling::FromMeta;
 use quote::ToTokens;
 use syn::Expr;
+use syn::ext::IdentExt;
 
 /// Arguments for the `#[account(...)]` attribute macro.
 #[derive(Debug, FromMeta)]
@@ -52,6 +53,289 @@ pub(crate) struct ErrorArgs {
 	/// Set whether the error enum is in it's final form.
 	#[darling(rename = "final")]
 	pub(crate) is_final: darling::util::Flag,
+}
+
+/// Arguments for the `#[pda(...)]` attribute macro.
+#[derive(Debug)]
+pub(crate) struct PdaArgs {
+	/// Set the path to the crate
+	pub(crate) crate_path: syn::Path,
+	/// The typed PDA seed list.
+	pub(crate) seeds: Vec<PdaSeedArg>,
+	/// The name of the field that stores the PDA bump seed.
+	pub(crate) bump: Option<syn::Ident>,
+}
+
+/// A single element of a `#[pda(seeds = [...])]` list.
+#[derive(Debug)]
+pub(crate) enum PdaSeedArg {
+	/// A byte-string literal seed (e.g. `b"counter"`).
+	Constant(Vec<u8>),
+	/// A reference to a `const &[u8]` seed (e.g. `COUNTER_SEED`).
+	ConstantRef(syn::Path),
+	/// A typed dynamic seed (e.g. `authority: Address`).
+	Variable { name: syn::Ident, ty: SeedType },
+}
+
+/// The supported typed PDA seed parameter types.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum SeedType {
+	Address,
+	U8,
+	U16,
+	U32,
+	U64,
+	Bytes(usize),
+}
+
+impl SeedType {
+	/// The maximum number of seeds before the bump seed.
+	pub(crate) const MAX_SEEDS: usize = 16;
+	/// The maximum byte length of a single seed.
+	pub(crate) const MAX_SEED_LEN: usize = 32;
+
+	/// The byte length of this seed type.
+	pub(crate) fn byte_size(&self) -> usize {
+		match self {
+			SeedType::Address => 32,
+			SeedType::U8 => 1,
+			SeedType::U16 => 2,
+			SeedType::U32 => 4,
+			SeedType::U64 => 8,
+			SeedType::Bytes(len) => *len,
+		}
+	}
+
+	/// The Rust type used for the constructor parameter.
+	pub(crate) fn param_type(&self) -> syn::Type {
+		match self {
+			SeedType::Address => syn::parse_quote!(&Address),
+			SeedType::U8 => syn::parse_quote!(u8),
+			SeedType::U16 => syn::parse_quote!(u16),
+			SeedType::U32 => syn::parse_quote!(u32),
+			SeedType::U64 => syn::parse_quote!(u64),
+			SeedType::Bytes(len) => syn::parse_quote!([u8; #len]),
+		}
+	}
+
+	/// The constructor parameter type with an explicit lifetime, used by the
+	/// `seeds()` method so multiple `&Address` parameters can share one
+	/// lifetime.
+	pub(crate) fn param_type_lt(&self) -> syn::Type {
+		match self {
+			SeedType::Address => syn::parse_quote!(&'a Address),
+			_ => self.param_type(),
+		}
+	}
+
+	/// The field type stored in the generated seeds struct.
+	pub(crate) fn field_type(&self) -> syn::Type {
+		match self {
+			SeedType::Address => syn::parse_quote!(&'a Address),
+			SeedType::U8 => syn::parse_quote!([u8; 1]),
+			SeedType::U16 => syn::parse_quote!([u8; 2]),
+			SeedType::U32 => syn::parse_quote!([u8; 4]),
+			SeedType::U64 => syn::parse_quote!([u8; 8]),
+			SeedType::Bytes(len) => syn::parse_quote!([u8; #len]),
+		}
+	}
+
+	/// The expression that stores a constructor parameter in the struct field.
+	pub(crate) fn to_stored_expr(&self, param: &syn::Ident) -> proc_macro2::TokenStream {
+		match self {
+			SeedType::Address | SeedType::Bytes(_) => quote::quote!(#param),
+			SeedType::U8 => quote::quote!([#param]),
+			SeedType::U16 | SeedType::U32 | SeedType::U64 => {
+				quote::quote!(#param.to_le_bytes())
+			}
+		}
+	}
+
+	/// The expression that turns a struct field into a seed byte slice.
+	pub(crate) fn slice_expr(&self, field: &syn::Ident) -> proc_macro2::TokenStream {
+		match self {
+			SeedType::Address => quote::quote!(self.#field.as_ref()),
+			SeedType::U8 | SeedType::U16 | SeedType::U32 | SeedType::U64 | SeedType::Bytes(_) => {
+				quote::quote!(&self.#field)
+			}
+		}
+	}
+
+	/// The expression that turns a field of the inner seeds struct into a
+	/// seed byte slice (used by the `SeedsWithBump` wrapper).
+	pub(crate) fn slice_expr_inner(&self, field: &syn::Ident) -> proc_macro2::TokenStream {
+		match self {
+			SeedType::Address => quote::quote!(self.inner.#field.as_ref()),
+			SeedType::U8 | SeedType::U16 | SeedType::U32 | SeedType::U64 | SeedType::Bytes(_) => {
+				quote::quote!(&self.inner.#field)
+			}
+		}
+	}
+}
+
+impl syn::parse::Parse for PdaArgs {
+	fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+		let mut crate_path = default_crate_path();
+		let mut seeds = None;
+		let mut bump = None;
+
+		while !input.is_empty() {
+			let key: syn::Ident = input.call(syn::Ident::parse_any)?;
+			input.parse::<syn::Token![=]>()?;
+
+			if key == "seeds" {
+				if seeds.is_some() {
+					return Err(syn::Error::new(key.span(), "duplicate `seeds` argument"));
+				}
+				seeds = Some(parse_seed_list(input)?);
+			} else if key == "bump" {
+				if bump.is_some() {
+					return Err(syn::Error::new(key.span(), "duplicate `bump` argument"));
+				}
+				bump = Some(input.parse()?);
+			} else if key == "crate" {
+				crate_path = input.parse()?;
+			} else {
+				return Err(syn::Error::new(
+					key.span(),
+					format!(
+						"unknown `#[pda]` argument `{key}`; expected `seeds`, `bump`, or `crate`"
+					),
+				));
+			}
+
+			if input.is_empty() {
+				break;
+			}
+			input.parse::<syn::Token![,]>()?;
+		}
+
+		let seeds = seeds.ok_or_else(|| {
+			syn::Error::new(
+				input.span(),
+				"`seeds` is required (e.g. `seeds = [b\"counter\", authority: Address]`)",
+			)
+		})?;
+
+		Ok(Self {
+			crate_path,
+			seeds,
+			bump,
+		})
+	}
+}
+
+/// Parse a `[b"literal", name: Type, ...]` seed list.
+///
+/// The list is parsed from raw tokens because `name: Type` type ascriptions
+/// are not valid Rust expressions.
+fn parse_seed_list(input: syn::parse::ParseStream) -> syn::Result<Vec<PdaSeedArg>> {
+	let content;
+	syn::bracketed!(content in input);
+
+	let mut seeds = Vec::new();
+	while !content.is_empty() {
+		if content.peek(syn::LitByteStr) {
+			let lit: syn::LitByteStr = content.parse()?;
+			let value = lit.value();
+			if value.len() > SeedType::MAX_SEED_LEN {
+				return Err(syn::Error::new_spanned(
+					&lit,
+					format!(
+						"seed literal is {} bytes, exceeds the maximum of {}",
+						value.len(),
+						SeedType::MAX_SEED_LEN
+					),
+				));
+			}
+			seeds.push(PdaSeedArg::Constant(value));
+		} else if content.peek2(syn::Token![:]) {
+			let name: syn::Ident = content.parse()?;
+			content.parse::<syn::Token![:]>()?;
+			let ty: syn::Type = content.parse()?;
+			let ty = parse_seed_type(&ty)?;
+			seeds.push(PdaSeedArg::Variable { name, ty });
+		} else {
+			// A path to a `const &[u8]` seed (e.g. `COUNTER_SEED`).
+			let path: syn::Path = content.parse()?;
+			seeds.push(PdaSeedArg::ConstantRef(path));
+		}
+
+		if content.is_empty() {
+			break;
+		}
+		content.parse::<syn::Token![,]>()?;
+	}
+
+	if seeds.len() > SeedType::MAX_SEEDS {
+		return Err(syn::Error::new(
+			input.span(),
+			format!(
+				"PDA seed list has {} seeds before the bump; the maximum is {}",
+				seeds.len(),
+				SeedType::MAX_SEEDS
+			),
+		));
+	}
+
+	Ok(seeds)
+}
+
+/// Parse a typed seed parameter type.
+fn parse_seed_type(ty: &syn::Type) -> syn::Result<SeedType> {
+	let error = |span: &dyn quote::ToTokens| {
+		syn::Error::new_spanned(
+			span,
+			"unsupported seed type; expected `Address`, `u8`, `u16`, `u32`, `u64`, or `[u8; N]`",
+		)
+	};
+
+	match ty {
+		syn::Type::Path(type_path) => {
+			let Some(ident) = type_path.path.get_ident() else {
+				return Err(error(ty));
+			};
+			match ident.to_string().as_str() {
+				"Address" => Ok(SeedType::Address),
+				"u8" => Ok(SeedType::U8),
+				"u16" => Ok(SeedType::U16),
+				"u32" => Ok(SeedType::U32),
+				"u64" => Ok(SeedType::U64),
+				_ => Err(error(ident)),
+			}
+		}
+		syn::Type::Array(array) => {
+			let syn::Type::Path(item_path) = &*array.elem else {
+				return Err(error(ty));
+			};
+			let Some(ident) = item_path.path.get_ident() else {
+				return Err(error(ty));
+			};
+			if ident != "u8" {
+				return Err(error(ty));
+			}
+			let syn::Expr::Lit(lit) = &array.len else {
+				return Err(error(ty));
+			};
+			let syn::Lit::Int(int) = &lit.lit else {
+				return Err(error(ty));
+			};
+			let len = int.base10_parse::<usize>().map_err(|e| {
+				syn::Error::new_spanned(ty, format!("invalid seed array length: {e}"))
+			})?;
+			if len == 0 || len > SeedType::MAX_SEED_LEN {
+				return Err(syn::Error::new_spanned(
+					ty,
+					format!(
+						"seed array length must be between 1 and {}",
+						SeedType::MAX_SEED_LEN
+					),
+				));
+			}
+			Ok(SeedType::Bytes(len))
+		}
+		_ => Err(error(ty)),
+	}
 }
 
 fn default_crate_path() -> syn::Path {

--- a/crates/pina_macros/src/lib.rs
+++ b/crates/pina_macros/src/lib.rs
@@ -3,6 +3,8 @@ use args::AccountsInput;
 use args::DiscriminatorArgs;
 use args::ErrorArgs;
 use args::EventArgs;
+use args::PdaArgs;
+use args::PdaSeedArg;
 use darling::FromDeriveInput;
 use darling::FromMeta;
 use darling::ast::NestedMeta;
@@ -612,7 +614,7 @@ fn discriminator_impl(
 ///
 /// It will transform the following:
 ///
-/// ```rust
+/// ```ignore
 /// use pina::*;
 ///
 /// #[discriminator(crate = ::pina, primitive = u8, final)]
@@ -1085,6 +1087,333 @@ fn account_impl(
 	}
 }
 
+/// The `#[pda(...)]` attribute macro declares the typed PDA seeds for an
+/// `#[account]` struct and generates derivation, verification, and CPI
+/// signing helpers.
+///
+/// #### Attributes
+///
+/// - `seeds` - (required) the typed PDA seed list. Each element is either a
+///   byte-string literal (`b"counter"`) or a typed dynamic seed
+///   (`authority: Address`). Supported types: `Address`, `u8`, `u16`, `u32`,
+///   `u64`, and `[u8; N]` (with `N <= 32`). At most 16 seeds are allowed
+///   before the bump seed.
+/// - `bump` - (optional) the name of the field that stores the PDA bump
+///   seed. When present, the generated `assert_seeds` method verifies the
+///   account against the stored bump instead of searching for the canonical
+///   one.
+/// - `crate` - (optional) the path to the `pina` crate. Defaults to `::pina`.
+///
+/// #### Codegen
+///
+/// It will transform the following:
+///
+/// ```ignore
+/// use pina::*;
+///
+/// #[account(discriminator = CounterAccount)]
+/// #[pda(seeds = [b"counter", authority: Address], bump = bump)]
+/// pub struct CounterState {
+/// 	/// The authority whose address seeds the PDA.
+/// 	pub authority: Address,
+/// 	/// The PDA bump seed, stored on-chain so we don't need to re-derive it.
+/// 	pub bump: u8,
+/// }
+/// ```
+///
+/// Is transformed to:
+///
+/// ```ignore
+/// #[account(discriminator = CounterAccount)]
+/// pub struct CounterState {
+/// 	/// The authority whose address seeds the PDA.
+/// 	pub authority: Address,
+/// 	/// The PDA bump seed, stored on-chain so we don't need to re-derive it.
+/// 	pub bump: u8,
+/// }
+///
+/// /// The PDA seeds for `CounterState`.
+/// pub struct CounterSeeds<'a> {
+/// 	/// The `authority` seed.
+/// 	pub authority: &'a Address,
+/// }
+///
+/// /// The PDA seeds for `CounterState`, including the bump seed.
+/// pub struct CounterSeedsWithBump<'a> {
+/// 	inner: CounterSeeds<'a>,
+/// 	_bump: [u8; 1],
+/// }
+///
+/// impl CounterState {
+/// 	/// Build the PDA seeds for this account.
+/// 	pub fn seeds(authority: &Address) -> CounterSeeds<'_> {
+/// 		CounterSeeds { authority }
+/// 	}
+///
+/// 	/// Find the canonical PDA for this account and its bump seed.
+/// 	pub fn try_find_pda(authority: &Address, program_id: &Address) -> Option<(Address, u8)> {
+/// 		let seeds = Self::seeds(authority);
+/// 		::pina::try_find_program_address(&seeds.as_slices(), program_id)
+/// 	}
+///
+/// 	/// Find the canonical PDA for this account and its bump seed.
+/// 	///
+/// 	/// # Panics
+/// 	///
+/// 	/// Panics if no valid PDA exists for the given seeds.
+/// 	pub fn find_pda(authority: &Address, program_id: &Address) -> (Address, u8) {
+/// 		Self::try_find_pda(authority, program_id)
+/// 			.unwrap_or_else(|| panic!("could not find program address from seeds"))
+/// 	}
+///
+/// 	/// Assert that `account` is the PDA for the given seeds, using the
+/// 	/// stored `bump` field.
+/// 	pub fn assert_seeds(
+/// 		account: &AccountView,
+/// 		authority: &Address,
+/// 		program_id: &Address,
+/// 	) -> Result<(), ProgramError> {
+/// 		let bump = ::pina::AsAccount::as_account::<Self>(account, program_id)?.bump;
+/// 		let seeds = Self::seeds(authority).with_bump(bump);
+/// 		::pina::AccountValidation::assert_seeds_with_bump(account, &seeds.as_slices(), program_id)
+/// 	}
+/// }
+///
+/// impl<'a> CounterSeeds<'a> {
+/// 	/// The seeds as byte slices, without the bump seed.
+/// 	pub fn as_slices(&self) -> [&[u8]; 2] {
+/// 		[b"counter", self.authority.as_ref()]
+/// 	}
+///
+/// 	/// Append the bump seed to the seeds.
+/// 	pub fn with_bump(self, bump: u8) -> CounterSeedsWithBump<'a> {
+/// 		CounterSeedsWithBump { inner: self, _bump: [bump] }
+/// 	}
+/// }
+///
+/// impl<'a> CounterSeedsWithBump<'a> {
+/// 	/// The seeds as byte slices, including the bump seed.
+/// 	pub fn as_slices(&self) -> [&[u8]; 3] {
+/// 		[b"counter", self.inner.authority.as_ref(), &self._bump]
+/// 	}
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn pda(args: TokenStream, input: TokenStream) -> TokenStream {
+	pda_impl(args.into(), input.into()).into()
+}
+
+fn pda_impl(
+	args: proc_macro2::TokenStream,
+	input: proc_macro2::TokenStream,
+) -> proc_macro2::TokenStream {
+	// Parse macro arguments
+	let args = match syn::parse2::<PdaArgs>(args) {
+		Ok(v) => v,
+		Err(e) => return e.to_compile_error(),
+	};
+
+	// Parse input struct
+	let item_struct: ItemStruct = match syn::parse2(input) {
+		Ok(v) => v,
+		Err(e) => return e.to_compile_error(),
+	};
+
+	// Extract configuration
+	let struct_name = &item_struct.ident;
+	let crate_path = &args.crate_path;
+	let seeds_name = format_ident!("{}Seeds", struct_name);
+	let seeds_with_bump_name = format_ident!("{}SeedsWithBump", struct_name);
+
+	// Validate the struct has named fields
+	let named_fields = match &item_struct.fields {
+		Fields::Named(named) => &named.named,
+		_ => {
+			return syn::Error::new_spanned(
+				item_struct,
+				"`#[pda]` can only be applied to structs with named fields",
+			)
+			.to_compile_error();
+		}
+	};
+
+	// Validate the bump field exists and is a `u8`
+	if let Some(bump_field) = &args.bump {
+		let field = named_fields
+			.iter()
+			.find(|f| f.ident.as_ref() == Some(bump_field));
+		let Some(field) = field else {
+			return syn::Error::new_spanned(
+				bump_field,
+				format!("`bump` field `{bump_field}` was not found on `{struct_name}`"),
+			)
+			.to_compile_error();
+		};
+
+		let is_u8 = matches!(
+			&field.ty,
+			Type::Path(type_path) if type_path.path.is_ident("u8")
+		);
+		if !is_u8 {
+			return syn::Error::new_spanned(
+				&field.ty,
+				format!("`bump` field `{bump_field}` must have type `u8`"),
+			)
+			.to_compile_error();
+		}
+	}
+
+	// Build the seed struct fields, constructor params, and slice expressions
+	let mut seed_fields = Vec::new();
+	let mut seed_field_docs = Vec::new();
+	let mut seed_params = Vec::new();
+	let mut seeds_params_lt = Vec::new();
+	let mut seed_param_names = Vec::new();
+	let mut seed_stored_exprs = Vec::new();
+	let mut seed_slice_exprs = Vec::new();
+	let mut seed_slice_exprs_with_bump = Vec::new();
+	let mut seed_constants = Vec::new();
+
+	for seed in &args.seeds {
+		match seed {
+			PdaSeedArg::Constant(value) => {
+				let lit = syn::LitByteStr::new(value, proc_macro2::Span::call_site());
+				seed_constants.push(quote!(#lit));
+			}
+			PdaSeedArg::ConstantRef(path) => {
+				seed_constants.push(quote!(#path));
+			}
+			PdaSeedArg::Variable { name, ty } => {
+				let field_type = ty.field_type();
+				let param_type = ty.param_type();
+				let param_type_lt = ty.param_type_lt();
+				let stored_expr = ty.to_stored_expr(name);
+				let slice_expr = ty.slice_expr(name);
+				let slice_expr_with_bump = ty.slice_expr_inner(name);
+				let doc = format!("The `{name}` seed.");
+
+				seed_fields.push(quote!(pub #name: #field_type));
+				seed_field_docs.push(quote!(#[doc = #doc]));
+				seed_params.push(quote!(#name: #param_type));
+				seeds_params_lt.push(quote!(#name: #param_type_lt));
+				seed_param_names.push(name.clone());
+				seed_stored_exprs.push(stored_expr);
+				seed_slice_exprs.push(slice_expr);
+				seed_slice_exprs_with_bump.push(slice_expr_with_bump);
+			}
+		}
+	}
+
+	let seed_count = args.seeds.len();
+	let seed_count_with_bump = seed_count + 1;
+	let seeds_doc = format!("The PDA seeds for `{struct_name}`.");
+	let seeds_with_bump_doc =
+		format!("The PDA seeds for `{struct_name}`, including the bump seed.");
+
+	// The `seeds()` constructor params (with a shared lifetime) and the
+	// `try_find_pda`/`find_pda`/`assert_seeds` params
+	let seeds_params = seeds_params_lt;
+	let find_params = {
+		let mut params = seed_params.clone();
+		params.push(quote!(program_id: &Address));
+		params
+	};
+
+	// The `assert_seeds` method (only when a bump field is declared)
+	let assert_seeds = args.bump.as_ref().map(|bump_field| {
+		let doc = format!(
+			"Assert that `account` is the PDA for the given seeds, using the stored \
+			 `{bump_field}` field."
+		);
+		quote! {
+			#[doc = #doc]
+			pub fn assert_seeds(
+				account: &#crate_path::AccountView,
+				#(#seed_params,)*
+				program_id: &#crate_path::Address,
+			) -> ::core::result::Result<(), #crate_path::ProgramError> {
+				let bump = #crate_path::AsAccount::as_account::<Self>(account, program_id)?.bump;
+				let seeds = Self::seeds(#(#seed_param_names,)*).with_bump(bump);
+				<&#crate_path::AccountView as #crate_path::AccountInfoValidation>::assert_seeds_with_bump(
+					account,
+					&seeds.as_slices(),
+					program_id,
+				)
+				.map(|_| ())
+			}
+		}
+	});
+
+	let generated = quote! {
+		#[doc = #seeds_doc]
+		#[derive(Clone, Copy)]
+		pub struct #seeds_name<'a> {
+			#(#seed_field_docs)*
+			#(#seed_fields,)*
+		}
+
+		#[doc = #seeds_with_bump_doc]
+		pub struct #seeds_with_bump_name<'a> {
+			inner: #seeds_name<'a>,
+			_bump: [u8; 1],
+		}
+
+		impl #struct_name {
+			/// Build the PDA seeds for this account.
+			pub fn seeds<'a>(#(#seeds_params,)*) -> #seeds_name<'a> {
+				#seeds_name {
+					#(#seed_param_names: #seed_stored_exprs,)*
+				}
+			}
+
+			/// Find the canonical PDA for this account and its bump seed.
+			pub fn try_find_pda(#(#find_params,)*) -> ::core::option::Option<(#crate_path::Address, u8)> {
+				let seeds = Self::seeds(#(#seed_param_names,)*);
+				#crate_path::try_find_program_address(&seeds.as_slices(), program_id)
+			}
+
+			/// Find the canonical PDA for this account and its bump seed.
+			///
+			/// # Panics
+			///
+			/// Panics if no valid PDA exists for the given seeds.
+			pub fn find_pda(#(#find_params,)*) -> (#crate_path::Address, u8) {
+				Self::try_find_pda(#(#seed_param_names,)* program_id)
+					.unwrap_or_else(|| panic!("could not find program address from seeds"))
+			}
+
+			#assert_seeds
+		}
+
+		impl<'a> #seeds_name<'a> {
+			/// The seeds as byte slices, without the bump seed.
+			pub fn as_slices(&self) -> [&[u8]; #seed_count] {
+				[#(#seed_constants,)* #(#seed_slice_exprs,)*]
+			}
+
+			/// Append the bump seed to the seeds.
+			pub fn with_bump(&self, bump: u8) -> #seeds_with_bump_name<'a> {
+				#seeds_with_bump_name {
+					inner: *self,
+					_bump: [bump],
+				}
+			}
+		}
+
+		impl<'a> #seeds_with_bump_name<'a> {
+			/// The seeds as byte slices, including the bump seed.
+			pub fn as_slices(&self) -> [&[u8]; #seed_count_with_bump] {
+				[#(#seed_constants,)* #(#seed_slice_exprs_with_bump,)* &self._bump]
+			}
+		}
+	};
+
+	quote! {
+		#item_struct
+		#generated
+	}
+}
+
 /// The instruction macro is used to annotate instruction data that will exist
 /// within a solana instruction.
 ///
@@ -1101,7 +1430,7 @@ fn account_impl(
 ///
 /// It will transform the following:
 ///
-/// ```rust
+/// ```ignore
 /// use pina::*;
 ///
 /// #[discriminator(crate = ::pina, primitive = u8, final)]
@@ -1437,7 +1766,7 @@ fn instruction_impl(
 ///
 /// It will transform the following:
 ///
-/// ```rust
+/// ```ignore
 /// use pina::*;
 ///
 /// #[discriminator(primitive = u8)]

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__pda_all_seed_types.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__pda_all_seed_types.snap
@@ -1,0 +1,141 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+pub struct TestState {
+    pub authority: Address,
+    pub amount: PodU64,
+    pub side: u8,
+    pub tag: [u8; 8],
+    pub width: PodU16,
+    pub height: PodU32,
+    pub bump: u8,
+}
+///The PDA seeds for `TestState`.
+#[derive(Clone, Copy)]
+pub struct TestStateSeeds<'a> {
+    ///The `authority` seed.
+    ///The `amount` seed.
+    ///The `side` seed.
+    ///The `tag` seed.
+    ///The `width` seed.
+    ///The `height` seed.
+    pub authority: &'a Address,
+    pub amount: [u8; 8],
+    pub side: [u8; 1],
+    pub tag: [u8; 8usize],
+    pub width: [u8; 2],
+    pub height: [u8; 4],
+}
+///The PDA seeds for `TestState`, including the bump seed.
+pub struct TestStateSeedsWithBump<'a> {
+    inner: TestStateSeeds<'a>,
+    _bump: [u8; 1],
+}
+impl TestState {
+    /// Build the PDA seeds for this account.
+    pub fn seeds<'a>(
+        authority: &'a Address,
+        amount: u64,
+        side: u8,
+        tag: [u8; 8usize],
+        width: u16,
+        height: u32,
+    ) -> TestStateSeeds<'a> {
+        TestStateSeeds {
+            authority: authority,
+            amount: amount.to_le_bytes(),
+            side: [side],
+            tag: tag,
+            width: width.to_le_bytes(),
+            height: height.to_le_bytes(),
+        }
+    }
+    /// Find the canonical PDA for this account and its bump seed.
+    pub fn try_find_pda(
+        authority: &Address,
+        amount: u64,
+        side: u8,
+        tag: [u8; 8usize],
+        width: u16,
+        height: u32,
+        program_id: &Address,
+    ) -> ::core::option::Option<(::pina::Address, u8)> {
+        let seeds = Self::seeds(authority, amount, side, tag, width, height);
+        ::pina::try_find_program_address(&seeds.as_slices(), program_id)
+    }
+    /// Find the canonical PDA for this account and its bump seed.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no valid PDA exists for the given seeds.
+    pub fn find_pda(
+        authority: &Address,
+        amount: u64,
+        side: u8,
+        tag: [u8; 8usize],
+        width: u16,
+        height: u32,
+        program_id: &Address,
+    ) -> (::pina::Address, u8) {
+        Self::try_find_pda(authority, amount, side, tag, width, height, program_id)
+            .unwrap_or_else(|| panic!("could not find program address from seeds"))
+    }
+    ///Assert that `account` is the PDA for the given seeds, using the stored `bump` field.
+    pub fn assert_seeds(
+        account: &::pina::AccountView,
+        authority: &Address,
+        amount: u64,
+        side: u8,
+        tag: [u8; 8usize],
+        width: u16,
+        height: u32,
+        program_id: &::pina::Address,
+    ) -> ::core::result::Result<(), ::pina::ProgramError> {
+        let bump = ::pina::AsAccount::as_account::<Self>(account, program_id)?.bump;
+        let seeds = Self::seeds(authority, amount, side, tag, width, height)
+            .with_bump(bump);
+        <&::pina::AccountView as ::pina::AccountInfoValidation>::assert_seeds_with_bump(
+                account,
+                &seeds.as_slices(),
+                program_id,
+            )
+            .map(|_| ())
+    }
+}
+impl<'a> TestStateSeeds<'a> {
+    /// The seeds as byte slices, without the bump seed.
+    pub fn as_slices(&self) -> [&[u8]; 7usize] {
+        [
+            b"test",
+            self.authority.as_ref(),
+            &self.amount,
+            &self.side,
+            &self.tag,
+            &self.width,
+            &self.height,
+        ]
+    }
+    /// Append the bump seed to the seeds.
+    pub fn with_bump(&self, bump: u8) -> TestStateSeedsWithBump<'a> {
+        TestStateSeedsWithBump {
+            inner: *self,
+            _bump: [bump],
+        }
+    }
+}
+impl<'a> TestStateSeedsWithBump<'a> {
+    /// The seeds as byte slices, including the bump seed.
+    pub fn as_slices(&self) -> [&[u8]; 8usize] {
+        [
+            b"test",
+            self.inner.authority.as_ref(),
+            &self.inner.amount,
+            &self.inner.side,
+            &self.inner.tag,
+            &self.inner.width,
+            &self.inner.height,
+            &self._bump,
+        ]
+    }
+}

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__pda_basic_address_seed_with_bump.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__pda_basic_address_seed_with_bump.snap
@@ -1,0 +1,78 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+pub struct CounterState {
+    pub authority: Address,
+    pub bump: u8,
+}
+///The PDA seeds for `CounterState`.
+#[derive(Clone, Copy)]
+pub struct CounterStateSeeds<'a> {
+    ///The `authority` seed.
+    pub authority: &'a Address,
+}
+///The PDA seeds for `CounterState`, including the bump seed.
+pub struct CounterStateSeedsWithBump<'a> {
+    inner: CounterStateSeeds<'a>,
+    _bump: [u8; 1],
+}
+impl CounterState {
+    /// Build the PDA seeds for this account.
+    pub fn seeds<'a>(authority: &'a Address) -> CounterStateSeeds<'a> {
+        CounterStateSeeds {
+            authority: authority,
+        }
+    }
+    /// Find the canonical PDA for this account and its bump seed.
+    pub fn try_find_pda(
+        authority: &Address,
+        program_id: &Address,
+    ) -> ::core::option::Option<(::pina::Address, u8)> {
+        let seeds = Self::seeds(authority);
+        ::pina::try_find_program_address(&seeds.as_slices(), program_id)
+    }
+    /// Find the canonical PDA for this account and its bump seed.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no valid PDA exists for the given seeds.
+    pub fn find_pda(authority: &Address, program_id: &Address) -> (::pina::Address, u8) {
+        Self::try_find_pda(authority, program_id)
+            .unwrap_or_else(|| panic!("could not find program address from seeds"))
+    }
+    ///Assert that `account` is the PDA for the given seeds, using the stored `bump` field.
+    pub fn assert_seeds(
+        account: &::pina::AccountView,
+        authority: &Address,
+        program_id: &::pina::Address,
+    ) -> ::core::result::Result<(), ::pina::ProgramError> {
+        let bump = ::pina::AsAccount::as_account::<Self>(account, program_id)?.bump;
+        let seeds = Self::seeds(authority).with_bump(bump);
+        <&::pina::AccountView as ::pina::AccountInfoValidation>::assert_seeds_with_bump(
+                account,
+                &seeds.as_slices(),
+                program_id,
+            )
+            .map(|_| ())
+    }
+}
+impl<'a> CounterStateSeeds<'a> {
+    /// The seeds as byte slices, without the bump seed.
+    pub fn as_slices(&self) -> [&[u8]; 2usize] {
+        [b"counter", self.authority.as_ref()]
+    }
+    /// Append the bump seed to the seeds.
+    pub fn with_bump(&self, bump: u8) -> CounterStateSeedsWithBump<'a> {
+        CounterStateSeedsWithBump {
+            inner: *self,
+            _bump: [bump],
+        }
+    }
+}
+impl<'a> CounterStateSeedsWithBump<'a> {
+    /// The seeds as byte slices, including the bump seed.
+    pub fn as_slices(&self) -> [&[u8]; 3usize] {
+        [b"counter", self.inner.authority.as_ref(), &self._bump]
+    }
+}

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__pda_constant_ref_seed.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__pda_constant_ref_seed.snap
@@ -1,0 +1,78 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+pub struct CounterState {
+    pub authority: Address,
+    pub bump: u8,
+}
+///The PDA seeds for `CounterState`.
+#[derive(Clone, Copy)]
+pub struct CounterStateSeeds<'a> {
+    ///The `authority` seed.
+    pub authority: &'a Address,
+}
+///The PDA seeds for `CounterState`, including the bump seed.
+pub struct CounterStateSeedsWithBump<'a> {
+    inner: CounterStateSeeds<'a>,
+    _bump: [u8; 1],
+}
+impl CounterState {
+    /// Build the PDA seeds for this account.
+    pub fn seeds<'a>(authority: &'a Address) -> CounterStateSeeds<'a> {
+        CounterStateSeeds {
+            authority: authority,
+        }
+    }
+    /// Find the canonical PDA for this account and its bump seed.
+    pub fn try_find_pda(
+        authority: &Address,
+        program_id: &Address,
+    ) -> ::core::option::Option<(::pina::Address, u8)> {
+        let seeds = Self::seeds(authority);
+        ::pina::try_find_program_address(&seeds.as_slices(), program_id)
+    }
+    /// Find the canonical PDA for this account and its bump seed.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no valid PDA exists for the given seeds.
+    pub fn find_pda(authority: &Address, program_id: &Address) -> (::pina::Address, u8) {
+        Self::try_find_pda(authority, program_id)
+            .unwrap_or_else(|| panic!("could not find program address from seeds"))
+    }
+    ///Assert that `account` is the PDA for the given seeds, using the stored `bump` field.
+    pub fn assert_seeds(
+        account: &::pina::AccountView,
+        authority: &Address,
+        program_id: &::pina::Address,
+    ) -> ::core::result::Result<(), ::pina::ProgramError> {
+        let bump = ::pina::AsAccount::as_account::<Self>(account, program_id)?.bump;
+        let seeds = Self::seeds(authority).with_bump(bump);
+        <&::pina::AccountView as ::pina::AccountInfoValidation>::assert_seeds_with_bump(
+                account,
+                &seeds.as_slices(),
+                program_id,
+            )
+            .map(|_| ())
+    }
+}
+impl<'a> CounterStateSeeds<'a> {
+    /// The seeds as byte slices, without the bump seed.
+    pub fn as_slices(&self) -> [&[u8]; 2usize] {
+        [COUNTER_SEED, self.authority.as_ref()]
+    }
+    /// Append the bump seed to the seeds.
+    pub fn with_bump(&self, bump: u8) -> CounterStateSeedsWithBump<'a> {
+        CounterStateSeedsWithBump {
+            inner: *self,
+            _bump: [bump],
+        }
+    }
+}
+impl<'a> CounterStateSeedsWithBump<'a> {
+    /// The seeds as byte slices, including the bump seed.
+    pub fn as_slices(&self) -> [&[u8]; 3usize] {
+        [COUNTER_SEED, self.inner.authority.as_ref(), &self._bump]
+    }
+}

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__pda_default_crate_path.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__pda_default_crate_path.snap
@@ -1,0 +1,76 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+pub struct TodoState {
+    pub owner: Address,
+    pub bump: u8,
+}
+///The PDA seeds for `TodoState`.
+#[derive(Clone, Copy)]
+pub struct TodoStateSeeds<'a> {
+    ///The `owner` seed.
+    pub owner: &'a Address,
+}
+///The PDA seeds for `TodoState`, including the bump seed.
+pub struct TodoStateSeedsWithBump<'a> {
+    inner: TodoStateSeeds<'a>,
+    _bump: [u8; 1],
+}
+impl TodoState {
+    /// Build the PDA seeds for this account.
+    pub fn seeds<'a>(owner: &'a Address) -> TodoStateSeeds<'a> {
+        TodoStateSeeds { owner: owner }
+    }
+    /// Find the canonical PDA for this account and its bump seed.
+    pub fn try_find_pda(
+        owner: &Address,
+        program_id: &Address,
+    ) -> ::core::option::Option<(::pina::Address, u8)> {
+        let seeds = Self::seeds(owner);
+        ::pina::try_find_program_address(&seeds.as_slices(), program_id)
+    }
+    /// Find the canonical PDA for this account and its bump seed.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no valid PDA exists for the given seeds.
+    pub fn find_pda(owner: &Address, program_id: &Address) -> (::pina::Address, u8) {
+        Self::try_find_pda(owner, program_id)
+            .unwrap_or_else(|| panic!("could not find program address from seeds"))
+    }
+    ///Assert that `account` is the PDA for the given seeds, using the stored `bump` field.
+    pub fn assert_seeds(
+        account: &::pina::AccountView,
+        owner: &Address,
+        program_id: &::pina::Address,
+    ) -> ::core::result::Result<(), ::pina::ProgramError> {
+        let bump = ::pina::AsAccount::as_account::<Self>(account, program_id)?.bump;
+        let seeds = Self::seeds(owner).with_bump(bump);
+        <&::pina::AccountView as ::pina::AccountInfoValidation>::assert_seeds_with_bump(
+                account,
+                &seeds.as_slices(),
+                program_id,
+            )
+            .map(|_| ())
+    }
+}
+impl<'a> TodoStateSeeds<'a> {
+    /// The seeds as byte slices, without the bump seed.
+    pub fn as_slices(&self) -> [&[u8]; 2usize] {
+        [b"todo", self.owner.as_ref()]
+    }
+    /// Append the bump seed to the seeds.
+    pub fn with_bump(&self, bump: u8) -> TodoStateSeedsWithBump<'a> {
+        TodoStateSeedsWithBump {
+            inner: *self,
+            _bump: [bump],
+        }
+    }
+}
+impl<'a> TodoStateSeedsWithBump<'a> {
+    /// The seeds as byte slices, including the bump seed.
+    pub fn as_slices(&self) -> [&[u8]; 3usize] {
+        [b"todo", self.inner.owner.as_ref(), &self._bump]
+    }
+}

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__pda_without_bump_field.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__pda_without_bump_field.snap
@@ -1,0 +1,60 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+pub struct VaultState {
+    pub user: Address,
+}
+///The PDA seeds for `VaultState`.
+#[derive(Clone, Copy)]
+pub struct VaultStateSeeds<'a> {
+    ///The `user` seed.
+    pub user: &'a Address,
+}
+///The PDA seeds for `VaultState`, including the bump seed.
+pub struct VaultStateSeedsWithBump<'a> {
+    inner: VaultStateSeeds<'a>,
+    _bump: [u8; 1],
+}
+impl VaultState {
+    /// Build the PDA seeds for this account.
+    pub fn seeds<'a>(user: &'a Address) -> VaultStateSeeds<'a> {
+        VaultStateSeeds { user: user }
+    }
+    /// Find the canonical PDA for this account and its bump seed.
+    pub fn try_find_pda(
+        user: &Address,
+        program_id: &Address,
+    ) -> ::core::option::Option<(::pina::Address, u8)> {
+        let seeds = Self::seeds(user);
+        ::pina::try_find_program_address(&seeds.as_slices(), program_id)
+    }
+    /// Find the canonical PDA for this account and its bump seed.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no valid PDA exists for the given seeds.
+    pub fn find_pda(user: &Address, program_id: &Address) -> (::pina::Address, u8) {
+        Self::try_find_pda(user, program_id)
+            .unwrap_or_else(|| panic!("could not find program address from seeds"))
+    }
+}
+impl<'a> VaultStateSeeds<'a> {
+    /// The seeds as byte slices, without the bump seed.
+    pub fn as_slices(&self) -> [&[u8]; 2usize] {
+        [b"vault", self.user.as_ref()]
+    }
+    /// Append the bump seed to the seeds.
+    pub fn with_bump(&self, bump: u8) -> VaultStateSeedsWithBump<'a> {
+        VaultStateSeedsWithBump {
+            inner: *self,
+            _bump: [bump],
+        }
+    }
+}
+impl<'a> VaultStateSeedsWithBump<'a> {
+    /// The seeds as byte slices, including the bump seed.
+    pub fn as_slices(&self) -> [&[u8]; 3usize] {
+        [b"vault", self.inner.user.as_ref(), &self._bump]
+    }
+}

--- a/crates/pina_macros/src/tests.rs
+++ b/crates/pina_macros/src/tests.rs
@@ -6,6 +6,7 @@ use crate::discriminator_impl;
 use crate::error_impl;
 use crate::event_impl;
 use crate::instruction_impl;
+use crate::pda_impl;
 
 /// Format a `proc_macro2::TokenStream` into a readable Rust string using
 /// `prettyplease`.
@@ -517,4 +518,89 @@ fn accounts_derive_default_crate() {
 	};
 	let output = pretty(accounts_derive_impl(input));
 	insta::assert_snapshot!("accounts_derive_default_crate", output);
+}
+
+// ---------------------------------------------------------------------------
+// #[pda] snapshots
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pda_basic_address_seed_with_bump() {
+	let args = quote! { crate = ::pina, seeds = [b"counter", authority: Address], bump = bump };
+	let input = quote! {
+		pub struct CounterState {
+			pub authority: Address,
+			pub bump: u8,
+		}
+	};
+	let output = pretty(pda_impl(args, input));
+	insta::assert_snapshot!("pda_basic_address_seed_with_bump", output);
+}
+
+#[test]
+fn pda_all_seed_types() {
+	let args = quote! {
+		crate = ::pina,
+		seeds = [
+			b"test",
+			authority: Address,
+			amount: u64,
+			side: u8,
+			tag: [u8; 8],
+			width: u16,
+			height: u32,
+		],
+		bump = bump,
+	};
+	let input = quote! {
+		pub struct TestState {
+			pub authority: Address,
+			pub amount: PodU64,
+			pub side: u8,
+			pub tag: [u8; 8],
+			pub width: PodU16,
+			pub height: PodU32,
+			pub bump: u8,
+		}
+	};
+	let output = pretty(pda_impl(args, input));
+	insta::assert_snapshot!("pda_all_seed_types", output);
+}
+
+#[test]
+fn pda_without_bump_field() {
+	let args = quote! { crate = ::pina, seeds = [b"vault", user: Address] };
+	let input = quote! {
+		pub struct VaultState {
+			pub user: Address,
+		}
+	};
+	let output = pretty(pda_impl(args, input));
+	insta::assert_snapshot!("pda_without_bump_field", output);
+}
+
+#[test]
+fn pda_default_crate_path() {
+	let args = quote! { seeds = [b"todo", owner: Address], bump = bump };
+	let input = quote! {
+		pub struct TodoState {
+			pub owner: Address,
+			pub bump: u8,
+		}
+	};
+	let output = pretty(pda_impl(args, input));
+	insta::assert_snapshot!("pda_default_crate_path", output);
+}
+
+#[test]
+fn pda_constant_ref_seed() {
+	let args = quote! { crate = ::pina, seeds = [COUNTER_SEED, authority: Address], bump = bump };
+	let input = quote! {
+		pub struct CounterState {
+			pub authority: Address,
+			pub bump: u8,
+		}
+	};
+	let output = pretty(pda_impl(args, input));
+	insta::assert_snapshot!("pda_constant_ref_seed", output);
 }

--- a/crates/pina_macros/tests/ui/fail/pda_bump_field_missing.rs
+++ b/crates/pina_macros/tests/ui/fail/pda_bump_field_missing.rs
@@ -1,0 +1,9 @@
+use pina::*;
+
+#[account(discriminator = TestAccount)]
+#[pda(seeds = [b"test", authority: Address], bump = missing)]
+pub struct TestAccount {
+	pub authority: Address,
+}
+
+fn main() {}

--- a/crates/pina_macros/tests/ui/fail/pda_bump_field_missing.stderr
+++ b/crates/pina_macros/tests/ui/fail/pda_bump_field_missing.stderr
@@ -1,0 +1,5 @@
+error: `bump` field `missing` was not found on `TestAccount`
+ --> tests/ui/fail/pda_bump_field_missing.rs:4:53
+  |
+4 | #[pda(seeds = [b"test", authority: Address], bump = missing)]
+  |                                                     ^^^^^^^

--- a/crates/pina_macros/tests/ui/fail/pda_bump_field_wrong_type.rs
+++ b/crates/pina_macros/tests/ui/fail/pda_bump_field_wrong_type.rs
@@ -1,0 +1,10 @@
+use pina::*;
+
+#[account(discriminator = TestAccount)]
+#[pda(seeds = [b"test", authority: Address], bump = bump)]
+pub struct TestAccount {
+	pub authority: Address,
+	pub bump: PodU64,
+}
+
+fn main() {}

--- a/crates/pina_macros/tests/ui/fail/pda_bump_field_wrong_type.stderr
+++ b/crates/pina_macros/tests/ui/fail/pda_bump_field_wrong_type.stderr
@@ -1,0 +1,5 @@
+error: `bump` field `bump` must have type `u8`
+ --> tests/ui/fail/pda_bump_field_wrong_type.rs:7:12
+  |
+7 |     pub bump: PodU64,
+  |               ^^^^^^

--- a/crates/pina_macros/tests/ui/fail/pda_missing_seeds.rs
+++ b/crates/pina_macros/tests/ui/fail/pda_missing_seeds.rs
@@ -1,0 +1,9 @@
+use pina::*;
+
+#[account(discriminator = TestAccount)]
+#[pda(bump = bump)]
+pub struct TestAccount {
+	pub bump: u8,
+}
+
+fn main() {}

--- a/crates/pina_macros/tests/ui/fail/pda_missing_seeds.stderr
+++ b/crates/pina_macros/tests/ui/fail/pda_missing_seeds.stderr
@@ -1,0 +1,7 @@
+error: `seeds` is required (e.g. `seeds = [b"counter", authority: Address]`)
+ --> tests/ui/fail/pda_missing_seeds.rs:4:1
+  |
+4 | #[pda(bump = bump)]
+  | ^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `pda` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/pina_macros/tests/ui/fail/pda_seed_too_long.rs
+++ b/crates/pina_macros/tests/ui/fail/pda_seed_too_long.rs
@@ -1,0 +1,9 @@
+use pina::*;
+
+#[account(discriminator = TestAccount)]
+#[pda(seeds = [b"this seed literal is way too long to be a valid seed"], bump = bump)]
+pub struct TestAccount {
+	pub bump: u8,
+}
+
+fn main() {}

--- a/crates/pina_macros/tests/ui/fail/pda_seed_too_long.stderr
+++ b/crates/pina_macros/tests/ui/fail/pda_seed_too_long.stderr
@@ -1,0 +1,5 @@
+error: seed literal is 52 bytes, exceeds the maximum of 32
+ --> tests/ui/fail/pda_seed_too_long.rs:4:16
+  |
+4 | #[pda(seeds = [b"this seed literal is way too long to be a valid seed"], bump = bump)]
+  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/pina_macros/tests/ui/fail/pda_unknown_argument.rs
+++ b/crates/pina_macros/tests/ui/fail/pda_unknown_argument.rs
@@ -1,0 +1,7 @@
+use pina::*;
+
+#[account(discriminator = TestAccount)]
+#[pda(seeds = [b"test"], unknown = true)]
+pub struct TestAccount {}
+
+fn main() {}

--- a/crates/pina_macros/tests/ui/fail/pda_unknown_argument.stderr
+++ b/crates/pina_macros/tests/ui/fail/pda_unknown_argument.stderr
@@ -1,0 +1,5 @@
+error: unknown `#[pda]` argument `unknown`; expected `seeds`, `bump`, or `crate`
+ --> tests/ui/fail/pda_unknown_argument.rs:4:26
+  |
+4 | #[pda(seeds = [b"test"], unknown = true)]
+  |                          ^^^^^^^

--- a/crates/pina_macros/tests/ui/fail/pda_unsupported_seed_type.rs
+++ b/crates/pina_macros/tests/ui/fail/pda_unsupported_seed_type.rs
@@ -1,0 +1,10 @@
+use pina::*;
+
+#[account(discriminator = TestAccount)]
+#[pda(seeds = [b"test", authority: String], bump = bump)]
+pub struct TestAccount {
+	pub authority: String,
+	pub bump: u8,
+}
+
+fn main() {}

--- a/crates/pina_macros/tests/ui/fail/pda_unsupported_seed_type.stderr
+++ b/crates/pina_macros/tests/ui/fail/pda_unsupported_seed_type.stderr
@@ -1,0 +1,5 @@
+error: unsupported seed type; expected `Address`, `u8`, `u16`, `u32`, `u64`, or `[u8; N]`
+ --> tests/ui/fail/pda_unsupported_seed_type.rs:4:36
+  |
+4 | #[pda(seeds = [b"test", authority: String], bump = bump)]
+  |                                    ^^^^^^

--- a/crates/pina_macros/tests/ui/pass/pda_basic.rs
+++ b/crates/pina_macros/tests/ui/pass/pda_basic.rs
@@ -1,0 +1,27 @@
+use pina::*;
+
+#[discriminator]
+pub enum TestAccountType {
+	TestAccount = 0,
+}
+
+/// Seed prefix for test PDAs.
+const TEST_SEED: &[u8] = b"test";
+
+#[account(discriminator = TestAccountType)]
+#[pda(seeds = [TEST_SEED, authority: Address, amount: u64, side: u8, tag: [u8; 8]], bump = bump)]
+pub struct TestAccount {
+	pub authority: Address,
+	pub amount: PodU64,
+	pub side: u8,
+	pub tag: [u8; 8],
+	pub bump: u8,
+}
+
+fn main() {
+	let authority = Address::new_from_array([1u8; 32]);
+	let seeds = TestAccount::seeds(&authority, 42, 1, [0u8; 8]);
+	let _ = seeds.as_slices();
+	let _ = seeds.with_bump(1).as_slices();
+	let _ = TestAccount::try_find_pda(&authority, 42, 1, [0u8; 8], &authority);
+}

--- a/docs/src/tutorials/token-escrow.md
+++ b/docs/src/tutorials/token-escrow.md
@@ -115,22 +115,29 @@ pub struct TakeInstruction {}
 
 <br>
 
-The escrow PDA is derived from a prefix, the maker's address, and a user-chosen seed:
+The escrow PDA is derived from a prefix, the maker's address, and a user-chosen seed. Pina's `#[pda]` attribute declares the typed seeds once on the account struct:
 
 ```rust
-const SEED_PREFIX: &[u8] = b"escrow";
-
-macro_rules! seeds_escrow {
-	($maker:expr, $seed:expr) => {
-		&[SEED_PREFIX, $maker, $seed]
-	};
-	($maker:expr, $seed:expr, $bump:expr) => {
-		&[SEED_PREFIX, $maker, $seed, &[$bump]]
-	};
+#[account(discriminator = EscrowAccount)]
+#[pda(seeds = [SEED_PREFIX, maker: Address, seed: u64], bump = bump)]
+pub struct EscrowState {
+	pub maker: Address,
+	// ...
+	pub seed: PodU64,
+	pub bump: u8,
 }
+
+/// Seed prefix for escrow PDAs.
+const SEED_PREFIX: &[u8] = b"escrow";
 ```
 
-The seed macro generates the PDA seeds array in both forms: without bump (for `create_program_account_with_bump`) and with bump (for `assert_seeds_with_bump`).
+The attribute generates:
+
+- `EscrowState::seeds(maker, seed)` -- a typed seeds struct with `as_slices()` (without bump) and `with_bump(bump)` (with bump).
+- `EscrowState::try_find_pda(...)` / `find_pda(...)` -- canonical PDA derivation.
+- `EscrowState::assert_seeds(account, ...)` -- verifies an existing account against the stored `bump` field, avoiding a canonical bump search on-chain.
+
+Supported seed types are `Address`, `u8`, `u16`, `u32`, `u64`, `[u8; N]`, and `const &[u8]` references.
 
 ## Make: accounts and validation
 
@@ -161,8 +168,8 @@ impl<'a> ProcessAccountInfos<'a> for MakeAccounts<'a> {
 	fn process(self, data: &[u8]) -> ProgramResult {
 		let args = MakeInstruction::try_from_bytes(data)?;
 		let maker_address = *self.maker.address();
-		let escrow_seeds = seeds_escrow!(maker_address.as_ref(), &args.seed.0);
-		let escrow_seeds_with_bump = seeds_escrow!(maker_address.as_ref(), &args.seed.0, args.bump);
+		let escrow_seeds = EscrowState::seeds(&maker_address, u64::from(args.seed));
+		let escrow_seeds_with_bump = escrow_seeds.with_bump(args.bump);
 
 		// Validate all accounts before mutating anything.
 		self.token_program.assert_addresses(&SPL_PROGRAM_IDS)?;
@@ -177,7 +184,7 @@ impl<'a> ProcessAccountInfos<'a> for MakeAccounts<'a> {
 		self.escrow
 			.assert_empty()?
 			.assert_writable()?
-			.assert_seeds_with_bump(escrow_seeds_with_bump, &ID)?;
+			.assert_seeds_with_bump(&escrow_seeds_with_bump.as_slices(), &ID)?;
 		self.vault
 			.assert_empty()?
 			.assert_writable()?
@@ -214,7 +221,7 @@ create_program_account_with_bump::<EscrowState>(
 	self.escrow,
 	self.maker,
 	&ID,
-	escrow_seeds,
+	&escrow_seeds.as_slices(),
 	args.bump,
 )?;
 
@@ -292,6 +299,10 @@ impl<'a> ProcessAccountInfos<'a> for TakeAccounts<'a> {
 			(escrow.maker, escrow.seed, escrow.bump, escrow.amount_b)
 		};
 
+		// Verify the escrow is the PDA for the maker and seed, using the
+		// stored bump field (avoids re-deriving the canonical bump on-chain).
+		EscrowState::assert_seeds(self.escrow, &maker, u64::from(seed), &ID)?;
+
 		// Transfer token B: taker -> maker
 		token_2022::instructions::TransferChecked {
 			from: self.taker_ata_b,
@@ -305,10 +316,10 @@ impl<'a> ProcessAccountInfos<'a> for TakeAccounts<'a> {
 		.invoke()?;
 
 		// Transfer token A: vault -> taker (PDA-signed)
-		let bump_as_seeds = [bump];
-		let escrow_seeds =
-			seeds_escrow!(true, self.maker.address().as_ref(), &seed.0, &bump_as_seeds);
-		let escrow_signer = Signer::from(&escrow_seeds);
+		let escrow_seeds = EscrowState::seeds(&maker, u64::from(seed));
+		let escrow_seeds_with_bump = escrow_seeds.with_bump(bump);
+		let seed_values = escrow_seeds_with_bump.as_slices().map(Seed::from);
+		let escrow_signer = Signer::from(&seed_values);
 		let signers = [escrow_signer];
 
 		token_2022::instructions::TransferChecked {
@@ -390,16 +401,16 @@ mod tests {
 	}
 
 	#[test]
-	fn seeds_macro_builds_expected_seed_arrays() {
-		let maker = [3u8; 32];
+	fn seeds_build_expected_seed_arrays() {
+		let maker = Address::new_from_array([3u8; 32]);
 		let seed = PodU64::from_primitive(42);
 		let bump = 7u8;
 
-		let seeds = seeds_escrow!(&maker, &seed.0);
-		assert_eq!(seeds.len(), 3);
+		let seeds = EscrowState::seeds(&maker, u64::from(seed));
+		assert_eq!(seeds.as_slices().len(), 3);
 
-		let seeds_with_bump = seeds_escrow!(&maker, &seed.0, bump);
-		assert_eq!(seeds_with_bump.len(), 4);
+		let seeds_with_bump = seeds.with_bump(bump);
+		assert_eq!(seeds_with_bump.as_slices().len(), 4);
 	}
 
 	#[test]

--- a/examples/counter_program/src/lib.rs
+++ b/examples/counter_program/src/lib.rs
@@ -89,6 +89,7 @@ pub enum CounterAccountType {
 /// | 2      | 8    | count (PodU64)|
 /// ```
 #[account(discriminator = CounterAccountType)]
+#[pda(seeds = [COUNTER_SEED, authority: Address], bump = bump)]
 pub struct CounterState {
 	/// The PDA bump seed, stored on-chain so we don't need to re-derive it.
 	pub bump: u8,
@@ -122,21 +123,6 @@ pub struct IncrementInstruction {}
 
 /// Seed prefix for counter PDAs.
 const COUNTER_SEED: &[u8] = b"counter";
-
-/// Build the PDA seeds for a counter account.
-///
-/// Seeds: `["counter", <authority_address>]`
-///
-/// With bump: `["counter", <authority_address>, &[bump]]`
-#[macro_export]
-macro_rules! counter_seeds {
-	($authority:expr) => {
-		&[COUNTER_SEED, $authority]
-	};
-	($authority:expr, $bump:expr) => {
-		&[COUNTER_SEED, $authority, &[$bump]]
-	};
-}
 
 // ---------------------------------------------------------------------------
 // Accounts structs
@@ -175,14 +161,14 @@ impl<'a> ProcessAccountInfos<'a> for InitializeAccounts<'a> {
 		// Parse instruction and prepare PDA seeds
 		let args = InitializeInstruction::try_from_bytes(data)?;
 		let authority_key = self.authority.address();
-		let seeds = counter_seeds!(authority_key.as_ref());
-		let seeds_with_bump = counter_seeds!(authority_key.as_ref(), args.bump);
+		let seeds = CounterState::seeds(authority_key);
+		let seeds_with_bump = seeds.with_bump(args.bump);
 
 		// Validate accounts
 		self.authority.assert_signer()?;
 		self.counter
 			.assert_empty()?
-			.assert_seeds_with_bump(seeds_with_bump, &ID)?;
+			.assert_seeds_with_bump(&seeds_with_bump.as_slices(), &ID)?;
 		self.system_program.assert_address(&system::ID)?;
 
 		// Create the PDA account
@@ -190,7 +176,7 @@ impl<'a> ProcessAccountInfos<'a> for InitializeAccounts<'a> {
 			self.counter,
 			self.authority,
 			&ID,
-			seeds,
+			&seeds.as_slices(),
 			args.bump,
 		)?;
 
@@ -220,12 +206,9 @@ impl<'a> ProcessAccountInfos<'a> for IncrementAccounts<'a> {
 			.assert_not_empty()?
 			.assert_type::<CounterState>(&ID)?;
 
-		let bump = {
-			let counter = self.counter.as_account::<CounterState>(&ID)?;
-			counter.bump
-		};
-		let seeds_with_bump = counter_seeds!(authority_key.as_ref(), bump);
-		self.counter.assert_seeds_with_bump(seeds_with_bump, &ID)?;
+		// Verify the account is the PDA for the authority, using the stored
+		// bump field (avoids re-deriving the canonical bump on-chain).
+		CounterState::assert_seeds(self.counter, authority_key, &ID)?;
 
 		// Mutate state
 		let mut counter = self.counter.as_account_mut::<CounterState>(&ID)?;
@@ -366,22 +349,25 @@ mod tests {
 	}
 
 	#[test]
-	fn counter_seeds_macro() {
-		let authority = [1u8; 32];
-		let seeds = counter_seeds!(&authority);
-		assert_eq!(seeds.len(), 2);
-		assert_eq!(seeds[0], b"counter");
-		assert_eq!(seeds[1], &authority);
+	fn counter_seeds() {
+		let authority = Address::new_from_array([1u8; 32]);
+		let seeds = CounterState::seeds(&authority);
+		let slices = seeds.as_slices();
+		assert_eq!(slices.len(), 2);
+		assert_eq!(slices[0], b"counter");
+		assert_eq!(slices[1], authority.as_ref());
 	}
 
 	#[test]
-	fn counter_seeds_with_bump_macro() {
-		let authority = [1u8; 32];
-		let seeds = counter_seeds!(&authority, 42);
-		assert_eq!(seeds.len(), 3);
-		assert_eq!(seeds[0], b"counter");
-		assert_eq!(seeds[1], &authority);
-		assert_eq!(seeds[2], &[42u8]);
+	fn counter_seeds_with_bump() {
+		let authority = Address::new_from_array([1u8; 32]);
+		let seeds = CounterState::seeds(&authority);
+		let with_bump = seeds.with_bump(42);
+		let slices = with_bump.as_slices();
+		assert_eq!(slices.len(), 3);
+		assert_eq!(slices[0], b"counter");
+		assert_eq!(slices[1], authority.as_ref());
+		assert_eq!(slices[2], &[42u8]);
 	}
 
 	#[test]

--- a/examples/escrow_program/src/lib.rs
+++ b/examples/escrow_program/src/lib.rs
@@ -66,6 +66,7 @@ pub enum EscrowError {
 }
 
 #[account(discriminator = EscrowAccount)]
+#[pda(seeds = [SEED_PREFIX, maker: Address, seed: u64], bump = bump)]
 pub struct EscrowState {
 	pub maker: Address,
 	pub mint_a: Address,
@@ -104,35 +105,18 @@ pub struct MakeAccounts<'a> {
 	pub token_program: &'a AccountView,
 }
 
+/// Seed prefix for escrow PDAs.
 const SEED_PREFIX: &[u8] = b"escrow";
+
 const SPL_PROGRAM_IDS: [Address; 2] = [token::ID, token_2022::ID];
-
-#[macro_export]
-macro_rules! seeds_escrow {
-	($maker:expr, $seed:expr) => {
-		&[SEED_PREFIX, $maker, $seed]
-	};
-
-	($maker:expr, $seed:expr, $bump:expr) => {
-		&[SEED_PREFIX, $maker, $seed, &[$bump]]
-	};
-	(true, $maker:expr, $seed:expr, $bump:expr) => {
-		[
-			Seed::from(SEED_PREFIX),
-			Seed::from($maker),
-			Seed::from($seed),
-			Seed::from($bump),
-		]
-	};
-}
 
 impl<'a> ProcessAccountInfos<'a> for MakeAccounts<'a> {
 	fn process(self, data: &[u8]) -> ProgramResult {
 		// Parse instruction and prepare PDA seeds
 		let args = MakeInstruction::try_from_bytes(data)?;
 		let maker_address = *self.maker.address();
-		let escrow_seeds = seeds_escrow!(maker_address.as_ref(), &args.seed.0);
-		let escrow_seeds_with_bump = seeds_escrow!(maker_address.as_ref(), &args.seed.0, args.bump);
+		let escrow_seeds = EscrowState::seeds(&maker_address, u64::from(args.seed));
+		let escrow_seeds_with_bump = escrow_seeds.with_bump(args.bump);
 
 		// Validate accounts
 		self.token_program.assert_addresses(&SPL_PROGRAM_IDS)?;
@@ -147,7 +131,7 @@ impl<'a> ProcessAccountInfos<'a> for MakeAccounts<'a> {
 		)?;
 		self.escrow
 			.assert_empty()?
-			.assert_seeds_with_bump(escrow_seeds_with_bump, &ID)?;
+			.assert_seeds_with_bump(&escrow_seeds_with_bump.as_slices(), &ID)?;
 		self.vault
 			.assert_empty()?
 			.assert_writable()?
@@ -162,7 +146,7 @@ impl<'a> ProcessAccountInfos<'a> for MakeAccounts<'a> {
 			self.escrow,
 			self.maker,
 			&ID,
-			escrow_seeds,
+			&escrow_seeds.as_slices(),
 			args.bump,
 		)?;
 
@@ -266,9 +250,9 @@ impl<'a> ProcessAccountInfos<'a> for TakeAccounts<'a> {
 			)
 		};
 
-		let escrow_seeds_with_bump = seeds_escrow!(self.maker.address().as_ref(), &seed.0, bump);
-		self.escrow
-			.assert_seeds_with_bump(escrow_seeds_with_bump, &ID)?;
+		// Verify the escrow is the PDA for the maker and seed, using the
+		// stored bump field (avoids re-deriving the canonical bump on-chain).
+		EscrowState::assert_seeds(self.escrow, &maker, u64::from(seed), &ID)?;
 
 		// Validate maker and mint accounts
 		self.maker.assert_address(&maker)?;
@@ -320,10 +304,10 @@ impl<'a> ProcessAccountInfos<'a> for TakeAccounts<'a> {
 		.invoke()?;
 
 		// Prepare escrow signer for vault operations
-		let bump_as_seeds = [bump];
-		let escrow_seeds =
-			seeds_escrow!(true, self.maker.address().as_ref(), &seed.0, &bump_as_seeds);
-		let escrow_signer = Signer::from(&escrow_seeds);
+		let escrow_seeds = EscrowState::seeds(&maker, u64::from(seed));
+		let escrow_seeds_with_bump = escrow_seeds.with_bump(bump);
+		let seed_values = escrow_seeds_with_bump.as_slices().map(Seed::from);
+		let escrow_signer = Signer::from(&seed_values);
 		let signers = [escrow_signer];
 
 		// Transfer token A from vault to taker
@@ -366,23 +350,25 @@ mod tests {
 	}
 
 	#[test]
-	fn seeds_macro_builds_expected_seed_arrays() {
-		let maker = [3u8; 32];
+	fn seeds_build_expected_seed_arrays() {
+		let maker = Address::new_from_array([3u8; 32]);
 		let seed = PodU64::from_primitive(42);
 		let bump = 7u8;
 
-		let seeds = seeds_escrow!(&maker, &seed.0);
-		assert_eq!(seeds.len(), 3);
-		assert_eq!(seeds[0], SEED_PREFIX);
-		assert_eq!(seeds[1], &maker);
-		assert_eq!(seeds[2], &seed.0);
+		let seeds = EscrowState::seeds(&maker, u64::from(seed));
+		let slices = seeds.as_slices();
+		assert_eq!(slices.len(), 3);
+		assert_eq!(slices[0], b"escrow");
+		assert_eq!(slices[1], maker.as_ref());
+		assert_eq!(slices[2], &seed.0);
 
-		let seeds_with_bump = seeds_escrow!(&maker, &seed.0, bump);
-		assert_eq!(seeds_with_bump.len(), 4);
-		assert_eq!(seeds_with_bump[0], SEED_PREFIX);
-		assert_eq!(seeds_with_bump[1], &maker);
-		assert_eq!(seeds_with_bump[2], &seed.0);
-		assert_eq!(seeds_with_bump[3], &[bump]);
+		let with_bump = seeds.with_bump(bump);
+		let slices_with_bump = with_bump.as_slices();
+		assert_eq!(slices_with_bump.len(), 4);
+		assert_eq!(slices_with_bump[0], b"escrow");
+		assert_eq!(slices_with_bump[1], maker.as_ref());
+		assert_eq!(slices_with_bump[2], &seed.0);
+		assert_eq!(slices_with_bump[3], &[bump]);
 	}
 
 	#[test]

--- a/examples/profile_program/src/lib.rs
+++ b/examples/profile_program/src/lib.rs
@@ -109,6 +109,7 @@ pub enum ProfileError {
 /// | 230    | 1    | active (PodBool) |
 /// ```
 #[account(discriminator = ProfileAccountType)]
+#[pda(seeds = [PROFILE_SEED, authority: Address], bump = bump)]
 pub struct ProfileState {
 	/// The PDA bump seed, stored on-chain so we don't need to re-derive it.
 	pub bump: u8,
@@ -174,21 +175,6 @@ pub struct RemoveTagInstruction {
 /// Seed prefix for profile PDAs.
 const PROFILE_SEED: &[u8] = b"profile";
 
-/// Build the PDA seeds for a profile account.
-///
-/// Seeds: `["profile", <authority_address>]`
-///
-/// With bump: `["profile", <authority_address>, &[bump]]`
-#[macro_export]
-macro_rules! profile_seeds {
-	($authority:expr) => {
-		&[PROFILE_SEED, $authority]
-	};
-	($authority:expr, $bump:expr) => {
-		&[PROFILE_SEED, $authority, &[$bump]]
-	};
-}
-
 // ---------------------------------------------------------------------------
 // Accounts structs
 // ---------------------------------------------------------------------------
@@ -222,16 +208,16 @@ impl<'a> ProcessAccountInfos<'a> for InitializeAccounts<'a> {
 	fn process(self, data: &[u8]) -> ProgramResult {
 		// Parse instruction and prepare PDA seeds
 		let args = InitializeInstruction::try_from_bytes(data)?;
+		let authority_key = *self.authority.address();
+		let seeds = ProfileState::seeds(&authority_key);
+		let seeds_with_bump = seeds.with_bump(args.bump);
 
 		// Validate accounts
 		self.authority.assert_signer()?;
 		self.profile
 			.assert_empty()?
 			.assert_writable()?
-			.assert_seeds_with_bump(
-				profile_seeds!(self.authority.address().as_ref(), args.bump),
-				&ID,
-			)?;
+			.assert_seeds_with_bump(&seeds_with_bump.as_slices(), &ID)?;
 		self.system_program.assert_address(&system::ID)?;
 
 		// Validate UTF-8 before storing anything on-chain
@@ -247,7 +233,7 @@ impl<'a> ProcessAccountInfos<'a> for InitializeAccounts<'a> {
 			self.profile,
 			self.authority,
 			&ID,
-			profile_seeds!(self.authority.address().as_ref()),
+			&seeds.as_slices(),
 			args.bump,
 		)?;
 
@@ -278,12 +264,9 @@ impl<'a> ProcessAccountInfos<'a> for ProfileAccounts<'a> {
 			.assert_writable()?
 			.assert_type::<ProfileState>(&ID)?;
 
-		let bump = {
-			let profile = self.profile.as_account::<ProfileState>(&ID)?;
-			profile.bump
-		};
-		let seeds_with_bump = profile_seeds!(authority_key.as_ref(), bump);
-		self.profile.assert_seeds_with_bump(seeds_with_bump, &ID)?;
+		// Verify the profile is the PDA for the authority, using the stored
+		// bump field (avoids re-deriving the canonical bump on-chain).
+		ProfileState::assert_seeds(self.profile, authority_key, &ID)?;
 
 		// Dispatch on the instruction discriminator
 		let instruction = ProfileInstruction::try_from(
@@ -540,22 +523,25 @@ mod tests {
 	}
 
 	#[test]
-	fn profile_seeds_macro() {
-		let authority = [1u8; 32];
-		let seeds = profile_seeds!(&authority);
-		assert_eq!(seeds.len(), 2);
-		assert_eq!(seeds[0], b"profile");
-		assert_eq!(seeds[1], &authority);
+	fn profile_seeds() {
+		let authority = Address::new_from_array([1u8; 32]);
+		let seeds = ProfileState::seeds(&authority);
+		let slices = seeds.as_slices();
+		assert_eq!(slices.len(), 2);
+		assert_eq!(slices[0], b"profile");
+		assert_eq!(slices[1], authority.as_ref());
 	}
 
 	#[test]
-	fn profile_seeds_with_bump_macro() {
-		let authority = [1u8; 32];
-		let seeds = profile_seeds!(&authority, 42);
-		assert_eq!(seeds.len(), 3);
-		assert_eq!(seeds[0], b"profile");
-		assert_eq!(seeds[1], &authority);
-		assert_eq!(seeds[2], &[42u8]);
+	fn profile_seeds_with_bump() {
+		let authority = Address::new_from_array([1u8; 32]);
+		let seeds = ProfileState::seeds(&authority);
+		let with_bump = seeds.with_bump(42);
+		let slices = with_bump.as_slices();
+		assert_eq!(slices.len(), 3);
+		assert_eq!(slices[0], b"profile");
+		assert_eq!(slices[1], authority.as_ref());
+		assert_eq!(slices[2], &[42u8]);
 	}
 
 	#[test]

--- a/examples/role_registry_program/src/lib.rs
+++ b/examples/role_registry_program/src/lib.rs
@@ -82,6 +82,7 @@ pub enum RegistryAccountType {
 }
 
 #[account(discriminator = RegistryAccountType)]
+#[pda(seeds = [REGISTRY_SEED_PREFIX, admin: Address], bump = bump)]
 pub struct RegistryConfig {
 	pub admin: Address,
 	pub role_count: PodU64,
@@ -89,6 +90,7 @@ pub struct RegistryConfig {
 }
 
 #[account(discriminator = RegistryAccountType)]
+#[pda(seeds = [ROLE_ENTRY_SEED_PREFIX, registry: Address, role_id: u64], bump = bump)]
 pub struct RoleEntry {
 	pub registry: Address,
 	pub role_id: PodU64,
@@ -158,47 +160,30 @@ pub struct RotateAdminAccounts<'a> {
 	pub registry_config: &'a mut AccountView,
 }
 
+/// Seed prefix for registry config PDAs.
 const REGISTRY_SEED_PREFIX: &[u8] = b"registry";
+
+/// Seed prefix for role entry PDAs.
 const ROLE_ENTRY_SEED_PREFIX: &[u8] = b"role-entry";
-
-#[macro_export]
-macro_rules! registry_config_seeds {
-	($admin:expr) => {
-		&[REGISTRY_SEED_PREFIX, $admin]
-	};
-	($admin:expr, $bump:expr) => {
-		&[REGISTRY_SEED_PREFIX, $admin, &[$bump]]
-	};
-}
-
-#[macro_export]
-macro_rules! role_entry_seeds {
-	($registry:expr, $role_id:expr) => {
-		&[ROLE_ENTRY_SEED_PREFIX, $registry, $role_id]
-	};
-	($registry:expr, $role_id:expr, $bump:expr) => {
-		&[ROLE_ENTRY_SEED_PREFIX, $registry, $role_id, &[$bump]]
-	};
-}
 
 impl<'a> ProcessAccountInfos<'a> for InitializeAccounts<'a> {
 	fn process(self, data: &[u8]) -> ProgramResult {
 		let args = InitializeInstruction::try_from_bytes(data)?;
 		let admin_address = *self.admin.address();
-		let registry_seeds = registry_config_seeds!(admin_address.as_ref());
-		let registry_seeds_with_bump = registry_config_seeds!(admin_address.as_ref(), args.bump);
+		let registry_seeds = RegistryConfig::seeds(&admin_address);
+		let registry_seeds_with_bump = registry_seeds.with_bump(args.bump);
 
 		self.admin.assert_signer()?;
 		self.system_program.assert_address(&system::ID)?;
 		self.registry_config
 			.assert_empty()?
-			.assert_seeds_with_bump(registry_seeds_with_bump, &ID)?;
+			.assert_seeds_with_bump(&registry_seeds_with_bump.as_slices(), &ID)?;
 
 		create_program_account_with_bump::<RegistryConfig>(
 			self.registry_config,
 			self.admin,
 			&ID,
-			registry_seeds,
+			&registry_seeds.as_slices(),
 			args.bump,
 		)?;
 
@@ -217,9 +202,8 @@ impl<'a> ProcessAccountInfos<'a> for AddRoleAccounts<'a> {
 	fn process(self, data: &[u8]) -> ProgramResult {
 		let args = AddRoleInstruction::try_from_bytes(data)?;
 		let registry_address = *self.registry_config.address();
-		let role_entry_seeds = role_entry_seeds!(registry_address.as_ref(), &args.role_id.0);
-		let role_entry_seeds_with_bump =
-			role_entry_seeds!(registry_address.as_ref(), &args.role_id.0, args.bump);
+		let role_entry_seeds = RoleEntry::seeds(&registry_address, u64::from(args.role_id));
+		let role_entry_seeds_with_bump = role_entry_seeds.with_bump(args.bump);
 
 		self.admin.assert_signer()?;
 		self.system_program.assert_address(&system::ID)?;
@@ -228,7 +212,7 @@ impl<'a> ProcessAccountInfos<'a> for AddRoleAccounts<'a> {
 			.assert_type::<RegistryConfig>(&ID)?;
 		self.role_entry
 			.assert_empty()?
-			.assert_seeds_with_bump(role_entry_seeds_with_bump, &ID)?;
+			.assert_seeds_with_bump(&role_entry_seeds_with_bump.as_slices(), &ID)?;
 
 		let role_count = {
 			let registry_config = self.registry_config.as_account::<RegistryConfig>(&ID)?;
@@ -243,7 +227,7 @@ impl<'a> ProcessAccountInfos<'a> for AddRoleAccounts<'a> {
 			self.role_entry,
 			self.admin,
 			&ID,
-			role_entry_seeds,
+			&role_entry_seeds.as_slices(),
 			args.bump,
 		)?;
 

--- a/examples/staking_rewards_program/src/lib.rs
+++ b/examples/staking_rewards_program/src/lib.rs
@@ -80,6 +80,7 @@ pub enum StakingAccountType {
 }
 
 #[account(discriminator = StakingAccountType)]
+#[pda(seeds = [POOL_SEED_PREFIX, stake_mint: Address, reward_mint: Address], bump = bump)]
 pub struct PoolState {
 	pub admin: Address,
 	pub stake_mint: Address,
@@ -91,6 +92,7 @@ pub struct PoolState {
 }
 
 #[account(discriminator = StakingAccountType)]
+#[pda(seeds = [POSITION_SEED_PREFIX, pool: Address, owner: Address], bump = bump)]
 pub struct PositionState {
 	pub pool: Address,
 	pub owner: Address,
@@ -176,29 +178,13 @@ pub struct ClaimAccounts<'a> {
 	pub system_program: &'a AccountView,
 }
 
+/// Seed prefix for pool PDAs.
 const POOL_SEED_PREFIX: &[u8] = b"pool";
+
+/// Seed prefix for position PDAs.
 const POSITION_SEED_PREFIX: &[u8] = b"position";
+
 const SPL_PROGRAM_IDS: [Address; 2] = [token::ID, token_2022::ID];
-
-#[macro_export]
-macro_rules! pool_seeds {
-	($stake_mint:expr, $reward_mint:expr) => {
-		&[POOL_SEED_PREFIX, $stake_mint, $reward_mint]
-	};
-	($stake_mint:expr, $reward_mint:expr, $bump:expr) => {
-		&[POOL_SEED_PREFIX, $stake_mint, $reward_mint, &[$bump]]
-	};
-}
-
-#[macro_export]
-macro_rules! position_seeds {
-	($pool:expr, $owner:expr) => {
-		&[POSITION_SEED_PREFIX, $pool, $owner]
-	};
-	($pool:expr, $owner:expr, $bump:expr) => {
-		&[POSITION_SEED_PREFIX, $pool, $owner, &[$bump]]
-	};
-}
 
 fn assert_pool_stake_mint(pool_state: &PoolState, stake_mint: &AccountView) -> ProgramResult {
 	stake_mint
@@ -232,15 +218,8 @@ impl<'a> ProcessAccountInfos<'a> for InitializePoolAccounts<'a> {
 	fn process(self, data: &[u8]) -> ProgramResult {
 		// Parse instruction and prepare PDA seeds
 		let args = InitializePoolInstruction::try_from_bytes(data)?;
-		let pool_seeds = pool_seeds!(
-			self.stake_mint.address().as_ref(),
-			self.reward_mint.address().as_ref()
-		);
-		let pool_seeds_with_bump = pool_seeds!(
-			self.stake_mint.address().as_ref(),
-			self.reward_mint.address().as_ref(),
-			args.bump
-		);
+		let pool_seeds = PoolState::seeds(self.stake_mint.address(), self.reward_mint.address());
+		let pool_seeds_with_bump = pool_seeds.with_bump(args.bump);
 
 		// Validate accounts
 		self.admin.assert_signer()?;
@@ -250,7 +229,7 @@ impl<'a> ProcessAccountInfos<'a> for InitializePoolAccounts<'a> {
 		self.token_program.assert_addresses(&SPL_PROGRAM_IDS)?;
 		self.pool_state
 			.assert_empty()?
-			.assert_seeds_with_bump(pool_seeds_with_bump, &ID)?;
+			.assert_seeds_with_bump(&pool_seeds_with_bump.as_slices(), &ID)?;
 		self.stake_vault
 			.assert_empty()?
 			.assert_writable()?
@@ -273,7 +252,7 @@ impl<'a> ProcessAccountInfos<'a> for InitializePoolAccounts<'a> {
 			self.pool_state,
 			self.admin,
 			&ID,
-			pool_seeds,
+			&pool_seeds.as_slices(),
 			args.bump,
 		)?;
 
@@ -321,12 +300,8 @@ impl<'a> ProcessAccountInfos<'a> for OpenPositionAccounts<'a> {
 		// Parse instruction and prepare PDA seeds
 		let args = OpenPositionInstruction::try_from_bytes(data)?;
 		let pool_address = *self.pool_state.address();
-		let position_seeds = position_seeds!(pool_address.as_ref(), self.user.address().as_ref());
-		let position_seeds_with_bump = position_seeds!(
-			pool_address.as_ref(),
-			self.user.address().as_ref(),
-			args.bump
-		);
+		let position_seeds = PositionState::seeds(&pool_address, self.user.address());
+		let position_seeds_with_bump = position_seeds.with_bump(args.bump);
 
 		// Validate accounts
 		self.user.assert_signer()?;
@@ -336,7 +311,7 @@ impl<'a> ProcessAccountInfos<'a> for OpenPositionAccounts<'a> {
 			.assert_type::<PoolState>(&ID)?;
 		self.position_state
 			.assert_empty()?
-			.assert_seeds_with_bump(position_seeds_with_bump, &ID)?;
+			.assert_seeds_with_bump(&position_seeds_with_bump.as_slices(), &ID)?;
 
 		// Check pool is not paused
 		let pool_state = self.pool_state.as_account::<PoolState>(&ID)?;
@@ -349,7 +324,7 @@ impl<'a> ProcessAccountInfos<'a> for OpenPositionAccounts<'a> {
 			self.position_state,
 			self.user,
 			&ID,
-			position_seeds,
+			&position_seeds.as_slices(),
 			args.bump,
 		)?;
 

--- a/examples/todo_program/src/lib.rs
+++ b/examples/todo_program/src/lib.rs
@@ -33,6 +33,7 @@ pub enum TodoAccount {
 }
 
 #[account(discriminator = TodoAccount)]
+#[pda(seeds = [TODO_SEED, owner: Address], bump = bump)]
 pub struct TodoState {
 	pub owner: Address,
 	pub bump: u8,
@@ -54,17 +55,8 @@ pub struct UpdateDigestInstruction {
 	pub digest: [u8; 32],
 }
 
+/// Seed prefix for todo PDAs.
 const TODO_SEED: &[u8] = b"todo";
-
-#[macro_export]
-macro_rules! todo_seeds {
-	($owner:expr) => {
-		&[TODO_SEED, $owner]
-	};
-	($owner:expr, $bump:expr) => {
-		&[TODO_SEED, $owner, &[$bump]]
-	};
-}
 
 #[derive(Accounts, Debug)]
 pub struct InitializeAccounts<'a> {
@@ -84,19 +76,23 @@ impl<'a> ProcessAccountInfos<'a> for InitializeAccounts<'a> {
 		// Parse instruction and prepare PDA seeds
 		let args = InitializeInstruction::try_from_bytes(data)?;
 		let owner = self.owner.address();
-		let seeds = todo_seeds!(owner.as_ref());
-		let seeds_with_bump = todo_seeds!(owner.as_ref(), args.bump);
+		let seeds = TodoState::seeds(owner);
+		let seeds_with_bump = seeds.with_bump(args.bump);
 
 		// Validate accounts
 		self.owner.assert_signer()?;
 		self.todo
 			.assert_empty()?
-			.assert_seeds_with_bump(seeds_with_bump, &ID)?;
+			.assert_seeds_with_bump(&seeds_with_bump.as_slices(), &ID)?;
 		self.system_program.assert_address(&system::ID)?;
 
 		// Create the PDA account
 		create_program_account_with_bump::<TodoState>(
-			self.todo, self.owner, &ID, seeds, args.bump,
+			self.todo,
+			self.owner,
+			&ID,
+			&seeds.as_slices(),
+			args.bump,
 		)?;
 
 		// Initialize account data
@@ -129,14 +125,15 @@ impl<'a> ProcessAccountInfos<'a> for UpdateAccounts<'a> {
 			.assert_not_empty()?
 			.assert_type::<TodoState>(&ID)?;
 
-		let bump = {
+		let stored_owner = {
 			let todo = self.todo.as_account::<TodoState>(&ID)?;
-			self.owner.assert_address(&todo.owner)?;
-			todo.bump
+			todo.owner
 		};
+		self.owner.assert_address(&stored_owner)?;
 
-		let seeds_with_bump = todo_seeds!(owner.as_ref(), bump);
-		self.todo.assert_seeds_with_bump(seeds_with_bump, &ID)?;
+		// Verify the todo is the PDA for the owner, using the stored bump
+		// field (avoids re-deriving the canonical bump on-chain).
+		TodoState::assert_seeds(self.todo, owner, &ID)?;
 
 		// Execute instruction
 		match instruction {

--- a/examples/vesting_program/src/lib.rs
+++ b/examples/vesting_program/src/lib.rs
@@ -71,6 +71,7 @@ pub enum VestingAccountType {
 }
 
 #[account(discriminator = VestingAccountType)]
+#[pda(seeds = [VESTING_SEED_PREFIX, admin: Address, beneficiary: Address, mint: Address], bump = bump)]
 pub struct VestingState {
 	pub admin: Address,
 	pub beneficiary: Address,
@@ -132,18 +133,10 @@ pub struct CancelAccounts<'a> {
 	pub token_program: &'a AccountView,
 }
 
+/// Seed prefix for vesting PDAs.
 const VESTING_SEED_PREFIX: &[u8] = b"vesting";
-const SPL_PROGRAM_IDS: [Address; 2] = [token::ID, token_2022::ID];
 
-#[macro_export]
-macro_rules! vesting_seeds {
-	($admin:expr, $beneficiary:expr, $mint:expr) => {
-		&[VESTING_SEED_PREFIX, $admin, $beneficiary, $mint]
-	};
-	($admin:expr, $beneficiary:expr, $mint:expr, $bump:expr) => {
-		&[VESTING_SEED_PREFIX, $admin, $beneficiary, $mint, &[$bump]]
-	};
-}
+const SPL_PROGRAM_IDS: [Address; 2] = [token::ID, token_2022::ID];
 
 fn validate_schedule(start_ts: u64, cliff_ts: u64, end_ts: u64) -> ProgramResult {
 	if start_ts > cliff_ts || cliff_ts > end_ts {
@@ -162,17 +155,12 @@ impl<'a> ProcessAccountInfos<'a> for InitializeAccounts<'a> {
 
 		validate_schedule(start_ts, cliff_ts, end_ts)?;
 
-		let vesting_seeds = vesting_seeds!(
-			self.admin.address().as_ref(),
-			self.beneficiary.address().as_ref(),
-			self.mint.address().as_ref()
+		let vesting_seeds = VestingState::seeds(
+			self.admin.address(),
+			self.beneficiary.address(),
+			self.mint.address(),
 		);
-		let vesting_seeds_with_bump = vesting_seeds!(
-			self.admin.address().as_ref(),
-			self.beneficiary.address().as_ref(),
-			self.mint.address().as_ref(),
-			args.bump
-		);
+		let vesting_seeds_with_bump = vesting_seeds.with_bump(args.bump);
 
 		self.admin.assert_signer()?;
 		self.mint.assert_owners(&SPL_PROGRAM_IDS)?;
@@ -180,7 +168,7 @@ impl<'a> ProcessAccountInfos<'a> for InitializeAccounts<'a> {
 		self.token_program.assert_addresses(&SPL_PROGRAM_IDS)?;
 		self.vesting_state
 			.assert_empty()?
-			.assert_seeds_with_bump(vesting_seeds_with_bump, &ID)?;
+			.assert_seeds_with_bump(&vesting_seeds_with_bump.as_slices(), &ID)?;
 		self.vault
 			.assert_empty()?
 			.assert_writable()?
@@ -194,7 +182,7 @@ impl<'a> ProcessAccountInfos<'a> for InitializeAccounts<'a> {
 			self.vesting_state,
 			self.admin,
 			&ID,
-			vesting_seeds,
+			&vesting_seeds.as_slices(),
 			args.bump,
 		)?;
 
@@ -256,7 +244,7 @@ impl<'a> ProcessAccountInfos<'a> for ClaimAccounts<'a> {
 				self.token_program.address(),
 			)?;
 
-		let (admin, beneficiary, mint, bump, cancelled, claimed_amount, total_amount) = {
+		let (admin, beneficiary, mint, cancelled, claimed_amount, total_amount) = {
 			let vesting_state = self.vesting_state.as_account::<VestingState>(&ID)?;
 			self.beneficiary
 				.assert_address(&vesting_state.beneficiary)?;
@@ -266,16 +254,15 @@ impl<'a> ProcessAccountInfos<'a> for ClaimAccounts<'a> {
 				vesting_state.admin,
 				vesting_state.beneficiary,
 				vesting_state.mint,
-				vesting_state.bump,
 				bool::from(vesting_state.cancelled),
 				u64::from(vesting_state.claimed_amount),
 				u64::from(vesting_state.total_amount),
 			)
 		};
-		self.vesting_state.assert_seeds_with_bump(
-			vesting_seeds!(admin.as_ref(), beneficiary.as_ref(), mint.as_ref(), bump),
-			&ID,
-		)?;
+		// Verify the vesting state is the PDA for the admin, beneficiary, and
+		// mint, using the stored bump field (avoids re-deriving the canonical
+		// bump on-chain).
+		VestingState::assert_seeds(self.vesting_state, &admin, &beneficiary, &mint, &ID)?;
 
 		if cancelled {
 			return Err(VestingError::AlreadyCancelled.into());
@@ -324,7 +311,7 @@ impl<'a> ProcessAccountInfos<'a> for CancelAccounts<'a> {
 				self.token_program.address(),
 			)?;
 
-		let (admin, beneficiary, mint, bump, cancelled) = {
+		let (admin, beneficiary, mint, cancelled) = {
 			let vesting_state = self.vesting_state.as_account::<VestingState>(&ID)?;
 
 			self.admin.assert_address(&vesting_state.admin)?;
@@ -334,15 +321,14 @@ impl<'a> ProcessAccountInfos<'a> for CancelAccounts<'a> {
 				vesting_state.admin,
 				vesting_state.beneficiary,
 				vesting_state.mint,
-				vesting_state.bump,
 				bool::from(vesting_state.cancelled),
 			)
 		};
 
-		self.vesting_state.assert_seeds_with_bump(
-			vesting_seeds!(admin.as_ref(), beneficiary.as_ref(), mint.as_ref(), bump),
-			&ID,
-		)?;
+		// Verify the vesting state is the PDA for the admin, beneficiary, and
+		// mint, using the stored bump field (avoids re-deriving the canonical
+		// bump on-chain).
+		VestingState::assert_seeds(self.vesting_state, &admin, &beneficiary, &mint, &ID)?;
 
 		if cancelled {
 			return Err(VestingError::AlreadyCancelled.into());


### PR DESCRIPTION
## Summary

Adds a typed `#[pda(seeds = [...], bump = <field>)]` attribute macro for `#[account]` structs, replacing the manual `const` + `macro_rules!` seed pattern across all examples.

```rust
#[account(discriminator = CounterAccount)]
#[pda(seeds = [COUNTER_SEED, authority: Address], bump = bump)]
pub struct CounterState {
	pub authority: Address,
	pub bump: u8,
}
```

### What the macro generates

- **`CounterSeeds` / `CounterSeedsWithBump`** — owned seed structs (numeric seeds stored as little-endian bytes)
- **`CounterState::seeds(...)`** — typed constructor; **`as_slices()`** / **`with_bump(bump)`** — byte-slice access
- **`try_find_pda(...)` / `find_pda(...)`** — canonical PDA derivation
- **`assert_seeds(account, ...)`** — verifies an existing account against the **stored bump field** (declared via `bump = <field>`), avoiding a canonical bump search on-chain

Supported seed types: `Address`, `u8`, `u16`, `u32`, `u64`, `[u8; N]`, and `const &[u8]` references (e.g. `COUNTER_SEED`).

### IDL & client improvements

- `pina_cli` parses the attribute directly (no more `macro_rules!` heuristic), so seed types in the IDL are always accurate — **fixing the escrow `u64` seed being mis-typed as a 32-byte address** in generated clients (the client previously derived a *different* PDA than the program)
- The renderer now emits `find_pda` / `create_pda` helpers on Rust client account structs for linked PDAs
- All 7 examples with seed macros (counter, escrow, vesting, role_registry, todo, staking_rewards, profile) now use the attribute; the token-escrow tutorial is updated to match

### Testing

- 100% patch coverage on the new CLI parsing code (verified with `cargo llvm-cov`)
- New integration tests in `crates/pina/tests/pda_macro.rs` covering all seed types, derivation, and stored-bump verification against real `AccountView` instances
- Insta snapshots for the generated code, trybuild UI tests for error cases, and updated example IDL snapshots
- Full workspace tests, clippy, dprint, `verify-codama-idls.sh`, and `monochange check` all pass

## Attribution

The design of this feature is directly inspired by **Quasar** ([blueshift-gg/quasar](https://github.com/blueshift-gg/quasar)), a zero-copy Solana framework whose typed seed declarations (`#[seeds(b"escrow", maker: Address)]` + `address = Escrow::seeds(...)`) solve exactly the ergonomics problem this PR addresses. We're not using Quasar directly because we want complete control over our codebase and a deep understanding of what runs on-chain, but their work is exceptional.

Special thanks to **L0STE** ([@L0STE](https://github.com/L0STE)) for the original typed-seeds design in commit `551b3d6` ("feat: PDA seed validation, bump derivation, and zero-arg seed reconstruction") — the owned seed-set structs, little-endian numeric storage, and stored-bump verification pattern in this PR are adapted from that work. Thank you for the great work!
