### PR TITLE
fix(renderer): harden generated output boundaries

### DIFF
--- a/.changeset/harden_renderer_output.md
+++ b/.changeset/harden_renderer_output.md
@@ -1,0 +1,7 @@
+---
+pina_codama_renderer: fix
+---
+
+# Harden generated output boundaries
+
+Reject unsafe names and literals before rendering, validate generated Rust before replacing existing output, and constrain cleanup to managed files within the requested destination.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2411,6 +2411,8 @@ dependencies = [
  "heck",
  "insta",
  "serde_json",
+ "solana-pubkey",
+ "syn 3.0.3",
  "thiserror 2.0.20",
 ]
 

--- a/crates/pina_codama_renderer/Cargo.toml
+++ b/crates/pina_codama_renderer/Cargo.toml
@@ -14,6 +14,8 @@ clap = { workspace = true, features = ["derive", "std"], default-features = true
 codama-nodes = { workspace = true, default-features = true }
 heck = { workspace = true, default-features = true }
 serde_json = { workspace = true, default-features = true }
+solana-pubkey = { workspace = true, default-features = true }
+syn = { workspace = true, default-features = true }
 thiserror = { workspace = true, default-features = true }
 
 [dev-dependencies]

--- a/crates/pina_codama_renderer/src/__tests.rs
+++ b/crates/pina_codama_renderer/src/__tests.rs
@@ -999,3 +999,25 @@ fn rejects_symlinked_generated_directory() {
 		"keep"
 	);
 }
+
+#[cfg(unix)]
+#[test]
+fn rejects_dangling_symlinked_generated_directory() {
+	use std::os::unix::fs::symlink;
+
+	let root = load_fixture_root("counter_program");
+	let output_dir = unique_temp_dir("pina-codama-render-dangling-symlink");
+	let crate_dir = output_dir.join("client");
+	let dangling_target = output_dir.join("external/does-not-exist");
+	fs::create_dir_all(crate_dir.join("src"))
+		.unwrap_or_else(|error| panic!("failed to create crate directory: {error}"));
+	symlink(&dangling_target, crate_dir.join("src/generated"))
+		.unwrap_or_else(|error| panic!("failed to create dangling symlink: {error}"));
+
+	let error = render_root_node(&root, &crate_dir, &RenderConfig::default())
+		.err()
+		.unwrap_or_else(|| panic!("expected dangling symlinked output path to fail"));
+
+	assert!(matches!(error, RenderError::UnsafeOutputPath { .. }));
+	assert!(!dangling_target.exists());
+}

--- a/crates/pina_codama_renderer/src/__tests.rs
+++ b/crates/pina_codama_renderer/src/__tests.rs
@@ -804,3 +804,176 @@ fn snapshots_escrow_take_instruction() {
 	let content = read_generated_file(&crate_dir, "instructions/take.rs");
 	insta::assert_snapshot!("escrow_take_instruction_rs", content);
 }
