### PR TITLE
fix(pina): preflight fallible account mutations

### DIFF
--- a/.changeset/preflight_account_mutations.md
+++ b/.changeset/preflight_account_mutations.md
@@ -1,0 +1,7 @@
+---
+pina: fix
+---
+
+# Preflight fallible account mutations
+
+Check active borrows and the per-instruction growth limit before moving rent or closing account balances, so expected validation failures do not leave helper callers with partially mutated in-memory state.

--- a/crates/pina/src/cpi.rs
+++ b/crates/pina/src/cpi.rs
@@ -355,10 +355,9 @@ pub fn allocate_account_with_bump<'a>(
 /// Maximum number of bytes an account may grow by in a single instruction.
 ///
 /// This limit is enforced by the Solana runtime. Attempting to grow an account
-/// by more than this amount will cause `resize` to return
-/// `ProgramError::InvalidRealloc`.
+/// by more than this amount returns `ProgramError::InvalidRealloc`.
 #[cfg(feature = "account-resize")]
-pub const MAX_PERMITTED_DATA_INCREASE: usize = 10_240;
+pub const MAX_PERMITTED_DATA_INCREASE: usize = pinocchio::account::MAX_PERMITTED_DATA_INCREASE;
 
 /// Reallocates an account to `new_size` bytes, adjusting rent automatically.
 ///
@@ -375,6 +374,13 @@ pub const MAX_PERMITTED_DATA_INCREASE: usize = 10_240;
 /// The Solana runtime limits account growth to [`MAX_PERMITTED_DATA_INCREASE`]
 /// (10 KiB) per top-level instruction. Exceeding this limit returns
 /// `ProgramError::InvalidRealloc`.
+///
+/// This helper rejects a single growth request larger than that limit before
+/// moving rent lamports. Pinocchio does not expose the account's original
+/// serialized length, so a later growth after an earlier reallocation in the
+/// same instruction can still fail during `resize` after rent lamports have
+/// moved. Propagate that error instead of catching it to preserve transaction
+/// atomicity.
 ///
 /// # Errors
 ///
