### PR TITLE
fix(pina): correct CPI introspection guarantee

### DIFF
--- a/.changeset/correct_cpi_introspection_claim.md
+++ b/.changeset/correct_cpi_introspection_claim.md
@@ -1,0 +1,8 @@
+---
+pina: fix
+pina_cli: docs
+---
+
+# Correct the CPI introspection guarantee
+
+Expose `assert_current_instruction_program_id` for the guarantee the Instructions sysvar can actually provide. Deprecate the misleading `assert_no_cpi` name because transaction-level instruction metadata cannot detect self-CPI.

--- a/crates/pina/src/introspection.rs
+++ b/crates/pina/src/introspection.rs
@@ -76,7 +76,7 @@ pub fn assert_current_instruction_program_id(
 /// not expose invocation stack height. Use it only to validate the
 /// transaction-level instruction's program ID.
 #[deprecated(
-	since = "0.8.0",
+	since = "0.9.0",
 	note = "cannot detect self-CPI; use assert_current_instruction_program_id for the actual \
 	        guarantee"
 )]

--- a/crates/pina/src/introspection.rs
+++ b/crates/pina/src/introspection.rs
@@ -3,9 +3,8 @@
 //! These utilities enable on-chain programs to inspect the transaction-level
 //! instruction list. Common use cases include:
 //!
-//! - **Flash loan guards** — verify the current instruction is not being invoked
-//!   via CPI so that atomic flash-loan exploits are prevented.
-//! - **CPI depth checks** — ensure instructions are top-level calls.
+//! - **Program checks** — verify the transaction-level instruction at the
+//!   current index targets the expected program.
 //! - **Sandwich detection** — check whether a specific program appears before or
 //!   after the current instruction in the transaction.
 //!
@@ -19,11 +18,12 @@ use pinocchio::sysvars::instructions::Instructions;
 
 use crate::ProgramResult;
 
-/// Verifies the current instruction is not being invoked via CPI.
+/// Verifies the transaction-level instruction at the current index targets the
+/// expected program.
 ///
-/// This is useful for flash loan guards: a program can ensure it is the
-/// top-level caller by checking that the instruction at the current index
-/// in the sysvar has a matching `program_id`.
+/// The Instructions sysvar does not expose CPI stack height. A self-CPI has the
+/// same program ID as its transaction-level parent, so this check must not be
+/// used as a no-CPI or flash-loan guard.
 ///
 /// # Arguments
 ///
@@ -46,17 +46,19 @@ use crate::ProgramResult;
 /// # Example
 ///
 /// ```ignore
-/// use pina::introspection::assert_no_cpi;
+/// use pina::introspection::assert_current_instruction_program_id;
 ///
 /// fn process(accounts: &mut [AccountView], program_id: &Address) -> ProgramResult {
 ///     let instructions_account = &accounts[0];
-///     // Ensure we are not being called via CPI
-///     assert_no_cpi(instructions_account, program_id)?;
+///     assert_current_instruction_program_id(instructions_account, program_id)?;
 ///     // ... rest of the instruction logic
 ///     Ok(())
 /// }
 /// ```
-pub fn assert_no_cpi(instructions_account: &AccountView, program_id: &Address) -> ProgramResult {
+pub fn assert_current_instruction_program_id(
+	instructions_account: &AccountView,
+	program_id: &Address,
+) -> ProgramResult {
 	let instructions = Instructions::try_from(instructions_account)?;
 	let current_index = instructions.load_current_index();
 	let current_ix = instructions.load_instruction_at(current_index as usize)?;
@@ -66,6 +68,20 @@ pub fn assert_no_cpi(instructions_account: &AccountView, program_id: &Address) -
 	}
 
 	Ok(())
+}
+
+/// Deprecated alias for [`assert_current_instruction_program_id`].
+///
+/// This function cannot detect self-CPI because the Instructions sysvar does
+/// not expose invocation stack height. Use it only to validate the
+/// transaction-level instruction's program ID.
+#[deprecated(
+	since = "0.8.0",
+	note = "cannot detect self-CPI; use assert_current_instruction_program_id for the actual \
+	        guarantee"
+)]
+pub fn assert_no_cpi(instructions_account: &AccountView, program_id: &Address) -> ProgramResult {
+	assert_current_instruction_program_id(instructions_account, program_id)
 }
 
 /// Returns the total number of instructions in the transaction.