+
+#[test]
+fn renders_untrusted_multiline_text_as_valid_rust() {
+	let mut account_root = load_fixture_root("counter_program");
+	account_root.program.accounts[0]
+		.docs
+		.push("Account documentation.\npub const INJECTED: bool = true;");
+	let account_files = render_program_to_files(&account_root)
+		.unwrap_or_else(|error| panic!("render failed: {error}"));
+	let account_source = account_files
+		.get(Path::new("accounts/counter_state.rs"))
+		.unwrap_or_else(|| panic!("missing account source"));
+	assert!(account_source.contains("/// pub const INJECTED: bool = true;"));
+	assert!(!account_source.contains("\npub const INJECTED: bool = true;"));
+	syn::parse_file(account_source)
+		.unwrap_or_else(|error| panic!("generated account source is invalid: {error}"));
+
+	let mut error_root = load_fixture_root("anchor_errors");
+	error_root.program.errors[0].message =
+		"bad message\n)]\npub const INJECTED: bool = true;".to_string();
+	let error_files = render_program_to_files(&error_root)
+		.unwrap_or_else(|error| panic!("render failed: {error}"));
+	let error_path = format!("errors/{}.rs", snake(error_root.program.name.as_ref()));
+	let error_source = error_files
+		.get(Path::new(&error_path))
+		.unwrap_or_else(|| panic!("missing error source"));
+	assert!(error_source.contains("/// pub const INJECTED: bool = true;"));
+	assert!(!error_source.contains("\npub const INJECTED: bool = true;"));
+	syn::parse_file(error_source)
+		.unwrap_or_else(|error| panic!("generated error source is invalid: {error}"));
+}
+
+#[test]
+fn rejects_output_path_escape_without_mutating_files() {
+	let root = load_fixture_root("counter_program");
+	let output_dir = unique_temp_dir("pina-codama-render-path-escape");
+	let crate_dir = output_dir.join("client");
+	let escaped_dir = output_dir.join("escaped");
+	fs::create_dir_all(&escaped_dir)
+		.unwrap_or_else(|error| panic!("failed to create escaped directory: {error}"));
+	let sentinel_path = escaped_dir.join("sentinel.txt");
+	fs::write(&sentinel_path, "keep")
+		.unwrap_or_else(|error| panic!("failed to write sentinel: {error}"));
+
+	let error = render_root_node(
+		&root,
+		&crate_dir,
+		&RenderConfig {
+			delete_folder_before_rendering: true,
+			generated_folder: PathBuf::from("../escaped"),
+		},
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected unsafe output path to be rejected"));
+	assert!(matches!(error, RenderError::UnsafeOutputPath { .. }));
+	assert_eq!(
+		fs::read_to_string(&sentinel_path)
+			.unwrap_or_else(|error| panic!("failed to read sentinel: {error}")),
+		"keep"
+	);
+	assert!(!crate_dir.exists());
+
+	let absolute_error = render_root_node(
+		&root,
+		&crate_dir,
+		&RenderConfig {
+			delete_folder_before_rendering: true,
+			generated_folder: escaped_dir.clone(),
+		},
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected absolute output path to be rejected"));
+	assert!(matches!(
+		absolute_error,
+		RenderError::UnsafeOutputPath { .. }
+	));
+	assert_eq!(
+		fs::read_to_string(&sentinel_path)
+			.unwrap_or_else(|error| panic!("failed to reread sentinel: {error}")),
+		"keep"
+	);
+}
+
+#[test]
+fn refuses_to_delete_an_unmanaged_directory() {
+	let root = load_fixture_root("counter_program");
+	let crate_dir = unique_temp_dir("pina-codama-render-unmanaged");
+	let source_dir = crate_dir.join("src");
+	fs::create_dir_all(&source_dir)
+		.unwrap_or_else(|error| panic!("failed to create source directory: {error}"));
+	let sentinel_path = source_dir.join("lib.rs");
+	fs::write(&sentinel_path, "pub const KEEP: bool = true;")
+		.unwrap_or_else(|error| panic!("failed to write source sentinel: {error}"));
+
+	let error = render_root_node(
+		&root,
+		&crate_dir,
+		&RenderConfig {
+			delete_folder_before_rendering: true,
+			generated_folder: PathBuf::from("src"),
+		},
+	)
+	.err()
+	.unwrap_or_else(|| panic!("expected unmanaged source directory to be rejected"));
+	assert!(matches!(error, RenderError::UnsafeOutputPath { .. }));
+	assert_eq!(
+		fs::read_to_string(&sentinel_path)
+			.unwrap_or_else(|error| panic!("failed to read source sentinel: {error}")),
+		"pub const KEEP: bool = true;"
+	);
+}
+
+#[test]
+fn render_failure_preserves_last_known_good_output() {
+	let root = load_fixture_root("counter_program");
+	let crate_dir = unique_temp_dir("pina-codama-render-preserve");
+	render_root_node(&root, &crate_dir, &RenderConfig::default())
+		.unwrap_or_else(|error| panic!("initial render failed: {error}"));
+	let generated_path = crate_dir.join("src/generated/programs.rs");
+	let previous_source = fs::read_to_string(&generated_path)
+		.unwrap_or_else(|error| panic!("failed to read generated source: {error}"));
+	let cargo_path = crate_dir.join("Cargo.toml");
+	fs::write(&cargo_path, "last-known-good")
+		.unwrap_or_else(|error| panic!("failed to write Cargo sentinel: {error}"));
+
+	let mut invalid_root = root;
+	invalid_root.program.public_key =
+		"11111111111111111111111111111111\"); pub const INJECTED: bool = true; //".to_string();
+	let error = render_root_node(&invalid_root, &crate_dir, &RenderConfig::default())
+		.err()
+		.unwrap_or_else(|| panic!("expected invalid public key to fail"));
+	assert!(matches!(error, RenderError::UnsupportedValue { .. }));
+	assert_eq!(
+		fs::read_to_string(&generated_path)
+			.unwrap_or_else(|error| panic!("failed to reread generated source: {error}")),
+		previous_source
+	);
+	assert_eq!(
+		fs::read_to_string(&cargo_path)
+			.unwrap_or_else(|error| panic!("failed to reread Cargo sentinel: {error}")),
+		"last-known-good"
+	);
+}
+
+#[cfg(unix)]
+#[test]
+fn rejects_symlinked_generated_directory() {
+	use std::os::unix::fs::symlink;
+
+	let root = load_fixture_root("counter_program");
+	let output_dir = unique_temp_dir("pina-codama-render-symlink");
+	let crate_dir = output_dir.join("client");
+	let external_dir = output_dir.join("external");
+	fs::create_dir_all(crate_dir.join("src"))
+		.unwrap_or_else(|error| panic!("failed to create crate directory: {error}"));
+	fs::create_dir_all(&external_dir)
+		.unwrap_or_else(|error| panic!("failed to create external directory: {error}"));
+	let sentinel_path = external_dir.join("sentinel.txt");
+	fs::write(&sentinel_path, "keep")
+		.unwrap_or_else(|error| panic!("failed to write sentinel: {error}"));
+	symlink(&external_dir, crate_dir.join("src/generated"))
+		.unwrap_or_else(|error| panic!("failed to create symlink: {error}"));
+
+	let error = render_root_node(&root, &crate_dir, &RenderConfig::default())
+		.err()
+		.unwrap_or_else(|| panic!("expected symlinked output path to fail"));
+	assert!(matches!(error, RenderError::UnsafeOutputPath { .. }));
+	assert_eq!(
+		fs::read_to_string(&sentinel_path)
+			.unwrap_or_else(|error| panic!("failed to read sentinel: {error}")),
+		"keep"
+	);
+}

--- a/crates/pina_codama_renderer/src/__tests.rs
+++ b/crates/pina_codama_renderer/src/__tests.rs
@@ -917,6 +917,28 @@ fn refuses_to_delete_an_unmanaged_directory() {
 }
 
 #[test]
+fn refuses_to_delete_unmanaged_files_inside_a_generated_directory() {
+	let root = load_fixture_root("counter_program");
+	let crate_dir = unique_temp_dir("pina-codama-render-mixed-output");
+	render_root_node(&root, &crate_dir, &RenderConfig::default())
+		.unwrap_or_else(|error| panic!("initial render failed: {error}"));
+	let sentinel_path = crate_dir.join("src/generated/keep.txt");
+	fs::write(&sentinel_path, "user-authored")
+		.unwrap_or_else(|error| panic!("failed to write user file: {error}"));
+
+	let error = render_root_node(&root, &crate_dir, &RenderConfig::default())
+		.err()
+		.unwrap_or_else(|| panic!("expected mixed generated directory to be rejected"));
+
+	assert!(matches!(error, RenderError::UnsafeOutputPath { .. }));
+	assert_eq!(
+		fs::read_to_string(&sentinel_path)
+			.unwrap_or_else(|error| panic!("failed to read user file: {error}")),
+		"user-authored"
+	);
+}
+
+#[test]
 fn render_failure_preserves_last_known_good_output() {
 	let root = load_fixture_root("counter_program");
 	let crate_dir = unique_temp_dir("pina-codama-render-preserve");

--- a/crates/pina_codama_renderer/src/error.rs
+++ b/crates/pina_codama_renderer/src/error.rs
@@ -21,6 +21,10 @@ pub enum RenderError {
 		path: PathBuf,
 		source: serde_json::Error,
 	},
+	#[error("unsafe generated output path `{path}`: {reason}")]
+	UnsafeOutputPath { path: PathBuf, reason: String },
+	#[error("generated Rust source `{path}` is invalid: {reason}")]
+	InvalidGeneratedSource { path: PathBuf, reason: String },
 	#[error("unsupported type `{kind}` at `{context}`: {reason}")]
 	UnsupportedType {
 		context: String,

--- a/crates/pina_codama_renderer/src/lib.rs
+++ b/crates/pina_codama_renderer/src/lib.rs
@@ -191,19 +191,21 @@ fn validate_generated_dir(crate_dir: &Path, generated_folder: &Path) -> Result<P
 			unreachable!("components were validated above");
 		};
 		current.push(component);
-		if current.exists() {
-			let metadata = fs::symlink_metadata(&current).map_err(|source| {
-				RenderError::ReadFile {
+		let metadata = match fs::symlink_metadata(&current) {
+			Ok(metadata) => metadata,
+			Err(source) if source.kind() == std::io::ErrorKind::NotFound => continue,
+			Err(source) => {
+				return Err(RenderError::ReadFile {
 					path: current.clone(),
 					source,
-				}
-			})?;
-			if metadata.file_type().is_symlink() {
-				return Err(RenderError::UnsafeOutputPath {
-					path: current,
-					reason: "generated output path must not traverse symbolic links".to_string(),
 				});
 			}
+		};
+		if metadata.file_type().is_symlink() {
+			return Err(RenderError::UnsafeOutputPath {
+				path: current,
+				reason: "generated output path must not traverse symbolic links".to_string(),
+			});
 		}
 	}
 

--- a/crates/pina_codama_renderer/src/lib.rs
+++ b/crates/pina_codama_renderer/src/lib.rs
@@ -281,6 +281,59 @@ fn validate_existing_generated_dir(path: &Path, require_managed: bool) -> Result
 						.to_string(),
 				});
 			}
+
+			validate_renderer_managed_tree(path)?;
+		}
+	}
+
+	Ok(())
+}
+
+fn validate_renderer_managed_tree(path: &Path) -> Result<()> {
+	for entry in fs::read_dir(path).map_err(|source| {
+		RenderError::ReadFile {
+			path: path.to_path_buf(),
+			source,
+		}
+	})? {
+		let entry = entry.map_err(|source| {
+			RenderError::ReadFile {
+				path: path.to_path_buf(),
+				source,
+			}
+		})?;
+		let entry_path = entry.path();
+		let metadata = fs::symlink_metadata(&entry_path).map_err(|source| {
+			RenderError::ReadFile {
+				path: entry_path.clone(),
+				source,
+			}
+		})?;
+
+		if metadata.is_dir() {
+			validate_renderer_managed_tree(&entry_path)?;
+			continue;
+		}
+
+		if !metadata.is_file() {
+			return Err(RenderError::UnsafeOutputPath {
+				path: entry_path,
+				reason: "generated output tree contains an unmanaged entry".to_string(),
+			});
+		}
+
+		let source = fs::read_to_string(&entry_path).map_err(|source| {
+			RenderError::ReadFile {
+				path: entry_path.clone(),
+				source,
+			}
+		})?;
+		if !source.starts_with(GENERATED_HEADER) {
+			return Err(RenderError::UnsafeOutputPath {
+				path: entry_path,
+				reason: "refusing to delete a generated directory containing unmanaged files"
+					.to_string(),
+			});
 		}
 	}
 

--- a/crates/pina_codama_renderer/src/lib.rs
+++ b/crates/pina_codama_renderer/src/lib.rs
@@ -3,6 +3,7 @@ mod render;
 
 use std::collections::BTreeMap;
 use std::fs;
+use std::path::Component;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -48,9 +49,12 @@ pub fn render_idl_file(path: &Path, crate_dir: &Path, config: &RenderConfig) -> 
 }
 
 pub fn render_root_node(root: &RootNode, crate_dir: &Path, config: &RenderConfig) -> Result<()> {
-	ensure_crate_scaffold(crate_dir, root.program.name.as_ref())?;
+	let generated_dir = validate_generated_dir(crate_dir, &config.generated_folder)?;
+	let files = render_program_to_files(root)?;
+	validate_generated_sources(&files)?;
+	validate_existing_generated_dir(&generated_dir, config.delete_folder_before_rendering)?;
 
-	let generated_dir = crate_dir.join(&config.generated_folder);
+	ensure_crate_scaffold(crate_dir, root.program.name.as_ref())?;
 
 	if config.delete_folder_before_rendering && generated_dir.exists() {
 		fs::remove_dir_all(&generated_dir).map_err(|source| {
@@ -60,8 +64,6 @@ pub fn render_root_node(root: &RootNode, crate_dir: &Path, config: &RenderConfig
 			}
 		})?;
 	}
-
-	let files = render_program_to_files(root)?;
 
 	write_files(&generated_dir, files)
 }
