### PR TITLE
ci: harden dependency and fuzz checks

### DIFF
--- a/.github/actions/devenv/action.yml
+++ b/.github/actions/devenv/action.yml
@@ -21,13 +21,13 @@ runs:
       with:
         # Include the devenv/toolchain wiring in the cache key so cached build
         # scripts don't outlive the Nix environment that produced them.
-        prefix-key: "${{ inputs.cache-version }}-${{ hashFiles('devenv.nix', 'rust-toolchain.toml', '.github/actions/devenv/action.yml') }}"
+        prefix-key: "${{ inputs.cache-version }}-${{ hashFiles('devenv.nix', 'devenv.yaml', 'devenv.lock', 'rust-toolchain.toml', '.github/actions/devenv/action.yml') }}"
 
     - name: cache cargo binaries
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ./.bin
-        key: ${{ runner.os }}-cargo-bin-${{ inputs.cache-version }}-${{ env.RUSTUP_TOOLCHAIN }}-${{ hashFiles('devenv.nix', 'rust-toolchain.toml', '.github/actions/devenv/action.yml', 'Cargo.toml') }}
+        key: ${{ runner.os }}-cargo-bin-${{ inputs.cache-version }}-${{ env.RUSTUP_TOOLCHAIN }}-${{ hashFiles('devenv.nix', 'devenv.yaml', 'devenv.lock', 'rust-toolchain.toml', '.github/actions/devenv/action.yml', 'Cargo.toml') }}
         restore-keys: |
           ${{ runner.os }}-cargo-bin-${{ inputs.cache-version }}-
 
@@ -35,12 +35,23 @@ runs:
       uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
       with:
         github_access_token: ${{ inputs.github-token }}
+        extra_nix_config: |
+          accept-flake-config = true
+          extra-substituters = https://devenv.cachix.org
+          extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
 
     - name: setup nix environment
+      env:
+        SETUP_RETRIES: ${{ inputs.setup-retries }}
       run: |
         retry() {
           local attempts="$1"
           shift
+
+          if [[ ! "$attempts" =~ ^[1-9][0-9]*$ ]]; then
+            echo "setup-retries must be a positive integer." >&2
+            return 2
+          fi
 
           local attempt=1
           local delay=5
@@ -63,17 +74,34 @@ runs:
           done
         }
 
-        attempts="${{ inputs.setup-retries }}"
-        retry "$attempts" nix profile add --accept-flake-config nixpkgs#cachix
-        retry "$attempts" cachix use devenv
-        retry "$attempts" nix profile add nixpkgs#devenv
+        attempts="$SETUP_RETRIES"
+        devenv_revision="$(
+          nix eval --impure --raw --expr '
+            let
+              lock = builtins.fromJSON (builtins.readFile ./devenv.lock);
+              revision = lock.nodes.devenv.locked.rev;
+            in
+              if builtins.match "^[0-9a-f]{40}$" revision != null then
+                revision
+              else
+                throw "devenv.lock does not contain an immutable Devenv revision"
+          '
+        )"
+        retry "$attempts" nix profile add --accept-flake-config "github:cachix/devenv/${devenv_revision}#devenv"
       shell: bash
 
     - name: install dependencies
+      env:
+        SETUP_RETRIES: ${{ inputs.setup-retries }}
       run: |
         retry() {
           local attempts="$1"
           shift
+
+          if [[ ! "$attempts" =~ ^[1-9][0-9]*$ ]]; then
+            echo "setup-retries must be a positive integer." >&2
+            return 2
+          fi
 
           local attempt=1
           local delay=5
@@ -96,6 +124,6 @@ runs:
           done
         }
 
-        attempts="${{ inputs.setup-retries }}"
+        attempts="$SETUP_RETRIES"
         retry "$attempts" devenv shell -- bash -e -c "install:cargo:bin"
       shell: bash

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,12 @@ updates:
     # Check for updates every Monday
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,32 @@ jobs:
           test:all
         shell: devenv shell -- bash -e {0}
 
