### PR TITLE
ci(release): harden post-release automation

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -118,7 +118,7 @@ jobs:
   tag:
     if: github.repository_owner == 'pina-rs' && needs.create.outputs.is_release_commit == 'true'
     needs: create
-    timeout-minutes: 10
+    timeout-minutes: 20
     runs-on: ubuntu-24.04
     permissions:
       actions: write

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -49,6 +49,7 @@ jobs:
 
             resolved_commit="$(jq -r '.resolved_commit // "<missing>"' "$release_record")"
             record_commit="$(jq -r '.record_commit // "<missing>"' "$release_record")"
+            distance="$(jq -r '.distance // -1' "$release_record")"
             release_target_count="$(jq -r '.record.release_targets | length' "$release_record")"
 
             if [[ "$resolved_commit" == "$record_commit" ]] &&
@@ -61,6 +62,16 @@ jobs:
                 released_packages: .record.released_packages
               }' "$release_record" >> "$GITHUB_STEP_SUMMARY"
               echo '```' >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+
+            subject="$(git log -1 --pretty=%s)"
+            body="$(git log -1 --pretty=%B)"
+            if ((distance > 0)) &&
+              [[ "$subject" != chore\(release\):\ prepare\ release* ]] &&
+              ! grep -q '<!-- monochange:release-record:start -->' <<<"$body"; then
+              echo "### No pending release" >> "$GITHUB_STEP_SUMMARY"
+              echo "No changesets remain after the previous prepared release." >> "$GITHUB_STEP_SUMMARY"
               exit 0
             fi
 


### PR DESCRIPTION
## Summary

- raise the release tag job timeout from 10 to 20 minutes
- match the release-create job ceiling so pinned Devenv setup can finish on a cold runner
- treat an ordinary post-release commit with no remaining changesets as “no pending release”
- continue failing closed when a release-looking commit has a malformed or non-HEAD release record

## Validation

- `actionlint .github/workflows/release-preview.yml .github/workflows/release-pr.yml`
- `dprint check .github/workflows/release-preview.yml .github/workflows/release-pr.yml`
- exact post-release record regression: distance `1`, record commit `ccf674a…`, ordinary CI commit accepted
- full `lint:push` pre-push gate on the timeout change, including deterministic Rust/JavaScript/Dart client regeneration
- commit hooks and secret scanning on both commits
- `git diff --check`

This follows up on release run 32277408099, where the tag job was cancelled during setup at the exact 10-minute ceiling before any tag or publish operation ran, and the subsequent PR preview exposed the no-changeset post-release state handling gap.

Created on behalf of Ifiok Jr. (@ifiokjr) by Codex (GPT-5.6, high reasoning).