### PR TITLE
docs(agents): prefix all commands with devenv shell

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@ Pina is a Rust workspace for building performant, `no_std` Solana programs on to
 
 ## Repo defaults
 
+- **Always run commands inside `devenv shell`** so the nix-managed toolchain (cargo, mdt, dprint, clippy, etc.) is used instead of stale cargo-installed or system binaries.
 - Use `devenv` for the development shell and repo task runner.
 - Use `cargo` for workspace tasks; use `pnpm` only for JS/Codama subprojects.
 - Format with `fix:format` or `dprint fmt`; do not run `rustfmt` directly.


### PR DESCRIPTION
Adds a note to the top of the Repo defaults section in AGENTS.md reminding agents to always run commands inside `devenv shell` so the nix-managed toolchain (cargo, mdt, dprint, clippy, etc.) is used instead of stale cargo-installed or system binaries.

This prevents issues like the mdt v0.0.1 corruption (/// → ////) caused by a stale cargo-installed binary shadowing the nixpkgs-managed v0.9.0 binary.

Created on behalf of Ifiok Jr. (@ifiokjr) by ox-alpha.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized command execution through the project’s managed development environment.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->