+  fuzz:
+    timeout-minutes: 30
+    runs-on: ubuntu-24.04
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: setup
+        uses: ./.github/actions/devenv
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: replay corpus and fuzz for a bounded duration
+        run: test:fuzz:smoke
+        shell: devenv shell -c -- bash -e {0}
+
+      - name: upload fuzz artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fuzz-artifacts-${{ github.sha }}
+          path: crates/pina_fuzz/fuzz/artifacts
+          if-no-files-found: ignore
+
   miri:
     timeout-minutes: 90
     runs-on: ubuntu-24.04

--- a/crates/pina_fuzz/README.md
+++ b/crates/pina_fuzz/README.md
@@ -13,6 +13,7 @@ crates/pina_fuzz/
 ├── src/lib.rs                          # Re-exports for the fuzz targets
 └── fuzz/
     ├── Cargo.toml                      # Fuzz binary crate (cargo-fuzz runner)
+    ├── seed_corpus/                    # Inputs replayed before every CI fuzz run
     └── fuzz_targets/
         ├── account_deserialize.rs      # Fuzz PinaAccount validation
         └── parse_instruction.rs        # Fuzz parse_instruction
@@ -26,19 +27,29 @@ Install `cargo-fuzz`:
 cargo install cargo-fuzz
 ```
 
-Run a fuzz target from the `fuzz/` directory:
+Run a fuzz target from the `pina_fuzz` crate directory:
 
 ```sh