@@ -95,7 +97,7 @@ fn render_program_to_files(root: &RootNode) -> Result<BTreeMap<PathBuf, String>>
 	files.insert(PathBuf::from("mod.rs"), page(&render_root_mod(program)));
 	files.insert(
 		PathBuf::from("programs.rs"),
-		page(&render_programs_mod(&program_constants)),
+		page(&render_programs_mod(&program_constants)?),
 	);
 
 	// Account files
@@ -160,6 +162,162 @@ fn render_program_to_files(root: &RootNode) -> Result<BTreeMap<PathBuf, String>>
 	}
 
 	Ok(files)
+}
+
+fn validate_generated_dir(crate_dir: &Path, generated_folder: &Path) -> Result<PathBuf> {
+	let mut has_component = false;
+	for component in generated_folder.components() {
+		has_component = true;
+		if !matches!(component, Component::Normal(_)) {
+			return Err(RenderError::UnsafeOutputPath {
+				path: generated_folder.to_path_buf(),
+				reason: "expected a non-empty relative path without `.` or `..` components"
+					.to_string(),
+			});
+		}
+	}
+
+	if !has_component {
+		return Err(RenderError::UnsafeOutputPath {
+			path: generated_folder.to_path_buf(),
+			reason: "expected a non-empty relative path".to_string(),
+		});
+	}
+
+	let generated_dir = crate_dir.join(generated_folder);
+	let mut current = crate_dir.to_path_buf();
+	for component in generated_folder.components() {
+		let Component::Normal(component) = component else {
+			unreachable!("components were validated above");
+		};
+		current.push(component);
+		if current.exists() {
+			let metadata = fs::symlink_metadata(&current).map_err(|source| {
+				RenderError::ReadFile {
+					path: current.clone(),
+					source,
+				}
+			})?;
+			if metadata.file_type().is_symlink() {
+				return Err(RenderError::UnsafeOutputPath {
+					path: current,
+					reason: "generated output path must not traverse symbolic links".to_string(),
+				});
+			}
+		}
+	}
+
+	Ok(generated_dir)
+}
+
+fn validate_generated_sources(files: &BTreeMap<PathBuf, String>) -> Result<()> {
+	for (path, source) in files {
+		syn::parse_file(source).map_err(|error| {
+			RenderError::InvalidGeneratedSource {
+				path: path.clone(),
+				reason: error.to_string(),
+			}
+		})?;
+	}
+	Ok(())
+}
+
+fn validate_existing_generated_dir(path: &Path, require_managed: bool) -> Result<()> {
+	if !path.exists() {
+		return Ok(());
+	}
+
+	let metadata = fs::symlink_metadata(path).map_err(|source| {
+		RenderError::ReadFile {
+			path: path.to_path_buf(),
+			source,
+		}
+	})?;
+	if !metadata.is_dir() {
+		return Err(RenderError::UnsafeOutputPath {
+			path: path.to_path_buf(),
+			reason: "generated output path exists but is not a directory".to_string(),
+		});
+	}
+
+	validate_tree_has_no_symlinks(path)?;
+
+	if require_managed {
+		let mut entries = fs::read_dir(path).map_err(|source| {
+			RenderError::ReadFile {
+				path: path.to_path_buf(),
+				source,
+			}
+		})?;
+		if entries
+			.next()
+			.transpose()
+			.map_err(|source| {
+				RenderError::ReadFile {
+					path: path.to_path_buf(),
+					source,
+				}
+			})?
+			.is_some()
+		{
+			let marker_path = path.join("mod.rs");
+			if !marker_path.is_file() {
+				return Err(RenderError::UnsafeOutputPath {
+					path: path.to_path_buf(),
+					reason: "refusing to delete a directory not created by this renderer"
+						.to_string(),
+				});
+			}
+			let marker = fs::read_to_string(&marker_path).map_err(|source| {
+				RenderError::ReadFile {
+					path: marker_path.clone(),
+					source,
+				}
+			})?;
+			if !marker.starts_with(GENERATED_HEADER) {
+				return Err(RenderError::UnsafeOutputPath {
+					path: path.to_path_buf(),
+					reason: "refusing to delete a directory not created by this renderer"
+						.to_string(),
+				});
+			}
+		}
+	}
+
+	Ok(())
+}
+
+fn validate_tree_has_no_symlinks(path: &Path) -> Result<()> {
+	for entry in fs::read_dir(path).map_err(|source| {
+		RenderError::ReadFile {
+			path: path.to_path_buf(),
+			source,
+		}
+	})? {
+		let entry = entry.map_err(|source| {
+			RenderError::ReadFile {
+				path: path.to_path_buf(),
+				source,
+			}
+		})?;
+		let entry_path = entry.path();
+		let file_type = entry.file_type().map_err(|source| {
+			RenderError::ReadFile {
+				path: entry_path.clone(),
+				source,
+			}
+		})?;
+		if file_type.is_symlink() {
+			return Err(RenderError::UnsafeOutputPath {
+				path: entry_path,
+				reason: "generated output tree must not contain symbolic links".to_string(),
+			});
+		}
+		if file_type.is_dir() {
+			validate_tree_has_no_symlinks(&entry_path)?;
+		}
+	}
+	Ok(())
 }
 
 #[cfg(test)]

