### PR TITLE
fix(release): refresh standalone fuzz lockfiles during release preparation

### DIFF
--- a/monochange.toml
+++ b/monochange.toml
@@ -121,9 +121,13 @@ enabled = true
 versioned_files = ["Cargo.toml"]
 # Refresh Cargo.lock after a release bumps the workspace version. All pina
 # crates inherit `version = { workspace = true }`, so `cargo update --workspace`
-# syncs exactly those lockfile entries without touching dependencies.
+# syncs exactly those lockfile entries without touching dependencies. The
+# standalone fuzz workspaces keep their own lockfiles, so they must be refreshed
+# separately or `cargo check --locked` fails on the release PR.
 lockfile_commands = [
 	{ command = "cargo update --workspace", cwd = ".", shell = "bash" },
+	{ command = "cargo update --workspace --manifest-path crates/pina_fuzz/Cargo.toml", cwd = ".", shell = "bash" },
+	{ command = "cargo update --workspace --manifest-path crates/pina_fuzz/fuzz/Cargo.toml", cwd = ".", shell = "bash" },
 ]
 
 [ecosystems.cargo.publish]


### PR DESCRIPTION
## Summary

The `test` CI job fails on every release pull request with:

```
error: cannot update the lock file crates/pina_fuzz/fuzz/Cargo.lock because --locked was passed to prevent this
```

When a release bumps the workspace version, monochange refreshes the root `Cargo.lock` via its `lockfile_commands`, but the standalone fuzz workspaces (`crates/pina_fuzz` and `crates/pina_fuzz/fuzz`) keep their own lockfiles that pin the `pina` version. Those lockfiles go stale, and `test:all`'s `cargo check --locked` on the fuzz targets fails.

## Implementation

Extend the `[ecosystems.cargo]` `lockfile_commands` in `monochange.toml` to also run `cargo update --workspace` against both standalone fuzz manifests, so the release PR ships in-sync lockfiles and the CI test job passes. Verified end-to-end: running `monochange step prepare-release` with the new config updates all three lockfiles (root, `crates/pina_fuzz`, `crates/pina_fuzz/fuzz`) to the bumped version, and `cargo check --manifest-path crates/pina_fuzz/fuzz/Cargo.toml --all-targets --locked` then passes.

_Created on behalf of Ifiok Jr. ([@ifiokjr](https://github.com/ifiokjr)) by pi using GPT-5.1 at high thinking._