@@ -413,6 +419,13 @@ pub fn realloc_account(
 /// The Solana runtime limits account growth to [`MAX_PERMITTED_DATA_INCREASE`]
 /// (10 KiB) per top-level instruction. Exceeding this limit returns
 /// `ProgramError::InvalidRealloc`.
+///
+/// This helper rejects a single growth request larger than that limit before
+/// moving rent lamports. Pinocchio does not expose the account's original
+/// serialized length, so a later growth after an earlier reallocation in the
+/// same instruction can still fail during `resize` after rent lamports have
+/// moved. Propagate that error instead of catching it to preserve transaction
+/// atomicity.
 ///
 /// # Errors
 ///
@@ -453,6 +466,14 @@ fn realloc_account_inner(
 	// Early return when the size is unchanged.
 	if new_size == current_size {
 		return Ok(());
+	}
+
+	// `resize` would reject either condition after rent movement. The original
+	// serialized length is not exposed, so cumulative growth is still checked by
+	// the runtime and its error must be propagated by callers.
+	account.check_borrow_mut()?;
+	if new_size.saturating_sub(current_size) > MAX_PERMITTED_DATA_INCREASE {
+		return Err(ProgramError::InvalidRealloc);
 	}
 
 	let rent = Rent::get()?;

--- a/crates/pina/src/impls.rs
+++ b/crates/pina/src/impls.rs
@@ -753,6 +753,8 @@ fn checked_close_recipient_balance(
 		return Err(ProgramError::InvalidArgument);
 	}
 
+	account.check_borrow_mut()?;
+
 	checked_close_balance(account.lamports(), recipient.lamports()).inspect_err(|_| {
 		log!("Could not close account: lamport overflow");
 		log_caller();

--- a/crates/pina/tests/adversarial_invariants.rs
+++ b/crates/pina/tests/adversarial_invariants.rs
@@ -518,6 +518,44 @@ fn close_with_recipient_overflow_preserves_balances_and_data() {
 }
 
 #[test]
+fn close_with_recipient_active_borrow_preserves_balances_and_data() {
+	let state_bytes = build_balance_state_bytes(55);
+	let unique_accounts = [
+		AccountBuilder::new()
+			.address(fake_address(22))
+			.owner(system::ID)
+			.lamports(300)
+			.is_writable(true),
+		AccountBuilder::new()
+			.address(fake_address(23))
+			.owner(TEST_PROGRAM_ID)
+			.lamports(700)
+			.data(&state_bytes)
+			.is_writable(true),
+	];
+
+	let (_input, mut accounts, count) = load_accounts!(&unique_accounts, 1, 4);
+	let account_views = initialized_account_views(&mut accounts, count);
+	let recipient_before = account_views[0].lamports();
+	let source_before = account_views[1].lamports();
+	let data_len_before = account_views[1].data_len();
+	let (recipient, sources) = account_views.split_at_mut(1);
+	let (source, duplicate) = sources.split_at_mut(1);
+	let data = duplicate[0]
+		.try_borrow()
+		.unwrap_or_else(|error| panic!("borrow duplicate account data: {error:?}"));
+
+	let result = source[0].close_with_recipient(&mut recipient[0]);
+
+	assert_eq!(result, Err(ProgramError::AccountBorrowFailed));
+	assert_eq!(recipient[0].lamports(), recipient_before);
+	assert_eq!(source[0].lamports(), source_before);
+	assert_eq!(source[0].data_len(), data_len_before);
+	assert!(!source[0].is_data_empty());
+	drop(data);
+}
+
+#[test]
 fn assert_type_rejects_wrong_owner_before_trusting_bytes() {
 	let unique_accounts = [AccountBuilder::new()
 		.address(fake_address(22))

--- a/crates/pina/tests/cpi_helpers.rs
+++ b/crates/pina/tests/cpi_helpers.rs
@@ -146,6 +146,28 @@ fn realloc_rejects_oversized_single_growth_before_moving_rent() {
 	assert_eq!(account.data_len(), 8);
 }
 
+#[cfg(feature = "account-resize")]
+#[test]
+fn realloc_allows_the_maximum_single_growth_through_preflight() {
+	let owner = Address::new_from_array([9u8; 32]);
+	let mut stored_account = TestAccount::<8>::new(Address::new_from_array([1u8; 32]), false, true);
+	let mut stored_payer = TestAccount::<8>::new(Address::new_from_array([2u8; 32]), true, true);
+	let mut account = stored_account.view();
+	let mut payer = stored_payer.view();
+	let account_lamports = account.lamports();
+	let payer_lamports = payer.lamports();
+	let new_size = account.data_len() + MAX_PERMITTED_DATA_INCREASE;
+
+	let result = realloc_account(&mut account, new_size, &mut payer, &owner);
+
+	// Host tests cannot load the on-chain Rent sysvar. Reaching that error proves
+	// the exact runtime growth limit passed the preflight `>` check.
+	assert_eq!(result, Err(ProgramError::UnsupportedSysvar));
+	assert_eq!(account.lamports(), account_lamports);
+	assert_eq!(payer.lamports(), payer_lamports);
+	assert_eq!(account.data_len(), 8);
+}
+
 #[repr(C)]
 struct TestAccount<const N: usize> {
 	header: RuntimeAccount,

--- a/crates/pina/tests/cpi_helpers.rs
+++ b/crates/pina/tests/cpi_helpers.rs
@@ -102,6 +102,50 @@ fn realloc_functions_are_exported() {
 	) -> pinocchio::ProgramResult = realloc_account_zero;
 }
 
+#[cfg(feature = "account-resize")]
+#[test]
+fn realloc_rejects_an_active_borrow_before_moving_rent() {
+	let owner = Address::new_from_array([9u8; 32]);
+	let mut stored_account = TestAccount::<8>::new(Address::new_from_array([1u8; 32]), false, true);
+	let mut stored_payer = TestAccount::<8>::new(Address::new_from_array([2u8; 32]), true, true);
+	let mut account = stored_account.view();
+	let duplicate = account;
+	let mut payer = stored_payer.view();
+	let account_lamports = account.lamports();
+	let payer_lamports = payer.lamports();
+	let data = duplicate
+		.try_borrow()
+		.unwrap_or_else(|error| panic!("borrow account data: {error:?}"));
+
+	let result = realloc_account(&mut account, 16, &mut payer, &owner);
+
+	assert_eq!(result, Err(ProgramError::AccountBorrowFailed));
+	assert_eq!(account.lamports(), account_lamports);
+	assert_eq!(payer.lamports(), payer_lamports);
+	assert_eq!(account.data_len(), 8);
+	drop(data);
+}
+
+#[cfg(feature = "account-resize")]
+#[test]
+fn realloc_rejects_oversized_single_growth_before_moving_rent() {
+	let owner = Address::new_from_array([9u8; 32]);
+	let mut stored_account = TestAccount::<8>::new(Address::new_from_array([1u8; 32]), false, true);
+	let mut stored_payer = TestAccount::<8>::new(Address::new_from_array([2u8; 32]), true, true);
+	let mut account = stored_account.view();
+	let mut payer = stored_payer.view();
+	let account_lamports = account.lamports();
+	let payer_lamports = payer.lamports();
+	let new_size = account.data_len() + MAX_PERMITTED_DATA_INCREASE + 1;
+
+	let result = realloc_account(&mut account, new_size, &mut payer, &owner);
+
+	assert_eq!(result, Err(ProgramError::InvalidRealloc));
+	assert_eq!(account.lamports(), account_lamports);
+	assert_eq!(payer.lamports(), payer_lamports);
+	assert_eq!(account.data_len(), 8);
+}
+
 #[repr(C)]
 struct TestAccount<const N: usize> {
 	header: RuntimeAccount,

--- a/crates/pina/tests/miri_loader_guards.rs
+++ b/crates/pina/tests/miri_loader_guards.rs
@@ -309,6 +309,86 @@ fn as_account_mut_rejects_shared_and_mutable_reborrows_under_miri() {
 	assert_eq!(state.value.get(), 99);
 }
 
+#[test]
+fn close_with_recipient_rejects_an_active_alias_borrow_under_miri() {
+	let state_bytes = build_test_state_bytes(22);
+	let accounts = [
+		AccountBuilder::new()
+			.address(Address::new_from_array([1; ADDRESS_BYTES]))
+			.owner(TEST_PROGRAM_ID)
+			.lamports(700)
+			.data(&state_bytes)
+			.is_writable(true),
+		AccountBuilder::new()
+			.address(Address::new_from_array([2; ADDRESS_BYTES]))
+			.lamports(300)
+			.is_writable(true),
+	];
+
+	let mut input = unsafe { create_test_input(&accounts, &[]) };
+	let mut accts = [UNINIT; 4];
+	let (account_views, _) = unsafe { deserialize_test_input::<4>(&mut input, &mut accts) };
+	let source_alias = account_views[0];
+	let source_lamports = account_views[0].lamports();
+	let recipient_lamports = account_views[1].lamports();
+	let source_data_len = account_views[0].data_len();
+	let data = source_alias
+		.try_borrow()
+		.unwrap_or_else(|error| panic!("borrow source alias: {error:?}"));
+	let (source, recipient) = account_views.split_at_mut(1);
+
+	let result = source[0].close_with_recipient(&mut recipient[0]);
+
+	assert_eq!(result, Err(ProgramError::AccountBorrowFailed));
+	assert_eq!(source[0].lamports(), source_lamports);
+	assert_eq!(recipient[0].lamports(), recipient_lamports);
+	assert_eq!(source[0].data_len(), source_data_len);
+	drop(data);
+}
+
+#[cfg(feature = "account-resize")]
+#[test]
+fn realloc_rejects_an_active_alias_borrow_under_miri() {
+	let state_bytes = build_test_state_bytes(33);
+	let accounts = [
+		AccountBuilder::new()
+			.address(Address::new_from_array([3; ADDRESS_BYTES]))
+			.owner(TEST_PROGRAM_ID)
+			.lamports(700)
+			.data(&state_bytes)
+			.is_writable(true),
+		AccountBuilder::new()
+			.address(Address::new_from_array([4; ADDRESS_BYTES]))
+			.lamports(300)
+			.is_writable(true),
+	];
+
+	let mut input = unsafe { create_test_input(&accounts, &[]) };
+	let mut accts = [UNINIT; 4];
+	let (account_views, _) = unsafe { deserialize_test_input::<4>(&mut input, &mut accts) };
+	let source_alias = account_views[0];
+	let source_lamports = account_views[0].lamports();
+	let payer_lamports = account_views[1].lamports();
+	let source_data_len = account_views[0].data_len();
+	let data = source_alias
+		.try_borrow()
+		.unwrap_or_else(|error| panic!("borrow source alias: {error:?}"));
+	let (source, payer) = account_views.split_at_mut(1);
+
+	let result = realloc_account(
+		&mut source[0],
+		source_data_len + 1,
+		&mut payer[0],
+		&TEST_PROGRAM_ID,
+	);
+
+	assert_eq!(result, Err(ProgramError::AccountBorrowFailed));
+	assert_eq!(source[0].lamports(), source_lamports);
+	assert_eq!(payer[0].lamports(), payer_lamports);
+	assert_eq!(source[0].data_len(), source_data_len);
+	drop(data);
+}
+
 #[cfg(feature = "token")]
 #[test]
 fn as_token_mint_rejects_overlapping_mutable_borrows_under_miri() {


### PR DESCRIPTION
## Summary

- preflight active mutable borrows before reallocating or closing accounts
- reject single-call account growth above the Solana runtime limit before moving rent
- document the remaining cumulative-growth atomicity requirement
- add normal and Miri-oriented regressions for duplicate views and oversized growth

## Validation

- `cargo test --locked -p pina --all-features`
- `cargo check --locked -p pina --no-default-features --features account-resize`
- focused Miri suite previously passed (7/7)
- `dprint check` and `git diff --check`

Created on behalf of Ifiok Jr. (`@ifiokjr`), using OpenAI GPT-5.6 with high reasoning.
