### PR TITLE
feat(accounts): support distinct remaining accounts

### DIFF
--- a/.changeset/cpi-runtime-invariants.md
+++ b/.changeset/cpi-runtime-invariants.md
@@ -1,5 +1,5 @@
 ---
-pina: fix
+pina: major
 pina_cli: fix
 ---
 
@@ -8,3 +8,5 @@ pina_cli: fix
 Make CPI signer metadata describe the called instruction instead of inheriting outer-instruction privileges. Generated-style builders can now request signer accounts explicitly, so both transaction signatures and `invoke_signed` PDA seeds satisfy the same typed CPI API without forwarding unrelated signatures.
 
 Require `CpiContext` to receive a validated `Program<T>` and reject PDA account creation when the supplied account address does not match the requested seeds, bump, and owner. This prevents independently signing accounts from bypassing PDA derivation checks on both zero-balance and pre-funded allocation paths.
+
+When migrating, replace the raw program address passed to `CpiContext::new` with `Program::<YourProgram>::new(program_account)?`, and add the target program marker as the context's program type parameter. This deliberately breaks the previous constructor so program-ID validation cannot be bypassed accidentally.

--- a/.changeset/distinct-remaining-accounts.md
+++ b/.changeset/distinct-remaining-accounts.md
@@ -1,0 +1,8 @@
+---
+pina: feat
+pina_macros: feat
+---
+
+# Add strict mutable trailing accounts
+
+Add opt-in `#[pina(remaining, distinct)]` parsing for programs whose mutable trailing accounts must have unique addresses. Existing `#[pina(remaining)]` pass-through behavior remains unchanged for instructions that intentionally accept aliases.

--- a/crates/pina/src/traits.rs
+++ b/crates/pina/src/traits.rs
@@ -669,7 +669,9 @@ pub trait CloseAccountWithRecipient {
 /// advances through the account slice from left to right, supports explicit
 /// trailing-account capture, and rejects writable aliases for mutable accounts
 /// parsed individually through [`Self::next_mut`]. Trailing accounts returned
-/// by [`Self::remaining_mut`] preserve their original order and aliasing.
+/// by [`Self::remaining_mut`] preserve their original order and aliasing. Use
+/// [`Self::remaining_mut_distinct`] when every mutable trailing account must
+/// have a unique address.
 pub struct AccountsCursor<'a> {
 	remaining: &'a mut [AccountView],
 }
@@ -757,6 +759,26 @@ impl<'a> AccountsCursor<'a> {
 		Ok(remaining)
 	}
 
