### PR TITLE
docs: define example production boundaries

### DIFF
--- a/.changeset/document-example-boundaries.md
+++ b/.changeset/document-example-boundaries.md
@@ -1,0 +1,7 @@
+---
+pina: docs
+---
+
+# Document example production boundaries
+
+Mark the staking and vesting programs as account and bookkeeping scaffolds, state their intentionally missing economic behavior, and add a production-readiness gate for teams adapting Pina examples to asset-bearing programs.

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -31,6 +31,7 @@
 - [Anchor `lang-v2` review](./anchor-next-review.md)
 - [Accounts cursor runtime draft](./accounts-cursor-runtime-draft.md)
 - [Security Model](./security-model.md)
+- [Production Readiness](./production-readiness.md)
 - [Development Workflow](./development-workflow.md)
 - [CI and Releases](./ci-and-releases.md)
 - [Review Follow-ups](./review-follow-ups.md)

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -1,15 +1,15 @@
 # Examples
 
-The `examples/` workspace members demonstrate practical usage patterns:
+The `examples/` workspace members demonstrate focused usage patterns. They are not audited applications or deployment templates:
 
 - `hello_solana`: minimal program structure and instruction dispatch.
 - `counter_program`: PDA creation, mutation, and account validation.
 - `todo_program`: PDA-backed state with boolean + digest updates.
 - `transfer_sol`: lamport transfers and account checks.
 - `escrow_program`: richer multi-account flow and token-oriented logic.
-- `vesting_program`: token vesting / lockup scaffold with vault ATA setup and claim/cancel state.
+- `vesting_program`: schedule-state and vault-ATA scaffold; it does not enforce time-based vesting or transfer tokens.
 - `role_registry_program`: role-based configuration and registry PDAs with admin rotation.
-- `staking_rewards_program`: staking pool and user-position accounting scaffold with reward bookkeeping.
+- `staking_rewards_program`: staking account and bookkeeping scaffold; deposit, withdraw, and claim do not transfer tokens.
 - `profile_program`: user profile registry with fully initialized bounded UTF-8 and tag fields plus checked semantic accessors.
 - `pina_bpf`: minimal pina-native BPF hello world with nightly `build-std=core,alloc`.
 - `prop_amm_program`: Pina-native semantic port of Anchor `anchor-next` benchmark `prop-amm`, focused on authority-controlled oracle updates without the upstream asm fast path.
@@ -23,11 +23,11 @@ The `examples/` workspace members demonstrate practical usage patterns:
 - `anchor_sysvars`: clock/rent/stake-history sysvar validation parity.
 - `anchor_realloc`: authority-bound PDA realloc lifecycle, growth limits, and duplicate-target safety checks.
 
-Use examples as reference implementations for account layout, instruction parsing, and validation ordering.
+Use examples as references for the specific framework behavior each one demonstrates. Do not infer unimplemented economic behavior from an instruction name. Read [Production Readiness](./production-readiness.md) before adapting an example for an asset-bearing program.
 
 Anchor test-suite parity progress is tracked in [Anchor Test Porting](./anchor-test-porting.md).
 
-Every example directory includes a local `readme.md` with purpose, coverage, and run commands.
+Every example directory includes a local `readme.md` with purpose, coverage, limitations, and run commands. Some E2E suites skip when their SBF binary is missing; production CI should build the artifact first and treat a missing artifact as a failure.
 
 When adding new examples:
 

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -61,6 +61,8 @@ pina idl --path ./examples/counter_program --output ./codama/idls/counter_progra
 
 See [Codama Workflow](./codama-workflow.md) for end-to-end generation and external-project usage.
 
+Before adapting an example for a program that controls assets, work through the [Production Readiness](./production-readiness.md) gate. Examples demonstrate scoped framework behavior; they are not audited deployment templates.
+
 ## Build this documentation
 
 <!-- {=docsBuildCommand} -->

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -14,5 +14,6 @@ This book is the single place for project documentation. It complements API refe
 - Architecture decision records for the project's long-lived invariants and trade-offs.
 - Codama IDL/client-generation workflow (including external-project invocation).
 - Guidance for examples and security-focused development.
+- A production-readiness gate for asset-bearing programs.
 - CI/release pipeline expectations.
 - A practical recommendations roadmap for improving goal alignment.