-cd crates/pina_fuzz/fuzz
+cd crates/pina_fuzz
 cargo fuzz run account_deserialize
 cargo fuzz run parse_instruction
 ```
+
+Replay the committed seed corpus and run every target with the same bounded smoke test used by CI:
+
+```sh
+test:fuzz:smoke
+```
+
+CI gives each target 30 seconds of mutation time after replaying every committed seed. `PINA_FUZZ_SECONDS_PER_TARGET` can change the local duration, with a hard limit of 300 seconds per target so the smoke task remains bounded. Generated corpus entries remain under the ignored `fuzz/target/` directory; promote useful inputs into `seed_corpus/<target>/` explicitly.
 
 To reproduce a crash artifact:
 
 ```sh
 cargo fuzz run account_deserialize <crash-file>
 ```
+
+CI uploads files from `fuzz/artifacts/` when the fuzz job fails so the exact input can be downloaded and replayed locally.
 
 ## Account types under test
 

--- a/crates/pina_fuzz/fuzz/Cargo.toml
+++ b/crates/pina_fuzz/fuzz/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.0.0"
 edition = "2024"
 publish = false
 
+[package.metadata]
+cargo-fuzz = true
+
 [workspace]
 
 [dependencies]

--- a/crates/pina_fuzz/fuzz/seed_corpus/account_deserialize/short-input
+++ b/crates/pina_fuzz/fuzz/seed_corpus/account_deserialize/short-input
@@ -1,0 +1,1 @@
+pina-account-seed

--- a/crates/pina_fuzz/fuzz/seed_corpus/parse_instruction/discriminator-input
+++ b/crates/pina_fuzz/fuzz/seed_corpus/parse_instruction/discriminator-input
@@ -1,0 +1,1 @@
+pina-instruction-seed

--- a/devenv.nix
+++ b/devenv.nix
@@ -361,6 +361,15 @@ in
       description = "Run workspace tests and compile the standalone fuzz targets.";
       binary = "bash";
     };
+    "test:fuzz:smoke" = {
+      exec = ''
+        set -euo pipefail
+        export PATH=${pkgs.cargo-fuzz}/bin:"$PATH"
+        ${pkgs.bash}/bin/bash ${lib.escapeShellArg "${currentDir}/scripts/run-fuzz-smoke.sh"}
+      '';
+      description = "Replay the committed fuzz corpus and run every target for a bounded duration.";
+      binary = "bash";
+    };
     "test:miri" = {
       exec = ''
         set -euo pipefail
@@ -968,12 +977,21 @@ in
       description = "Run RustSec advisory audit for Cargo.lock.";
       binary = "bash";
     };
+    "security:npm-audit" = {
+      exec = ''
+        set -euo pipefail
+        ${pkgs.pnpm}/bin/pnpm --dir ${lib.escapeShellArg currentDir} audit
+      '';
+      description = "Fail on moderate-or-higher advisories in the pnpm lockfile.";
+      binary = "bash";
+    };
     "verify:security" = {
       exec = ''
         set -euo pipefail
         security:dylint
         security:deny
         security:audit
+        security:npm-audit
       '';
       description = "Run all custom and dependency security checks.";
       binary = "bash";

--- a/docs/src/ci-and-releases.md
+++ b/docs/src/ci-and-releases.md
@@ -7,8 +7,9 @@ The GitHub CI workflow verifies:
 - `lint:clippy`
 - `lint:format`
 - `verify:docs`
-- `verify:security`
+- `verify:security` (Rust security checks plus moderate-or-higher npm lockfile advisories)
 - `test:all` (`cargo test --all-features --locked`)
+- `test:fuzz:smoke` (replay committed seeds, then fuzz every target for 30 seconds)
 - `feature-matrix` for `pina` across explicit configurations:
   - `default` (`build:pina:default` + `test:pina:default`)
   - `no-default` (`build:pina:no-default-only` + `test:pina:no-default` + `doc:pina:no-default`)
@@ -25,6 +26,16 @@ Separate PR workflows also verify:
 - `compute-units` for tracked static CU regression reporting vs the PR base revision
 
 This keeps code quality, behavior, documentation build health, feature-flag compatibility, and performance visibility aligned.
+
+## Dependency and bootstrap integrity
+
+CI installs Devenv from the immutable revision in `devenv.lock`, configures the Devenv binary cache with its static endpoint and public key, and includes the environment lockfiles in tool-cache keys. The shared security task also runs `pnpm audit` at the moderate severity threshold. Weekly grouped Dependabot updates keep the npm lockfile current without making every newly available package version a blocking PR check.
+
+## Fuzz smoke testing
+
+The `fuzz` CI job runs in parallel with the rest of CI. It installs `cargo-fuzz` from the Nixpkgs revision locked by `devenv.lock`, replays every input under `crates/pina_fuzz/fuzz/seed_corpus/`, and gives each fuzz target 30 seconds of mutation time. Keeping both targets in one bounded job limits runner overhead and avoids adding their durations to the main test job's critical path.
+
+Failed runs upload `crates/pina_fuzz/fuzz/artifacts/`. After reproducing a useful artifact locally, add it to the corresponding seed corpus so later CI runs replay the regression before mutation starts.
 
 ## Compute-unit regression policy
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  brace-expansion@>=4.0.0 <5.0.9: 5.0.9
+  picomatch@>=4.0.0 <4.0.4: 4.0.4
+  vite@>=7.0.0 <=7.3.4: 7.3.5
+  ws@>=8.0.0 <8.21.0: 8.21.0
+
 importers:
 
   .:
@@ -53,7 +59,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.1
-        version: 4.1.1(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0))
+        version: 4.1.1(@types/node@25.5.0)(vite@7.3.5(@types/node@25.5.0))
 
   codama/tests/quasar-svm:
     devDependencies:
@@ -77,7 +83,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.1
-        version: 4.1.1(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0))
+        version: 4.1.1(@types/node@25.5.0)(vite@7.3.5(@types/node@25.5.0))
 
   packages/nodes-from-pina:
     dependencies:
@@ -99,7 +105,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.1
-        version: 4.1.1(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0))
+        version: 4.1.1(@types/node@25.5.0)(vite@7.3.5(@types/node@25.5.0))
 
 packages:
 
@@ -1613,7 +1619,7 @@ packages:
     resolution: {integrity: sha512-h3BOylsfsCLPeceuCPAAJ+BvNwSENgJa4hXoXu4im0bs9Lyp4URc4JYK4pWLZ4pG/UQn7AT92K6IByi6rE6g3A==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: 7.3.5
     peerDependenciesMeta:
       msw:
         optional: true
@@ -1651,9 +1657,9 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  brace-expansion@5.0.3:
-    resolution: {integrity: sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
@@ -1771,7 +1777,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: 4.0.4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -1947,8 +1953,8 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
   picomatch@4.0.5:
@@ -2127,8 +2133,8 @@ packages:
   undici-types@8.10.0:
     resolution: {integrity: sha512-ibvdovq3nCFs8Msrd95BW+zUOq+aOVbT+wpHUoPWhztbHEoPc6oof51iFDB6Es8lTKvNvVW9jNSAB8dwrKTMGg==}
 
-  vite@7.3.1:
-    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+  vite@7.3.5:
+    resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -2181,7 +2187,7 @@ packages:
       '@vitest/ui': 4.1.1
       happy-dom: '*'
       jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: 7.3.5
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -2207,8 +2213,8 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -3287,7 +3293,7 @@ snapshots:
       '@solana/functional': 6.5.0(typescript@5.9.3)
       '@solana/rpc-subscriptions-spec': 6.5.0(typescript@5.9.3)
       '@solana/subscribable': 6.5.0(typescript@5.9.3)
-      ws: 8.20.0
+      ws: 8.21.0
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -3658,13 +3664,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.1(vite@7.3.1(@types/node@25.5.0))':
+  '@vitest/mocker@4.1.1(vite@7.3.5(@types/node@25.5.0))':
     dependencies:
       '@vitest/spy': 4.1.1
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.5.0)
+      vite: 7.3.5(@types/node@25.5.0)
 
   '@vitest/pretty-format@4.1.1':
     dependencies:
@@ -3698,7 +3704,7 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  brace-expansion@5.0.3:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -3847,9 +3853,9 @@ snapshots:
   fastestsmallesttextencoderdecoder@1.0.22:
     optional: true
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
@@ -3972,7 +3978,7 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.3
+      brace-expansion: 5.0.9
 
   minipass@7.1.3: {}
 
@@ -4010,7 +4016,7 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@4.0.3: {}
+  picomatch@4.0.4: {}
 
   picomatch@4.0.5: {}
 
@@ -4162,8 +4168,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinyglobby@0.2.17:
     dependencies:
@@ -4216,11 +4222,11 @@ snapshots:
 
   undici-types@8.10.0: {}
 
-  vite@7.3.1(@types/node@25.5.0):
+  vite@7.3.5(@types/node@25.5.0):
     dependencies:
       esbuild: 0.27.7
-      fdir: 6.5.0(picomatch@4.0.5)
-      picomatch: 4.0.5
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
       postcss: 8.5.26
       rollup: 4.62.4
       tinyglobby: 0.2.17
@@ -4228,10 +4234,10 @@ snapshots:
       '@types/node': 25.5.0
       fsevents: 2.3.3
 
-  vitest@4.1.1(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0)):
+  vitest@4.1.1(@types/node@25.5.0)(vite@7.3.5(@types/node@25.5.0)):
     dependencies:
       '@vitest/expect': 4.1.1
-      '@vitest/mocker': 4.1.1(vite@7.3.1(@types/node@25.5.0))
+      '@vitest/mocker': 4.1.1(vite@7.3.5(@types/node@25.5.0))
       '@vitest/pretty-format': 4.1.1
       '@vitest/runner': 4.1.1
       '@vitest/snapshot': 4.1.1
@@ -4242,13 +4248,13 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.1(@types/node@25.5.0)
+      vite: 7.3.5(@types/node@25.5.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.5.0
@@ -4260,6 +4266,6 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  ws@8.20.0: {}
+  ws@8.21.0: {}
 
   ws@8.21.3: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,8 +9,17 @@ allowBuilds:
   esbuild: true
   koffi: true
 
+audit:
+  level: moderate
+
 onlyBuiltDependencies:
   - esbuild
   - koffi
+
+overrides:
+  "brace-expansion@>=4.0.0 <5.0.9": 5.0.9
+  "picomatch@>=4.0.0 <4.0.4": 4.0.4
+  "vite@>=7.0.0 <=7.3.4": 7.3.5
+  "ws@>=8.0.0 <8.21.0": 8.21.0
 
 useNodeVersion: 24.13.0

--- a/scripts/run-fuzz-smoke.sh
+++ b/scripts/run-fuzz-smoke.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly FUZZ_SECONDS_PER_TARGET="${PINA_FUZZ_SECONDS_PER_TARGET:-30}"
+readonly MAX_FUZZ_SECONDS_PER_TARGET=300
+readonly FUZZ_INPUT_TIMEOUT_SECONDS=10
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly ROOT_DIR
+readonly FUZZ_CRATE_DIR="$ROOT_DIR/crates/pina_fuzz"
+readonly FUZZ_DIR="$FUZZ_CRATE_DIR/fuzz"
+readonly SEED_CORPUS_DIR="$FUZZ_DIR/seed_corpus"
+readonly RUNTIME_CORPUS_DIR="$FUZZ_DIR/target/smoke-corpus"
+readonly -a FUZZ_TARGETS=(account_deserialize parse_instruction)
+
+if [[ ! "$FUZZ_SECONDS_PER_TARGET" =~ ^[1-9][0-9]*$ ]]; then
+	echo "PINA_FUZZ_SECONDS_PER_TARGET must be a positive integer." >&2
+	exit 1
+fi
+
+if ((FUZZ_SECONDS_PER_TARGET > MAX_FUZZ_SECONDS_PER_TARGET)); then
+	echo "PINA_FUZZ_SECONDS_PER_TARGET cannot exceed $MAX_FUZZ_SECONDS_PER_TARGET." >&2
+	exit 1
+fi
+
+if ! command -v cargo-fuzz >/dev/null 2>&1; then
+	echo "cargo-fuzz is required to run the fuzz smoke test." >&2
+	exit 1
+fi
+
+cd "$FUZZ_CRATE_DIR"
+shopt -s nullglob
+
+for target in "${FUZZ_TARGETS[@]}"; do
+	target_seed_dir="$SEED_CORPUS_DIR/$target"
+	target_runtime_dir="$RUNTIME_CORPUS_DIR/$target"
+	seed_inputs=("$target_seed_dir"/*)
+
+	if ((${#seed_inputs[@]} == 0)); then
+		echo "No committed seed corpus found for $target." >&2
+		exit 1
+	fi
+
+	mkdir -p "$target_runtime_dir"
+
+	for seed_input in "${seed_inputs[@]}"; do
+		[[ -f "$seed_input" ]] || continue
+		echo "Replaying $seed_input..."
+		cargo fuzz run "$target" "$seed_input"
+		cp "$seed_input" "$target_runtime_dir/"
+	done
+
+	echo "Fuzzing $target for ${FUZZ_SECONDS_PER_TARGET}s..."
+	cargo fuzz run "$target" "$target_runtime_dir" -- \
+		"-max_total_time=$FUZZ_SECONDS_PER_TARGET" \
+		"-timeout=$FUZZ_INPUT_TIMEOUT_SECONDS"
+done


### PR DESCRIPTION
## Summary

- bootstrap Devenv from the immutable revision recorded in `devenv.lock` and include environment locks in cache keys
- add weekly npm updates plus a moderate-severity audit policy with narrowly scoped advisory overrides
- replay committed fuzz seeds and exercise every fuzz target for a bounded interval in pull-request CI

## Validation

- `test:fuzz:smoke` (both targets, committed seed replay plus 30-second mutation windows)
- `pnpm install --frozen-lockfile`
- `pnpm audit` / `security:npm-audit`
- `pnpm run check:js`
- nodes-from-pina tests, all IDL fixtures, LiteSVM, and Quasar type-check/runtime coverage
- `dprint check`, `shellcheck`, `bash -n`, `actionlint`, `zizmor`, docs, monochange, and `git diff --check`

Created on behalf of Ifiok Jr. (@ifiokjr), using OpenAI GPT-5.6 with high reasoning.