--- a/crates/pina_codama_renderer/src/main.rs
+++ b/crates/pina_codama_renderer/src/main.rs
@@ -99,5 +99,27 @@ fn file_stem(path: &Path) -> Result<String, RenderError> {
 			reason: "expected a UTF-8 file stem".to_string(),
 		});
 	};
+	if stem.is_empty() || matches!(stem, "." | "..") {
+		return Err(RenderError::UnsupportedValue {
+			context: format!("path `{}`", path.display()),
+			kind: "path",
+			reason: "file stem must name a child output directory".to_string(),
+		});
+	}
 	Ok(stem.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+	use std::path::Path;
+
+	use super::file_stem;
+
+	#[test]
+	fn rejects_parent_directory_file_stem() {
+		let error = file_stem(Path::new("...json"))
+			.err()
+			.unwrap_or_else(|| panic!("expected parent-directory stem to be rejected"));
+		assert!(error.to_string().contains("child output directory"));
+	}
 }

--- a/crates/pina_codama_renderer/src/render/errors.rs
+++ b/crates/pina_codama_renderer/src/render/errors.rs
@@ -1,8 +1,9 @@
 use codama_nodes::ProgramNode;
 
-use super::helpers::escape_rust_str;
 use super::helpers::pascal;
+use super::helpers::render_doc;
 use super::helpers::render_docs;