--- a/docs/src/production-readiness.md
+++ b/docs/src/production-readiness.md
@@ -1,0 +1,70 @@
+# Production Readiness
+
+Pina supplies program-building primitives. It does not make an application safe merely because the application compiles, passes the framework tests, or follows an example. Before deploying a program that controls valuable assets, define its economic invariants, test them at the transaction boundary, and obtain an independent security review.
+
+## What the examples prove
+
+Examples have deliberately narrow scopes. They demonstrate framework APIs, account layouts, validation order, CPI construction, IDL extraction, or compatibility with an upstream test case. They are not audited applications.
+
+In particular:
+
+- `staking_rewards_program` proves pool and position account creation, authority checks, ATA validation, and checked bookkeeping. Deposit, withdraw, and claim do not transfer stake or reward tokens.
+- `vesting_program` proves schedule-state creation, PDA and ATA validation, and claim/cancel bookkeeping. It does not read the clock, calculate vested entitlement, transfer claimed tokens, or return tokens after cancellation.
+- A passing native test does not prove that an SBF-backed test ran. Some example E2E tests report a skip when the required program binary has not been built.
+
+Use these programs as focused implementation samples. Do not deploy them unchanged or treat their instruction names as evidence that the corresponding economic operation occurred.
+
+## Application invariants
+
+Write the invariants for each instruction before implementation. For an asset-bearing program, cover at least:
+
+- the authority allowed to initiate the transition;
+- the exact accounts, owners, mints, programs, and canonical PDAs accepted;
+- the assets that must move and the balances that must be conserved;
+- the state values that may change, including their monotonicity and bounds;
+- the allowed time window and the trusted time source;
+- rounding, precision, overflow, and zero-value behavior;
+- replay, duplicate-account, cancellation, pause, close, and migration behavior;
+- Token and Token-2022 compatibility, including extensions that the program accepts or rejects.
+
+Treat the on-chain account layout and instruction data as a protocol ABI. Plan migrations before changing either one.
+
+## Verification gate
+
+Before a public deployment:
+
+1. Test every instruction against the built SBF artifact. Make missing artifacts fail the production CI job instead of skipping tests.
+2. Add negative tests for every authority, owner, signer, writable, program-ID, mint, PDA, and account-aliasing constraint.
+3. Assert post-transaction token and lamport balances, not only program-owned bookkeeping fields.
+4. Test transaction atomicity: every rejected CPI or late validation failure must leave balances and state unchanged.
+5. Add boundary and property tests for arithmetic, time, capacity, and serialization rules.
+6. Pin the toolchain and dependencies used for the audited build, then reproduce the final SBF hash from a clean environment.
+7. Profile compute use on the SBF artifact with realistic account sizes and worst-case instruction inputs.
+8. Review upgrade authority, emergency controls, monitoring, and incident response before mainnet deployment.
+9. Commission an independent review of the application logic. Framework checks and repository CI are supporting evidence, not a substitute.
+
+## Staking completion checklist
+
+Before `staking_rewards_program` can represent a staking product, it needs application-specific decisions and tests for:
+
+- custody transfers between user accounts and PDA-controlled stake/reward vaults;
+- vault ownership, mint consistency, funding, solvency, and withdrawal authority;
+- a time-based reward-emission and precision model;
+- reward-debt settlement before every stake change;
+- the difference between accrued, claimable, and paid rewards;
+- pause, unpause, administration, position closure, and pool shutdown;
+- adversarial deposits, withdrawals, claims, duplicate accounts, and depleted reward vaults.
+
+## Vesting completion checklist
+
+Before `vesting_program` can represent a vesting product, it needs application-specific decisions and tests for:
+
+- clock-sysvar validation and a precise cliff/linear/unlock formula;
+- escrow funding during initialization and proof that the vault is sufficiently funded;
+- PDA-signed transfers from the vault to the beneficiary;
+- cancellation policy, including who receives unvested tokens and whether vested tokens remain claimable;
+- rounding at schedule boundaries and protection against claiming the same entitlement twice;
+- schedule amendment, closure, and recovery behavior;
+- adversarial claims before the cliff, after cancellation, at exact boundaries, and against substituted vaults or mints.
+
+The [Security Model](./security-model.md) documents framework-level invariants. The [CI and Releases](./ci-and-releases.md) page describes the repository's verification layers; an application should adopt equivalent gates for its own program logic.

--- a/docs/src/security-model.md
+++ b/docs/src/security-model.md
@@ -98,3 +98,5 @@ Fixed-capacity strings and vectors may contain uninitialized bytes outside their
 - Unit tests for negative validation cases.
 - Regression tests for every previously fixed bug class.
 - Integration tests for cross-account invariants where mutation order matters.
