### PR TITLE
fix(release): preserve macro dev dependency range

### DIFF
--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -30,6 +30,7 @@ jobs:
       - name: preview release
         run: |
           set -euo pipefail
+          scripts/preserve-pina-dev-dependency-range.sh --check
           echo "## Release Preview" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           if ! ls .changeset/*.md 1>/dev/null 2>&1; then

--- a/monochange.toml
+++ b/monochange.toml
@@ -65,6 +65,7 @@ steps = [
 help_text = "Prepare, format, commit, and open the release pull request."
 steps = [
 	{ name = "prepare release", type = "PrepareRelease", allow_empty_changesets = true, inputs = { format = "json" } },
+	{ name = "preserve macro test dependency range", type = "Command", shell = "bash", command = "scripts/preserve-pina-dev-dependency-range.sh", when = "{{ number_of_changesets > 0 }}" },
 	{ name = "format release commit", type = "Command", shell = "bash", command = "fix:format", when = "{{ number_of_changesets > 0 }}" },
 	{ name = "commit release", type = "CommitRelease", inputs = { stage_all = true, no_verify = true }, when = "{{ number_of_changesets > 0 }}" },
 	{ name = "open release request", type = "OpenReleaseRequest", inputs = { stage_all = true, no_verify = true }, when = "{{ number_of_changesets > 0 }}" },

--- a/scripts/preserve-pina-dev-dependency-range.sh
+++ b/scripts/preserve-pina-dev-dependency-range.sh
@@ -13,15 +13,31 @@ if [[ "$MODE" != "write" && "$MODE" != "--check" ]]; then
 	exit 2
 fi
 
-if ! command -v taplo >/dev/null 2>&1; then
-	echo "taplo is required to preserve the Pina development dependency range." >&2
-	exit 1
-fi
+read_manifest_values() {
+	cargo metadata \
+		--format-version 1 \
+		--locked \
+		--manifest-path "$MANIFEST" \
+		--no-deps |
+		jq -er '
+			[
+				.packages[]
+				| select(.name == "pina_macros")
+				| .version,
+				  (.dependencies[] | select(.name == "pina" and .kind == "dev") | .req)
+			]
+			| select(length == 2)
+			| .[]
+		'
+}
 
-if ! current_range="$(taplo get --file-path "$MANIFEST" --strip-newline workspace.dependencies.pina.version 2>/dev/null)"; then
-	echo "Cargo.toml must define workspace.dependencies.pina.version." >&2
+if ! manifest_values="$(read_manifest_values)"; then
+	echo "Cargo metadata must contain exactly one pina_macros package and its Pina development dependency." >&2
 	exit 1
 fi
+workspace_version="$(sed -n '1p' <<<"$manifest_values")"
+readonly workspace_version
+current_range="$(sed -n '2p' <<<"$manifest_values")"
 if [[ "$current_range" == "$EXPECTED_RANGE" ]]; then
 	exit 0
 fi
@@ -31,8 +47,7 @@ if [[ "$MODE" == "--check" ]]; then
 	exit 1
 fi
 
-workspace_version="$(taplo get --file-path "$MANIFEST" --strip-newline workspace.package.version)"
-if [[ "$current_range" != "$workspace_version" ]]; then
+if [[ "$current_range" != "^$workspace_version" ]]; then
 	echo "Refusing to replace unexpected Pina dependency range '$current_range'." >&2
 	exit 1
 fi
@@ -43,7 +58,7 @@ if [[ "$matching_lines" != "1" ]]; then
 	exit 1
 fi
 
-PINA_CURRENT_RANGE="$current_range" \
+PINA_CURRENT_RANGE="$workspace_version" \
 	PINA_EXPECTED_RANGE="$EXPECTED_RANGE" \
 	perl -pi -e '
 		if (/^pina = /) {
@@ -52,7 +67,11 @@ PINA_CURRENT_RANGE="$current_range" \
 		}
 	' "$MANIFEST"
 
-updated_range="$(taplo get --file-path "$MANIFEST" --strip-newline workspace.dependencies.pina.version)"
+if ! manifest_values="$(read_manifest_values)"; then
+	echo "Cargo metadata became invalid after restoring the Pina development dependency range." >&2
+	exit 1
+fi
+updated_range="$(sed -n '2p' <<<"$manifest_values")"
 if [[ "$updated_range" != "$EXPECTED_RANGE" ]]; then
 	echo "Failed to restore the Pina development dependency range." >&2
 	exit 1

--- a/scripts/preserve-pina-dev-dependency-range.sh
+++ b/scripts/preserve-pina-dev-dependency-range.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly EXPECTED_RANGE=">=0.8.0, <1.0.0"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly ROOT_DIR
+readonly MANIFEST="$ROOT_DIR/Cargo.toml"
+readonly MODE="${1:-write}"
+
+if [[ "$MODE" != "write" && "$MODE" != "--check" ]]; then
+	echo "Usage: $0 [--check]" >&2
+	exit 2
+fi
+
+if ! command -v taplo >/dev/null 2>&1; then
+	echo "taplo is required to preserve the Pina development dependency range." >&2
+	exit 1
+fi
+
+if ! current_range="$(taplo get --file-path "$MANIFEST" --strip-newline workspace.dependencies.pina.version 2>/dev/null)"; then
+	echo "Cargo.toml must define workspace.dependencies.pina.version." >&2
+	exit 1
+fi
+if [[ "$current_range" == "$EXPECTED_RANGE" ]]; then
+	exit 0
+fi
+
+if [[ "$MODE" == "--check" ]]; then
+	echo "workspace.dependencies.pina.version must remain '$EXPECTED_RANGE'; found '$current_range'." >&2
+	exit 1
+fi
+
+workspace_version="$(taplo get --file-path "$MANIFEST" --strip-newline workspace.package.version)"
+if [[ "$current_range" != "$workspace_version" ]]; then
+	echo "Refusing to replace unexpected Pina dependency range '$current_range'." >&2
+	exit 1
+fi
+
+matching_lines="$(grep -c '^pina = ' "$MANIFEST" || true)"
+if [[ "$matching_lines" != "1" ]]; then
+	echo "Expected exactly one workspace dependency named pina; found $matching_lines." >&2
+	exit 1
+fi
+
+PINA_CURRENT_RANGE="$current_range" \
+	PINA_EXPECTED_RANGE="$EXPECTED_RANGE" \
+	perl -pi -e '
+		if (/^pina = /) {
+			$replaced = s/version = "\Q$ENV{PINA_CURRENT_RANGE}\E"/version = "$ENV{PINA_EXPECTED_RANGE}"/;
+			die "pina dependency line did not contain the expected release version\n" unless $replaced;
+		}
+	' "$MANIFEST"
+
+updated_range="$(taplo get --file-path "$MANIFEST" --strip-newline workspace.dependencies.pina.version)"
+if [[ "$updated_range" != "$EXPECTED_RANGE" ]]; then
+	echo "Failed to restore the Pina development dependency range." >&2
+	exit 1
+fi


### PR DESCRIPTION
## Summary

Preserve the intentionally broad `pina` workspace dependency range after Monochange prepares a release, and verify that invariant in release-preview CI.

## Problem

`pina` is a development-only dependency of `pina_macros`. Its `>=0.8.0, <1.0.0` range lets Cargo verify the packaged macros crate against the already-published Pina release while workspace tests continue to use the local path.

Monochange correctly synchronizes ordinary internal dependency versions during release preparation, but it also rewrites this development-only exception to the pending version. For the 0.9.0 release that produced `pina = "0.9.0"`; because 0.9.0 is not published yet, `cargo publish --dry-run` for `pina_macros` then fails before the release can publish anything.

## Fix

- Add a fail-closed script that restores the approved 0.x compatibility range only when Monochange changed it to the current workspace release version. Unexpected values are rejected rather than overwritten.
- Run that repair immediately after `PrepareRelease`, before formatting and committing the automated release branch.
- Run the script in check-only mode in the release-preview workflow so a malformed prepared release cannot be merged.

## Validation

- Exercised both check-only and mutation paths against a disposable manifest copy.
- `shellcheck scripts/preserve-pina-dev-dependency-range.sh`
- `actionlint .github/workflows/release-preview.yml`
- `dprint check scripts/preserve-pina-dev-dependency-range.sh monochange.toml .github/workflows/release-preview.yml`
- `devenv shell -- mc step validate`
- `devenv shell -- monochange run release --dry-run --diff`
- Full repository pre-push gate, including Rust tests/clippy, security scan, and deterministic Rust/JavaScript/Dart Codama regeneration.

Created on behalf of Ifiok Jr. (`@ifiokjr`) using Codex (GPT-5.6-sol, high reasoning).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the development dependency version range during release previews and CLI releases.
  * Added validation to prevent unexpected dependency changes and confirm the final release state.

* **Chores**
  * Automated dependency-range preservation when preparing releases with pending changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->