+use super::helpers::rust_string_literal;
 use super::helpers::snake;
 
 pub(crate) fn render_errors_mod(program: &ProgramNode) -> String {
@@ -30,10 +31,12 @@ pub(crate) fn render_errors_page(program: &ProgramNode) -> String {
 		for doc_line in render_docs(&error.docs, 1) {
 			lines.push(doc_line);
 		}
-		lines.push(format!("\t/// {} - {}", error.code, error.message));
+		for doc_line in render_doc(&format!("{} - {}", error.code, error.message), 1) {
+			lines.push(doc_line);
+		}
 		lines.push(format!(
-			"\t#[error(\"{}\")]",
-			escape_rust_str(&error.message)
+			"\t#[error({})]",
+			rust_string_literal(&error.message)
 		));
 		lines.push(format!(
 			"\t{} = 0x{:X},",

--- a/crates/pina_codama_renderer/src/render/errors.rs
+++ b/crates/pina_codama_renderer/src/render/errors.rs
@@ -36,7 +36,7 @@ pub(crate) fn render_errors_page(program: &ProgramNode) -> String {
 		}
 		lines.push(format!(
 			"\t#[error({})]",
-			rust_string_literal(&error.message)
+			error_format_literal(&error.message)
 		));
 		lines.push(format!(
 			"\t{} = 0x{:X},",
@@ -59,4 +59,32 @@ pub(crate) fn render_errors_page(program: &ProgramNode) -> String {
 	lines.push("}".to_string());
 
 	lines.join("\n")
+}
+
+fn error_format_literal(message: &str) -> String {
+	let escaped = message.replace('{', "{{").replace('}', "}}");
+	rust_string_literal(&escaped)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::error_format_literal;
+
+	#[derive(Debug, thiserror::Error)]
+	enum BraceError {
+		#[error("invalid {{key}} and unexpected }}")]
+		Invalid,
+	}
+
+	#[test]
+	fn escapes_thiserror_format_braces() {
+		assert_eq!(
+			error_format_literal("invalid {key} and unexpected }"),
+			r#""invalid {{key}} and unexpected }}""#
+		);
+		assert_eq!(
+			BraceError::Invalid.to_string(),
+			"invalid {key} and unexpected }"
+		);
+	}
 }

--- a/crates/pina_codama_renderer/src/render/helpers.rs
+++ b/crates/pina_codama_renderer/src/render/helpers.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use codama_nodes::Docs;
 use codama_nodes::Number;
 use heck::ToShoutySnakeCase;
@@ -38,15 +40,36 @@ pub(crate) fn program_id_const_name(program_name: &str) -> String {
 	shouty(program_name) + "_ID"
 }
 
-pub(crate) fn escape_rust_str(value: &str) -> String {
-	value.replace('\\', "\\\\").replace('"', "\\\"")
+pub(crate) fn rust_string_literal(value: &str) -> String {
+	format!("{value:?}")
 }
 
 pub(crate) fn render_docs(docs: &Docs, indent_level: usize) -> Vec<String> {
-	let indent = "\t".repeat(indent_level);
 	docs.iter()
-		.map(|line| format!("{indent}/// {line}"))
+		.flat_map(|doc| render_doc(doc, indent_level))
 		.collect()
+}
+
+pub(crate) fn render_doc(doc: &str, indent_level: usize) -> Vec<String> {
+	let indent = "\t".repeat(indent_level);
+	doc.split('\n')
+		.map(|line| {
+			let line = line.strip_suffix('\r').unwrap_or(line);
+			format!("{indent}/// {line}")
+		})
+		.collect()
+}
+
+pub(crate) fn canonical_pubkey(value: &str, context: &str) -> Result<String> {
+	solana_pubkey::Pubkey::from_str(value)
+		.map(|public_key| public_key.to_string())
+		.map_err(|error| {
+			RenderError::UnsupportedValue {
+				context: context.to_string(),
+				kind: "publicKeyValueNode",
+				reason: format!("invalid public key: {error}"),
+			}
+		})
 }
 
 pub(crate) fn cast_unsigned(value: &Number, max: u128, context: &str) -> Result<u128> {

--- a/crates/pina_codama_renderer/src/render/instructions.rs
+++ b/crates/pina_codama_renderer/src/render/instructions.rs
@@ -12,6 +12,7 @@ use codama_nodes::PdaValuePda;
 use codama_nodes::ProgramNode;
 
 use super::discriminator::render_constant_discriminator;
+use super::helpers::canonical_pubkey;
 use super::helpers::pascal;
 use super::helpers::program_id_const_name;
 use super::helpers::render_docs;
@@ -467,7 +468,13 @@ fn render_instruction_account_default_value(
 
 	let value = match default_value {
 		InstructionInputValueNode::PublicKeyValue(public_key) => {
-			format!("solana_pubkey::pubkey!(\"{}\")", public_key.public_key)
+			let context = format!(
+				"instruction `{}` account `{}` public key default",
+				pascal(instruction.name.as_ref()),
+				snake(account.name.as_ref())
+			);
+			let public_key = canonical_pubkey(&public_key.public_key, &context)?;
+			format!("solana_pubkey::pubkey!(\"{public_key}\")")
 		}
 		InstructionInputValueNode::ProgramIdValue(_) => {
 			format!("crate::{primary_program_const}")

--- a/crates/pina_codama_renderer/src/render/mod.rs
+++ b/crates/pina_codama_renderer/src/render/mod.rs
@@ -13,6 +13,7 @@ pub(crate) use accounts::render_account_page;
 pub(crate) use accounts::render_accounts_mod;
 pub(crate) use errors::render_errors_mod;
 pub(crate) use errors::render_errors_page;
+pub(crate) use helpers::GENERATED_HEADER;
 pub(crate) use helpers::page;
 pub(crate) use helpers::program_id_const_name;
 pub(crate) use helpers::snake;

--- a/crates/pina_codama_renderer/src/render/mods.rs
+++ b/crates/pina_codama_renderer/src/render/mods.rs
@@ -1,6 +1,8 @@
 use codama_nodes::ProgramNode;
 
+use super::helpers::canonical_pubkey;
 use super::helpers::program_id_const_name;
+use crate::error::Result;
 
 pub(crate) fn render_root_mod(program: &ProgramNode) -> String {
 	let mut lines = Vec::new();
@@ -25,18 +27,23 @@ pub(crate) fn render_root_mod(program: &ProgramNode) -> String {
 	lines.join("\n")
 }
 
-pub(crate) fn render_programs_mod(programs: &[&ProgramNode]) -> String {
+pub(crate) fn render_programs_mod(programs: &[&ProgramNode]) -> Result<String> {
 	let mut lines = Vec::new();
 	lines.push("use solana_pubkey::{pubkey, Pubkey};".to_string());
 	lines.push(String::new());
 
 	for program in programs {
+		let program_name = program.name.as_ref();
+		let public_key = canonical_pubkey(
+			&program.public_key,
+			&format!("program `{program_name}` public key"),
+		)?;
 		lines.push(format!(
 			"pub const {}: Pubkey = pubkey!(\"{}\");",
-			program_id_const_name(program.name.as_ref()),
-			program.public_key
+			program_id_const_name(program_name),
+			public_key
 		));
 	}
 
-	lines.join("\n")
+	Ok(lines.join("\n"))
 }

--- a/crates/pina_codama_renderer/src/render/scaffold.rs
+++ b/crates/pina_codama_renderer/src/render/scaffold.rs
@@ -81,7 +81,6 @@ pub(crate) fn write_files(base: &Path, files: BTreeMap<PathBuf, String>) -> Resu
 
 #[cfg(test)]
 mod tests {
-	use std::path::PathBuf;
 	use std::time::SystemTime;
 	use std::time::UNIX_EPOCH;
 
@@ -93,10 +92,10 @@ mod tests {
 			.duration_since(UNIX_EPOCH)
 			.unwrap_or_default()
 			.as_nanos();
-		let crate_dir =
-			PathBuf::from(std::env::temp_dir()).join(format!("pina-scaffold-{unique_id}"));
+		let crate_dir = std::env::temp_dir().join(format!("pina-scaffold-{unique_id}"));
 
-		ensure_crate_scaffold(&crate_dir, "DemoProgram").expect("should write scaffold");
+		ensure_crate_scaffold(&crate_dir, "DemoProgram")
+			.unwrap_or_else(|error| panic!("should write scaffold: {error}"));
 		let cargo_toml = fs::read_to_string(crate_dir.join("Cargo.toml"))
 			.unwrap_or_else(|err| panic!("failed to read generated Cargo.toml: {err}"));
 
@@ -104,6 +103,7 @@ mod tests {
 		assert!(!cargo_toml.contains("workspace = true ,"));
 		assert!(!cargo_toml.contains("\n\t[dependencies]"));
 
-		fs::remove_dir_all(&crate_dir).expect("cleanup test scaffold dir");
+		fs::remove_dir_all(&crate_dir)
+			.unwrap_or_else(|error| panic!("cleanup test scaffold dir: {error}"));
 	}
 }

--- a/crates/pina_codama_renderer/src/render/seeds.rs
+++ b/crates/pina_codama_renderer/src/render/seeds.rs
@@ -8,6 +8,7 @@ use codama_nodes::NumberFormat;
 use codama_nodes::TypeNode;
 use codama_nodes::ValueNode;
 
+use super::helpers::canonical_pubkey;
 use super::helpers::cast_signed;
 use super::helpers::cast_unsigned;
 use super::types::render_type_for_pod;
@@ -125,10 +126,11 @@ pub(crate) fn render_constant_seed_expression(
 			render_number_seed_expression(r#type, &number_value.number, context)
 		}
 		ConstantPdaSeedValue::PublicKey(public_key_value) => {
-			Ok(format!(
-				"solana_pubkey::pubkey!(\"{}\").as_ref()",
-				public_key_value.public_key
-			))
+			let public_key = canonical_pubkey(
+				&public_key_value.public_key,
+				&format!("{context} public key seed"),
+			)?;
+			Ok(format!("solana_pubkey::pubkey!(\"{public_key}\").as_ref()"))
 		}
 		ConstantPdaSeedValue::Constant(constant_value) => {
 			match constant_value.value.as_ref() {


### PR DESCRIPTION
## Summary

- validate generated Rust before replacing the last-known-good output
- reject unsafe file stems, path escapes, symlinked destinations, and unmanaged recursive deletion
- render untrusted docs, errors, public keys, and seeds as syntax-safe Rust tokens
- add regression coverage for traversal, injection, failed rendering, and cleanup boundaries

## Validation

- `cargo test --locked -p pina_codama_renderer` (27 tests passed)
- `cargo clippy --locked -p pina_codama_renderer --lib -- -D warnings`
- `dprint check` and `git diff --check`

Created on behalf of Ifiok Jr. (`@ifiokjr`), using OpenAI GPT-5.6 with high reasoning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened generated output handling by rejecting unsafe paths, symlinks, invalid names, and malformed Rust source.
  * Prevented deletion or replacement of unmanaged existing files and directories.
  * Improved validation and canonicalization of public-key values.
  * Improved multiline documentation formatting and Rust string escaping.
* **Tests**
  * Added coverage for unsafe paths, symlinks, unmanaged content, render failures, and documentation formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->