+
+These framework guarantees do not validate an application's economic design. Use the [Production Readiness](./production-readiness.md) gate before deploying an asset-bearing program.

--- a/docs/src/tutorials/first-program.md
+++ b/docs/src/tutorials/first-program.md
@@ -287,4 +287,4 @@ For full integration tests that simulate the Solana runtime, add `mollusk-svm` a
 - Add on-chain state with `#[account]` -- see the `counter_program` example.
 - Handle multiple instructions by adding more variants to your discriminator enum.
 - Add PDA-based accounts with `create_program_account_with_bump`.
-- Follow the [Token Escrow Tutorial](./token-escrow.md) for a real-world program with token transfers and CPI.
+- Follow the [Token Escrow Tutorial](./token-escrow.md) for a production-shaped exercise with token transfers and CPI, then apply the [Production Readiness](../production-readiness.md) gate before deployment.

--- a/examples/staking_rewards_program/readme.md
+++ b/examples/staking_rewards_program/readme.md
@@ -2,7 +2,9 @@
 
 <br>
 
-Staking and rewards distribution scaffold.
+Staking account and rewards-bookkeeping scaffold.
+
+> **Not production-ready:** Deposit, withdraw, and claim update program-owned bookkeeping but do not transfer stake or reward tokens. Do not deploy or fork this example as a staking product without completing the custody and reward model described below.
 
 ## What it covers
 
@@ -10,10 +12,19 @@ Staking and rewards distribution scaffold.
 
 - Pool initialization with stake and reward vault ATAs.
 - Per-user position PDAs keyed by pool + owner.
-- Deposit, withdraw, and claim bookkeeping flows.
+- Deposit, withdraw, and claim validation and bookkeeping flows.
 - Token-program validation and ATA creation (eager for pool vaults, idempotent for deposits).
 
-The `tests/e2e.rs` file exercises the staking lifecycle through Mollusk.
+The `tests/e2e.rs` file exercises the bookkeeping lifecycle through Mollusk. It does not assert token custody or reward payments. The tests report a skip when the SBF binary is missing, so build the binary first when using this suite as a deployment gate.
+
+## Deliberately out of scope
+
+- Transfers into and out of the PDA-controlled stake vault.
+- Transfers from the reward vault to a claimant.
+- Reward funding, solvency, emissions, time, precision, and settlement rules.
+- Pause administration, position closure, pool shutdown, and recovery policy.
+
+See the book's [Production Readiness](../../docs/src/production-readiness.md) checklist for the invariants and adversarial tests a real staking program needs.
 
 ## Run
 
@@ -23,6 +34,8 @@ The `tests/e2e.rs` file exercises the staking lifecycle through Mollusk.
 cargo test -p staking_rewards_program
 pina idl --path examples/staking_rewards_program --output codama/idls/staking_rewards_program.json
 ```
+
+The first command still runs useful native tests when the SBF artifact is absent; read its output and do not mistake a skipped E2E path for an executed program test.
 
 ## Optional SBF build
 

--- a/examples/staking_rewards_program/src/lib.rs
+++ b/examples/staking_rewards_program/src/lib.rs
@@ -1,14 +1,16 @@
-//! Staking and rewards distribution scaffold built with pina.
+//! Staking account and rewards-bookkeeping scaffold built with pina.
 //!
-//! This example keeps a realistic staking lifecycle in place:
+//! This example demonstrates the account and validation shape of a staking
+//! lifecycle:
 //! - initialize a rewards pool
 //! - open per-user positions
-//! - deposit and withdraw stake
-//! - claim rewards against a position account
+//! - record deposits and withdrawals
+//! - update reward bookkeeping against a position account
 //!
-//! The first scaffold focuses on deterministic account structure and IDL
-//! extraction. Token transfer logic can be layered in after the accounting
-//! contract is stable.
+//! This is not a staking product. Deposit, withdraw, and claim do not transfer
+//! tokens, and the example does not define reward emissions, funding, or
+//! solvency. See the example README and the book's production-readiness guide
+//! before adapting it for an asset-bearing program.
 
 #![allow(clippy::inline_always)]
 #![no_std]

--- a/examples/vesting_program/readme.md
+++ b/examples/vesting_program/readme.md
@@ -2,7 +2,9 @@
 
 <br>
 
-Token vesting and lockup scaffold.
+Vesting schedule-state and account-validation scaffold.
+
+> **Not production-ready:** Claim and cancel mutate schedule bookkeeping but do not use the clock or transfer tokens. Do not deploy or fork this example as a vesting product without completing the entitlement and custody model described below.
 
 ## What it covers
 
@@ -10,10 +12,19 @@ Token vesting and lockup scaffold.
 
 - Vesting schedule initialization with a PDA-owned state account.
 - Vault ATA creation for the schedule account.
-- Claim and cancel flows with explicit validation chains.
+- Claim and cancel bookkeeping with explicit validation chains.
 - Token-program account validation and ATA scaffolding.
 
-Token transfers are not wired in; this example is an account-structure scaffold. The `tests/e2e.rs` file exercises the schedule lifecycle through Mollusk.
+The `tests/e2e.rs` file exercises the schedule-state lifecycle through Mollusk. It does not prove cliff enforcement, vested-amount calculation, token release, or cancellation refunds. The tests report a skip when the SBF binary is missing, so build the binary first when using this suite as a deployment gate.
+
+## Deliberately out of scope
+
+- Clock-sysvar validation and cliff or linear-unlock calculations.
+- Funding the vault and transferring vested tokens to the beneficiary.
+- Returning or preserving tokens after cancellation.
+- Rounding, amendment, closure, recovery, and insolvency policy.
+
+See the book's [Production Readiness](../../docs/src/production-readiness.md) checklist for the invariants and adversarial tests a real vesting program needs.
 
 ## Run
 
@@ -23,6 +34,8 @@ Token transfers are not wired in; this example is an account-structure scaffold.
 cargo test -p vesting_program
 pina idl --path examples/vesting_program --output codama/idls/vesting_program.json
 ```