--- a/crates/pina/tests/introspection.rs
+++ b/crates/pina/tests/introspection.rs
@@ -30,7 +30,7 @@ use std::alloc::alloc;
 use std::alloc::dealloc;
 
 use pina::Address;
-use pina::introspection::assert_no_cpi;
+use pina::introspection::assert_current_instruction_program_id;
 use pina::introspection::get_current_instruction_index;
 use pina::introspection::get_instruction_count;
 use pina::introspection::has_instruction_after;
@@ -335,7 +335,7 @@ fn get_current_instruction_index_returns_correct_value() {
 }
 
 #[test]
-fn assert_no_cpi_passes_when_top_level() {
+fn current_instruction_program_id_accepts_match() {
 	let instructions = vec![FakeInstruction::simple(PROGRAM_A)];
 	let sysvar_data = build_sysvar_data(&instructions, 0);
 	let builder = AccountBuilder::sysvar(sysvar_data);
@@ -343,12 +343,12 @@ fn assert_no_cpi_passes_when_top_level() {
 	let mut accounts = [UNINIT];
 	let account = unsafe { deserialize_input(&mut input, &mut accounts) };
 
-	assert_no_cpi(account, &PROGRAM_A)
-		.unwrap_or_else(|e| panic!("assert_no_cpi should pass for top-level call: {e:?}"));
+	assert_current_instruction_program_id(account, &PROGRAM_A)
+		.unwrap_or_else(|e| panic!("program ID check should accept a match: {e:?}"));
 }
 
 #[test]
-fn assert_no_cpi_fails_when_program_id_mismatch() {
+fn current_instruction_program_id_rejects_mismatch() {
 	// Current instruction is PROGRAM_A, but we claim to be PROGRAM_B
 	let instructions = vec![FakeInstruction::simple(PROGRAM_A)];
 	let sysvar_data = build_sysvar_data(&instructions, 0);
@@ -357,12 +357,12 @@ fn assert_no_cpi_fails_when_program_id_mismatch() {
 	let mut accounts = [UNINIT];
 	let account = unsafe { deserialize_input(&mut input, &mut accounts) };
 
-	let result = assert_no_cpi(account, &PROGRAM_B);
+	let result = assert_current_instruction_program_id(account, &PROGRAM_B);
 	assert_eq!(result, Err(ProgramError::InvalidAccountData));
 }
 
 #[test]
-fn assert_no_cpi_checks_correct_index() {
+fn current_instruction_program_id_checks_correct_index() {
 	// 3 instructions: [A, B, C], current=1 → B is the current program
 	let instructions = vec![
 		FakeInstruction::simple(PROGRAM_A),
@@ -376,11 +376,11 @@ fn assert_no_cpi_checks_correct_index() {
 	let account = unsafe { deserialize_input(&mut input, &mut accounts) };
 
 	// B is at index 1, so this should pass
-	assert_no_cpi(account, &PROGRAM_B)
+	assert_current_instruction_program_id(account, &PROGRAM_B)
 		.unwrap_or_else(|e| panic!("should pass for PROGRAM_B at index 1: {e:?}"));
 
 	// A is NOT at index 1, so this should fail
-	let result = assert_no_cpi(account, &PROGRAM_A);
+	let result = assert_current_instruction_program_id(account, &PROGRAM_A);
 	assert_eq!(result, Err(ProgramError::InvalidAccountData));
 }
 
@@ -493,8 +493,8 @@ fn instructions_with_accounts_and_data() {
 	let count = get_instruction_count(account).unwrap_or_else(|e| panic!("failed: {e:?}"));
 	assert_eq!(count, 1);
 
-	assert_no_cpi(account, &PROGRAM_A)
-		.unwrap_or_else(|e| panic!("assert_no_cpi should pass: {e:?}"));
+	assert_current_instruction_program_id(account, &PROGRAM_A)
+		.unwrap_or_else(|e| panic!("program ID check should pass: {e:?}"));
 }
 
 #[test]

--- a/crates/pina_cli/templates/pina-overview.md
+++ b/crates/pina_cli/templates/pina-overview.md
@@ -154,7 +154,7 @@ cargo nextest run  # Faster parallel test execution
 
 The `pina::introspection` module provides helpers for reading the Instructions sysvar at runtime. This enables:
 
-- **Flash loan guards** — verify the current instruction is not being invoked via CPI (`assert_no_cpi`)
+- **Program checks** — verify that the transaction-level instruction at the current index targets the expected program (`assert_current_instruction_program_id`). The Instructions sysvar cannot distinguish self-CPI, so this is not a no-CPI or flash-loan guard.
 - **Transaction inspection** — count instructions (`get_instruction_count`) or find the current index (`get_current_instruction_index`)
 - **Sandwich detection** — check whether a specific program appears before or after the current instruction (`has_instruction_before`, `has_instruction_after`)
 

--- a/docs/src/core-concepts.md
+++ b/docs/src/core-concepts.md
@@ -165,7 +165,7 @@ let fee = balance.checked_mul(3u64).unwrap_or(PodU64::MAX);
 
 The `pina::introspection` module provides helpers for reading the Instructions sysvar at runtime. This enables:
 
-- **Flash loan guards** — verify the current instruction is not being invoked via CPI (`assert_no_cpi`)
+- **Program checks** — verify that the transaction-level instruction at the current index targets the expected program (`assert_current_instruction_program_id`). The Instructions sysvar cannot distinguish self-CPI, so this is not a no-CPI or flash-loan guard.
 - **Transaction inspection** — count instructions (`get_instruction_count`) or find the current index (`get_current_instruction_index`)
 - **Sandwich detection** — check whether a specific program appears before or after the current instruction (`has_instruction_before`, `has_instruction_after`)
 

--- a/templates/pina-overview.t.md
+++ b/templates/pina-overview.t.md
@@ -174,7 +174,7 @@ cargo nextest run  # Faster parallel test execution
 
 The `pina::introspection` module provides helpers for reading the Instructions sysvar at runtime. This enables:
 
-- **Flash loan guards** — verify the current instruction is not being invoked via CPI (`assert_no_cpi`)
+- **Program checks** — verify that the transaction-level instruction at the current index targets the expected program (`assert_current_instruction_program_id`). The Instructions sysvar cannot distinguish self-CPI, so this is not a no-CPI or flash-loan guard.
 - **Transaction inspection** — count instructions (`get_instruction_count`) or find the current index (`get_current_instruction_index`)
 - **Sandwich detection** — check whether a specific program appears before or after the current instruction (`has_instruction_before`, `has_instruction_after`)
 


### PR DESCRIPTION
## Summary

- expose `assert_current_instruction_program_id` for the guarantee the Instructions sysvar can actually provide
- deprecate the misleading `assert_no_cpi` name without breaking existing callers
- state explicitly that self-CPI is indistinguishable and this must not be used as a flash-loan/no-CPI guard
- update the reusable overview and focused tests to use the accurately named API

## Why

The Instructions sysvar describes transaction-level instructions, not invocation stack height. A self-CPI retains the same program ID, so comparing the current instruction program cannot prove that execution is top level.

## Validation

- focused introspection tests (12/12)
- `cargo doc --locked -p pina --no-deps --all-features`
- `devenv shell -- lint:monochange`
- complete `lint:push` gate
- `git diff --check`

Created on behalf of Ifiok Jr. (`@ifiokjr`), using OpenAI GPT-5.6 with high reasoning.