+	/// Consume and return distinct writable trailing accounts.
+	///
+	/// This is the strict counterpart to [`Self::remaining_mut`]. Every account
+	/// must be writable and every address must occur exactly once. The check is
+	/// allocation-free and preserves the original account order.
+	pub fn remaining_mut_distinct(&mut self) -> Result<&'a mut [AccountView], ProgramError> {
+		let remaining = core::mem::take(&mut self.remaining);
+		for (index, account) in remaining.iter().enumerate() {
+			validate_writable(*account)?;
+			if remaining[..index]
+				.iter()
+				.any(|previous| previous.address() == account.address())
+			{
+				return Err(PinaProgramError::DuplicateMutableAccount.into());
+			}
+		}
+
+		Ok(remaining)
+	}
+
 	/// Require that no unparsed accounts remain.
 	pub fn finish_exact(&self) -> Result<(), ProgramError> {
 		if self.remaining.is_empty() {
@@ -771,6 +793,7 @@ impl<'a> AccountsCursor<'a> {
 	///
 	/// This check protects fields parsed individually through [`Self::next_mut`].
 	/// It does not inspect pairs contained entirely within [`Self::remaining_mut`].
+	/// [`Self::remaining_mut_distinct`] performs that stricter trailing check.
 	fn track_mutable_account(&self, account: AccountView) -> Result<(), ProgramError> {
 		if !account.is_writable() {
 			return Ok(());

--- a/crates/pina/tests/accounts_derive.rs
+++ b/crates/pina/tests/accounts_derive.rs
@@ -56,6 +56,14 @@ struct TestAccountsRemainingMut<'a> {
 	pub remaining: &'a mut [AccountView],
 }
 
+#[derive(Accounts)]
+#[pina(crate = pina)]
+struct TestAccountsRemainingMutDistinct<'a> {
+	pub one: &'a AccountView,
+	#[pina(remaining, distinct)]
+	pub remaining: &'a mut [AccountView],
+}
+
 #[test]
 fn test_accounts_derive_exact() {
 	let ix_data = [3u8; 100];
@@ -205,6 +213,35 @@ fn test_accounts_derive_mutable_remaining_rejects_readonly_accounts() {
 		unsafe { core::slice::from_raw_parts_mut(accounts.as_mut_ptr().cast(), count) };
 
 	let result = TestAccountsRemainingMut::try_from_account_infos(accounts);
+	assert!(matches!(result, Err(ProgramError::InvalidAccountData)));
+}
+
+#[test]
+fn test_accounts_derive_distinct_mutable_remaining_accepts_unique_accounts() {
+	let ix_data = [3u8; 100];
+	let mut input = create_input(4, &ix_data);
+	let mut accounts = [UNINIT; 4];
+
+	let count = unsafe { deserialize(input.as_mut_ptr(), &mut accounts) }.1;
+	let accounts: &mut [AccountView] =
+		unsafe { core::slice::from_raw_parts_mut(accounts.as_mut_ptr().cast(), count) };
+
+	let parsed = TestAccountsRemainingMutDistinct::try_from_account_infos(accounts).unwrap();
+	assert_ne!(parsed.one.address(), parsed.remaining[0].address());
+	assert_eq!(parsed.remaining.len(), 3);
+}
+
+#[test]
+fn test_accounts_derive_distinct_mutable_remaining_rejects_readonly_accounts() {
+	let ix_data = [3u8; 100];
+	let mut input = create_input_with_writability(3, &ix_data, |index| index != 2);
+	let mut accounts = [UNINIT; 3];
+
+	let count = unsafe { deserialize(input.as_mut_ptr(), &mut accounts) }.1;
+	let accounts: &mut [AccountView] =
+		unsafe { core::slice::from_raw_parts_mut(accounts.as_mut_ptr().cast(), count) };
+
+	let result = TestAccountsRemainingMutDistinct::try_from_account_infos(accounts);
 	assert!(matches!(result, Err(ProgramError::InvalidAccountData)));
 }
 

--- a/crates/pina/tests/adversarial_invariants.rs
+++ b/crates/pina/tests/adversarial_invariants.rs
@@ -45,6 +45,15 @@ struct RemainingPassthrough<'a> {
 	pub rest: &'a mut [AccountView],
 }
 
+#[derive(Accounts, Debug)]
+#[pina(crate = pina)]
+#[allow(dead_code)]
+struct DistinctRemaining<'a> {
+	pub first: &'a AccountView,
+	#[pina(remaining, distinct)]
+	pub rest: &'a mut [AccountView],
+}
+
 struct AccountBuilder {
 	address: Address,
 	owner: Address,
@@ -393,6 +402,30 @@ fn remaining_accounts_preserve_duplicate_order_and_aliasing() {
 		Err(ProgramError::AccountBorrowFailed)
 	));
 	drop(duplicated_borrow);
+}
+
+#[test]
+fn distinct_remaining_accounts_reject_duplicate_mutable_addresses() {
+	let unique_accounts = [
+		AccountBuilder::new()
+			.address(fake_address(41))
+			.owner(TEST_PROGRAM_ID)
+			.is_writable(true),
+		AccountBuilder::new()
+			.address(fake_address(42))
+			.owner(TEST_PROGRAM_ID)
+			.is_writable(true),
+	];
+
+	let (_input, mut accounts, count) = load_accounts!(&unique_accounts, 1, 4);
+	let account_views = initialized_account_views(&mut accounts, count);
+	let result = DistinctRemaining::try_from(account_views);
+
+	assert!(matches!(
+		result,
+		Err(ProgramError::Custom(error))
+			if error == PinaProgramError::DuplicateMutableAccount as u32
+	));
 }
 
 #[test]

--- a/crates/pina_macros/readme.md
+++ b/crates/pina_macros/readme.md
@@ -96,7 +96,7 @@ pub enum ExampleError {
 
 - Supports one lifetime parameter.
 - Supports `&'a AccountView`, `&'a mut AccountView`, `&'a [AccountView]`, and `&'a mut [AccountView]` fields.
-- Supports `#[pina(remaining)]` on a single trailing field to capture remaining accounts.
+- Supports `#[pina(remaining)]` on a single trailing field to capture remaining accounts, with opt-in `#[pina(remaining, distinct)]` validation for unique mutable addresses.
 - Supports `#[pina(crate = ::pina)]` on the struct to override the crate path.
 
 ## Notes

--- a/crates/pina_macros/src/accounts.rs
+++ b/crates/pina_macros/src/accounts.rs
@@ -56,6 +56,14 @@ pub(crate) fn expand(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
 	let mut seen_remaining = false;
 
 	for field in fields.iter() {
+		if field.distinct.is_present() && !field.remaining.is_present() {
+			return syn::Error::new_spanned(
+				&field.ident,
+				"`distinct` is only valid with `#[pina(remaining)]`",
+			)
+			.to_compile_error();
+		}
+
 		if !field.remaining.is_present() {
 			continue;
 		}
@@ -86,10 +94,19 @@ pub(crate) fn expand(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
 				.to_compile_error();
 			}
 
+			let is_mut = is_mut_reference(&field.ty);
+			if field.distinct.is_present() && !is_mut {
+				return syn::Error::new_spanned(
+					&field.ident,
+					"`#[pina(remaining, distinct)]` requires a mutable account slice",
+				)
+				.to_compile_error();
+			}
+
 			remaining_field = field
 				.ident
 				.as_ref()
-				.map(|ident| (ident, is_mut_reference(&field.ty)));
+				.map(|ident| (ident, is_mut, field.distinct.is_present()));
 			continue;
 		}
 
@@ -110,14 +127,16 @@ pub(crate) fn expand(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
 			cursor.finish_exact()?;
 		}
 	});
-	let remaining_binding = remaining_field.map(|(field, is_mut)| {
-		if is_mut {
+	let remaining_binding = remaining_field.map(|(field, is_mut, is_distinct)| {
+		if is_distinct {
+			quote! { let #field = cursor.remaining_mut_distinct()?; }
+		} else if is_mut {
 			quote! { let #field = cursor.remaining_mut()?; }
 		} else {
 			quote! { let #field = cursor.take_remaining(); }
 		}
 	});
-	let remaining_field_ident = remaining_field.map(|(field, _)| quote!(#field,));
+	let remaining_field_ident = remaining_field.map(|(field, ..)| quote!(#field,));
 
 	quote! {
 		impl #impl_generics #crate_path::ParseAccounts #ty_generics for #struct_name #ty_generics #where_clause {

--- a/crates/pina_macros/src/args.rs
+++ b/crates/pina_macros/src/args.rs
@@ -456,4 +456,6 @@ pub(crate) struct AccountsField {
 	pub(crate) ty: Type,
 	#[darling(default)]
 	pub(crate) remaining: Flag,
+	#[darling(default)]
+	pub(crate) distinct: Flag,
 }

--- a/crates/pina_macros/src/lib.rs
+++ b/crates/pina_macros/src/lib.rs
@@ -39,6 +39,7 @@ use pda::expand as pda_impl;
 ///
 /// Fields can be shared or mutable `AccountView` references. A final slice
 /// field annotated with `#[pina(remaining)]` captures all trailing accounts.
+/// Add `distinct` to reject duplicate mutable trailing-account addresses.
 ///
 /// # Example
 ///
@@ -49,6 +50,13 @@ use pda::expand as pda_impl;
 ///     state: &'a mut AccountView,
 ///     #[pina(remaining)]
 ///     remaining: &'a [AccountView],
+/// }
+///
+/// #[derive(Accounts)]
+/// struct SettleAccounts<'a> {
+///     authority: &'a AccountView,
+///     #[pina(remaining, distinct)]
+///     positions: &'a mut [AccountView],
 /// }
 /// ```
 #[proc_macro_derive(Accounts, attributes(pina))]

--- a/crates/pina_macros/src/snapshots/pina_macros__tests__accounts_derive_with_distinct_mutable_remaining.snap
+++ b/crates/pina_macros/src/snapshots/pina_macros__tests__accounts_derive_with_distinct_mutable_remaining.snap
@@ -1,0 +1,31 @@
+---
+source: crates/pina_macros/src/tests.rs
+expression: output
+---
+impl<'a> ::pina::ParseAccounts<'a> for TransferAccounts<'a> {
+    fn parse_accounts(
+        cursor: &mut ::pina::AccountsCursor<'a>,
+    ) -> ::core::result::Result<Self, ::pina::ProgramError> {
+        let authority = cursor.next()?;
+        let extra = cursor.remaining_mut_distinct()?;
+        Ok(Self { authority, extra })
+    }
+}
+impl<'a> ::pina::TryFromAccountInfos<'a> for TransferAccounts<'a> {
+    fn try_from_account_infos(
+        accounts: &'a mut [::pina::AccountView],
+    ) -> ::core::result::Result<Self, ::pina::ProgramError> {
+        let mut cursor = ::pina::AccountsCursor::new(accounts);
+        let parsed = <Self as ::pina::ParseAccounts>::parse_accounts(&mut cursor)?;
+        Ok(parsed)
+    }
+}
+impl<'a> ::core::convert::TryFrom<&'a mut [::pina::AccountView]>
+for TransferAccounts<'a> {
+    type Error = ::pina::ProgramError;
+    fn try_from(
+        accounts: &'a mut [::pina::AccountView],
+    ) -> ::core::result::Result<Self, Self::Error> {
+        <Self as ::pina::TryFromAccountInfos>::try_from_account_infos(accounts)
+    }
+}

--- a/crates/pina_macros/src/tests.rs
+++ b/crates/pina_macros/src/tests.rs
@@ -491,6 +491,20 @@ fn accounts_derive_with_mutable_remaining() {
 }
 
 #[test]
+fn accounts_derive_with_distinct_mutable_remaining() {
+	let input = quote! {
+		#[pina(crate = ::pina)]
+		pub struct TransferAccounts<'a> {
+			pub authority: &'a AccountView,
+			#[pina(remaining, distinct)]
+			pub extra: &'a mut [AccountView],
+		}
+	};
+	let output = pretty(accounts_derive_impl(input));
+	insta::assert_snapshot!("accounts_derive_with_distinct_mutable_remaining", output);
+}
+
+#[test]
 fn accounts_derive_single_field() {
 	let input = quote! {
 		#[pina(crate = ::pina)]

--- a/crates/pina_macros/tests/ui/fail/accounts_distinct_immutable_remaining.rs
+++ b/crates/pina_macros/tests/ui/fail/accounts_distinct_immutable_remaining.rs
@@ -1,0 +1,9 @@
+use pina::*;
+
+#[derive(Accounts)]
+pub struct DistinctImmutableRemaining<'a> {
+	#[pina(remaining, distinct)]
+	pub remaining: &'a [AccountView],
+}
+
+fn main() {}

--- a/crates/pina_macros/tests/ui/fail/accounts_distinct_immutable_remaining.stderr
+++ b/crates/pina_macros/tests/ui/fail/accounts_distinct_immutable_remaining.stderr
@@ -1,0 +1,5 @@
+error: `#[pina(remaining, distinct)]` requires a mutable account slice
+ --> tests/ui/fail/accounts_distinct_immutable_remaining.rs:6:6
+  |
+6 |     pub remaining: &'a [AccountView],
+  |         ^^^^^^^^^

--- a/crates/pina_macros/tests/ui/fail/accounts_distinct_without_remaining.rs
+++ b/crates/pina_macros/tests/ui/fail/accounts_distinct_without_remaining.rs
@@ -1,0 +1,9 @@
+use pina::*;
+
+#[derive(Accounts)]
+pub struct DistinctWithoutRemaining<'a> {
+	#[pina(distinct)]
+	pub payer: &'a mut AccountView,
+}
+
+fn main() {}

--- a/crates/pina_macros/tests/ui/fail/accounts_distinct_without_remaining.stderr
+++ b/crates/pina_macros/tests/ui/fail/accounts_distinct_without_remaining.stderr
@@ -1,0 +1,5 @@
+error: `distinct` is only valid with `#[pina(remaining)]`
+ --> tests/ui/fail/accounts_distinct_without_remaining.rs:6:6
+  |
+6 |     pub payer: &'a mut AccountView,
+  |         ^^^^^

--- a/docs/src/core-concepts.md
+++ b/docs/src/core-concepts.md
@@ -122,7 +122,7 @@ Traits in `crates/pina/src/impls.rs` provide typed conversion paths from raw `Ac
 
 ## Account cursors
 
-`AccountsCursor` is the runtime layer used by `#[derive(Accounts)]`. It advances through the account slice from left to right and rejects writable aliases for mutable accounts parsed individually through `next_mut()`, without heap allocation. Explicit trailing-account capture via `#[pina(remaining)]` is pass-through: it preserves account order and aliases, so handlers that require distinct trailing accounts must validate their addresses.
+`AccountsCursor` is the runtime layer used by `#[derive(Accounts)]`. It advances through the account slice from left to right and rejects writable aliases for mutable accounts parsed individually through `next_mut()`, without heap allocation. Explicit trailing-account capture via `#[pina(remaining)]` is pass-through and preserves account order and aliases. Use `#[pina(remaining, distinct)]` on a mutable trailing slice when duplicate addresses must be rejected by the generated parser.
 
 ## Instruction authoring tips
 

--- a/docs/src/core-concepts.md
+++ b/docs/src/core-concepts.md
@@ -122,7 +122,7 @@ Traits in `crates/pina/src/impls.rs` provide typed conversion paths from raw `Ac
 
 ## Account cursors
 
-`AccountsCursor` is the runtime layer used by `#[derive(Accounts)]`. It advances through the account slice from left to right and rejects writable aliases for mutable accounts parsed individually through `next_mut()`, without heap allocation. Explicit trailing-account capture via `#[pina(remaining)]` is pass-through and preserves account order and aliases. Use `#[pina(remaining, distinct)]` on a mutable trailing slice when duplicate addresses must be rejected by the generated parser.
+`AccountsCursor` is the runtime layer used by `#[derive(Accounts)]`. It advances through the account slice from left to right and rejects writable aliases for mutable accounts parsed individually through `next_mut()`, without heap allocation. Explicit trailing-account capture via `#[pina(remaining)]` preserves account order and duplicate addresses; mutable trailing slices still reject readonly accounts. Use `#[pina(remaining, distinct)]` on a mutable trailing slice when duplicate addresses must also be rejected by the generated parser.
 
 ## Instruction authoring tips
 


### PR DESCRIPTION
## Summary

- add opt-in `#[pina(remaining, distinct)]` parsing for mutable trailing accounts
- reject repeated mutable account addresses without heap allocation
- preserve the existing alias-preserving behavior of `#[pina(remaining)]`
- reject invalid macro combinations at compile time
- document the distinction and include a release changeset

## Why

A raw mutable trailing slice may legitimately preserve duplicate Solana account entries, so changing `#[pina(remaining)]` globally would break valid pass-through instructions. Instructions that treat every trailing account as an independent mutable state object need a stronger invariant, however: accepting the same address twice can apply bookkeeping or economic effects more than once.

This PR makes that policy explicit at the account schema boundary:

```rust
#[derive(Accounts)]
struct SettleAccounts<'a> {
    authority: &'a AccountView,
    #[pina(remaining, distinct)]
    positions: &'a mut [AccountView],
}
```

The generated parser calls `AccountsCursor::remaining_mut_distinct()`, which requires every account to be writable and every address to occur once. The scan is allocation-free and retains input order.

## Compatibility

- `#[pina(remaining)]` is unchanged and continues to preserve aliases.
- `distinct` is opt-in and only valid on a mutable `remaining` slice.
- This is a backwards-compatible public API addition.

## Test evidence

- adversarial serialized-account test proves duplicate runtime aliases are rejected
- positive and readonly-account derive tests cover the strict cursor path
- trybuild cases cover `distinct` without `remaining` and immutable strict slices
- macro expansion snapshot covers generated strict parsing

## Local verification

- `cargo test -p pina -p pina_macros --all-features`
- `lint:all`
- `coverage:all`
- changed runtime executable lines in `AccountsCursor::remaining_mut_distinct` are all covered in LCOV

Created on behalf of Ifiok Jr. (@ifiokjr) using Codex (GPT-5.6, high reasoning).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in `distinct` validation for mutable trailing accounts.
  * Duplicate account addresses are now rejected when distinct validation is enabled.
  * Existing trailing-account behavior remains unchanged unless `distinct` is specified.
* **Bug Fixes**
  * Added validation to reject readonly or invalid uses of distinct trailing accounts.
* **Documentation**
  * Updated usage guidance and examples for distinct trailing-account validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->