+
+The first command still runs useful native tests when the SBF artifact is absent; read its output and do not mistake a skipped E2E path for an executed program test.
 
 ## Optional SBF build
 

--- a/examples/vesting_program/src/lib.rs
+++ b/examples/vesting_program/src/lib.rs
@@ -1,13 +1,17 @@
-//! Token vesting and lockup scaffold built with pina.
+//! Vesting schedule-state and account-validation scaffold built with pina.
 //!
-//! This example keeps the core production-shaped contract in place:
+//! This example demonstrates the account and validation shape of a vesting
+//! lifecycle:
 //! - initialize a vesting schedule
 //! - create a PDA-owned vault ATA
-//! - claim vested amounts
-//! - cancel a remaining schedule
+//! - record claimed amounts
+//! - record schedule cancellation
 //!
-//! The first scaffold focuses on account structure, validation chains, and
-//! deterministic IDL extraction. Token transfer wiring can be layered in later.
+//! This is not a vesting product. Claim and cancel do not read the clock or
+//! transfer tokens, so the code does not enforce a cliff, calculate vested
+//! entitlement, release funds, or return funds after cancellation. See the
+//! example README and the book's production-readiness guide before adapting it
+//! for an asset-bearing program.
 
 #![allow(clippy::inline_always)]
 #![no_std]


### PR DESCRIPTION
## Summary

- add a book chapter that separates framework guarantees from application production readiness
- document deployment gates for economic invariants, SBF tests, balance conservation, reproducible builds, operations, and independent review
- mark the staking and vesting examples as bookkeeping/account-validation scaffolds rather than complete token products
- enumerate the missing custody, reward, clock, entitlement, cancellation, and adversarial-test work for both examples
- clarify that native example tests can pass while an unavailable SBF-backed path reports a skip
- include a descriptive `pina` documentation changeset

## Why this is necessary

The existing staking and vesting names suggest economic behavior that their code intentionally does not implement. Staking deposit, withdraw, and claim mutate program state without transferring tokens. Vesting claim and cancel neither read the clock nor move tokens. Their E2E harnesses also permit a missing SBF binary to skip the program execution path. Those are valid scaffold boundaries, but they must be explicit before developers use the examples as the starting point for a real asset-bearing program.

This PR changes documentation and crate-level prose only. It does not alter program behavior.

## Verification

- `devenv shell -- test:program-e2e`
  - freshly built all SBF artifacts
  - 13 staking Mollusk tests passed
  - 9 vesting Mollusk tests passed
  - 2 LiteSVM tests passed
  - 36 Quasar tests passed
- `devenv shell -- lint:all`
- mdBook and API documentation builds passed
- `devenv shell -- coverage:all`
- patch coverage: no executable lines changed (`0/0`); no uncovered patch lines

Created on behalf of Ifiok Jr. (@ifiokjr) using Codex (GPT-5.6, high reasoning).
