### PR TITLE
feat(cli): publish canonical program IDLs

### DIFF
--- a/.changeset/canonical-idl-metadata.md
+++ b/.changeset/canonical-idl-metadata.md
@@ -1,0 +1,8 @@
+---
+pina_cli: feat
+pina_skill: feat
+---
+
+# Publish canonical program IDLs
+
+Extend `pina idl` with explicit generation, canonical Program Metadata fetch, semantic diff, direct publication, and an option to export all planner transactions for multisig or DAO signing. The official transaction planner is version-pinned, network targets are explicit, IDLs and keypairs are validated before use, and the mdBook documents authority, rent, buffers, RPC safety, automation, and failure recovery.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2657,6 +2657,7 @@ dependencies = [
  "codama-nodes",
  "comfy-table",
  "ed25519-dalek",
+ "flate2",
  "fs2",
  "heck",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ clap = { default-features = false, version = "^4", features = ["derive", "std"] 
 codama-nodes = { default-features = false, version = "0.11.0" }
 darling = { default-features = false, version = "0.24.0" }
 ed25519-dalek = { version = "2.2.0", default-features = false }
+flate2 = { default-features = true, version = "1.1.2" }
 fs2 = { default-features = false, version = "^0.4" }
 heck = { default-features = false, version = "^0.5" }
 insta = { default-features = false, version = "^1" }

--- a/crates/pina_cli/Cargo.toml
+++ b/crates/pina_cli/Cargo.toml
@@ -24,6 +24,7 @@ clap = { workspace = true, default-features = true }
 codama-nodes = { workspace = true, default-features = true }
 comfy-table = "8.0.0"
 ed25519-dalek = { workspace = true }
+flate2 = { workspace = true }
 fs2 = { workspace = true, default-features = true }
 heck = { workspace = true, default-features = true }
 owo-colors = "4.0"
@@ -49,7 +50,6 @@ insta = { workspace = true, features = ["json"], default-features = true }
 insta-cmd = { workspace = true, default-features = true }
 object = { features = ["write", "elf", "std"], workspace = true, default-features = true }
 serde_json = { workspace = true, default-features = true }
-tempfile = { workspace = true, default-features = true }
 
 [lints]
 workspace = true

--- a/crates/pina_cli/readme.md
+++ b/crates/pina_cli/readme.md
@@ -240,6 +240,41 @@ That last count-parity check is important because it catches silent extraction r
 
 <!-- {/pinaIdlVerificationContract} -->
 
+<!-- {=pinaIdlProgramMetadata} -->
+
+## Canonical on-chain IDLs
+
+The existing `pina idl` generation command also provides explicit lifecycle subcommands:
+
+```text
+pina idl generate
+pina idl fetch --cluster <CLUSTER> [--program-id <ADDRESS>]
+pina idl diff --cluster <CLUSTER> [--program-id <ADDRESS>]
+pina idl publish --cluster <CLUSTER> --authority <KEYPAIR>
+```
+
+Bare `pina idl [OPTIONS]` is unchanged and remains equivalent to `pina idl generate [OPTIONS]`.
+
+Publication uses the canonical `idl` seed with direct zlib-compressed UTF-8 JSON. Pina validates the complete Codama document and requires its `program.publicKey` to match the target. Network commands always require an explicit cluster.
+
+The transaction planner is the pinned official package `@solana-program/program-metadata@0.9.0`, invoked through an npx-compatible runner without a shell. `npx` may download that exact version when it is not cached. The adapter was cross-checked against upstream commit `33eb527e124cc4a09d8aae448cd306a9bd87db14`.
+
+Use export mode to inspect or multisig-sign every planned transaction without submitting:
+
+```text
+pina idl publish --cluster mainnet-beta --authority ./authority.json --export
+pina idl publish --cluster mainnet-beta --file ./idl.json \
+  --export <MULTISIG_AUTHORITY> --export-encoding base58 --output ./idl-plan.txt
+```
+
+The output preserves every `[Transaction #N]` block from the official planner. An export authority is a noop signer; it does not require or accept a local authority/payer secret.
+
+Fetch uses raw mode and locally performs bounded zlib, UTF-8, JSON, Codama-schema, and program-address validation. URL/external-account metadata and alternate encodings fail closed rather than causing an unexpected outbound request.
+
+See the mdBook chapter **Pina CLI → Generate and publish IDLs** for authority, rent, buffer, RPC, multisig, exit-status, and failure-recovery details.
+
+<!-- {/pinaIdlProgramMetadata} -->
+
 For best IDL extraction fidelity, follow the rules documented in [`crates/pina_cli/rules.md`](./rules.md).
 
 [crate-image]: https://img.shields.io/crates/v/pina_cli.svg?style=flat-square

--- a/crates/pina_cli/src/cli.rs
+++ b/crates/pina_cli/src/cli.rs
@@ -130,42 +130,24 @@ pub(crate) enum Commands {
 		npx: String,
 	},
 
-	/// Generate a Codama IDL from a Pina program crate.
+	/// Generate, inspect, and publish canonical Codama IDLs.
 	///
-	/// Parses the crate rooted at PATH, follows Rust modules from src/lib.rs,
-	/// and emits a Codama root-node JSON document. JSON is written to stdout
-	/// unless OUTPUT is supplied; progress and the extraction summary are
-	/// written to stderr.
+	/// Bare invocation preserves local generation: it parses PATH and emits a
+	/// Codama root-node JSON document. The generate subcommand spells that action
+	/// explicitly. Fetch, diff, and publish manage canonical `idl` metadata for a
+	/// deployed program through the pinned official Program Metadata client.
 	#[command(after_help = "Examples:\n  pina idl\n  pina idl --path \
 	                        ./programs/counter_program\n  pina idl -p ./programs/counter_program \
 	                        -o ./idls/counter_program.json\n  pina idl -p \
 	                        ./programs/counter_program --compact")]
 	Idl {
-		/// Program crate directory containing Cargo.toml and src/lib.rs. Defaults to the current directory.
-		#[arg(
-			short,
-			long,
-			default_value = ".",
-			hide_default_value = true,
-			value_name = "DIR"
-		)]
-		path: PathBuf,
+		/// IDL generation and canonical on-chain publication operation.
+		#[command(subcommand)]
+		command: Option<IdlCommands>,
 
-		/// Write the JSON document to FILE instead of stdout.
-		#[arg(short, long, value_name = "FILE")]
-		output: Option<PathBuf>,
-
-		/// Override the program name inferred from Cargo.toml.
-		#[arg(short, long, value_name = "NAME")]
-		name: Option<String>,
-
-		/// Emit compact JSON instead of the default pretty-printed JSON.
-		#[arg(long)]
-		compact: bool,
-
-		/// Preserve compatibility with the former explicit pretty-print flag.
-		#[arg(long, hide = true, conflicts_with = "compact")]
-		pretty: bool,
+		/// IDL generation options used when no subcommand is supplied.
+		#[command(flatten)]
+		generate: IdlGenerateArgs,
 	},
 
 	/// Read bundled Pina reference documentation in the terminal.
@@ -264,6 +246,256 @@ pub(crate) enum Commands {
 		#[command(subcommand)]
 		command: CodamaCommands,
 	},
+}
+
+/// Arguments shared by `pina idl` and `pina idl generate`.
+#[derive(clap::Args, Debug)]
+pub(crate) struct IdlGenerateArgs {
+	/// Program crate directory containing Cargo.toml and src/lib.rs. Defaults to the current directory.
+	#[arg(
+		short,
+		long,
+		default_value = ".",
+		hide_default_value = true,
+		value_name = "DIR"
+	)]
+	pub(crate) path: PathBuf,
+
+	/// Write the JSON document to FILE instead of stdout.
+	#[arg(short, long, value_name = "FILE")]
+	pub(crate) output: Option<PathBuf>,
+
+	/// Override the program name inferred from Cargo.toml.
+	#[arg(short, long, value_name = "NAME")]
+	pub(crate) name: Option<String>,
+
+	/// Emit compact JSON instead of the default pretty-printed JSON.
+	#[arg(long)]
+	pub(crate) compact: bool,
+
+	/// Preserve compatibility with the former explicit pretty-print flag.
+	#[arg(long, hide = true, conflicts_with = "compact")]
+	pub(crate) pretty: bool,
+}
+
+/// IDL generation and Program Metadata workflows.
+#[derive(Subcommand, Debug)]
+pub(crate) enum IdlCommands {
+	/// Generate a Codama IDL from local Pina source.
+	#[command(
+		after_help = "Examples:\n  pina idl generate\n  pina idl generate --path \
+		              ./programs/counter --output ./target/idl/counter.json\n\nCompatibility:\n  \
+		              Bare 'pina idl [OPTIONS]' remains equivalent to this command."
+	)]
+	Generate(IdlGenerateArgs),
+
+	/// Fetch a direct zlib/UTF-8 canonical on-chain IDL for a deployed program.
+	#[command(
+		after_help = "Examples:\n  pina idl fetch --cluster devnet --program-id <ADDRESS>\n  pina \
+		              idl fetch --cluster mainnet-beta --program-id <ADDRESS> --output \
+		              ./idl.json\n\nRequirements:\n  Uses the pinned official \
+		              @solana-program/program-metadata package through npx. The canonical \
+		              metadata seed is always 'idl'. URL, external-account, and other encoding \
+		              formats fail closed in this initial workflow."
+	)]
+	Fetch {
+		/// Solana cluster moniker or HTTP(S) RPC URL. This is always explicit.
+		#[arg(long, value_name = "CLUSTER")]
+		cluster: String,
+
+		/// Deployed program address. Inferred from the local IDL when omitted.
+		#[arg(long, value_name = "ADDRESS")]
+		program_id: Option<String>,
+
+		/// Directory inside the local project used for program ID inference.
+		#[arg(
+			short,
+			long,
+			default_value = ".",
+			hide_default_value = true,
+			value_name = "DIR"
+		)]
+		project: PathBuf,
+
+		/// Write the fetched IDL to FILE instead of stdout.
+		#[arg(short, long, value_name = "FILE")]
+		output: Option<PathBuf>,
+
+		/// Emit a machine-readable result envelope.
+		#[arg(long, conflicts_with = "output")]
+		json: bool,
+
+		/// npx-compatible runner for the pinned official package. May download version 0.9.0.
+		#[arg(
+			long,
+			default_value = "npx",
+			hide_default_value = true,
+			value_name = "COMMAND"
+		)]
+		npx: String,
+	},
+
+	/// Compare a local IDL with canonical on-chain metadata.
+	#[command(
+		after_help = "Examples:\n  pina idl diff --cluster devnet --program-id <ADDRESS>\n  pina \
+		              idl diff --cluster mainnet-beta --file ./target/idl/program.json \
+		              --program-id <ADDRESS> --json\n\nComparison:\n  JSON object key order and \
+		              whitespace are ignored. A difference exits with status 2, making the \
+		              command useful in CI."
+	)]
+	Diff {
+		/// Solana cluster moniker or HTTP(S) RPC URL. This is always explicit.
+		#[arg(long, value_name = "CLUSTER")]
+		cluster: String,
+
+		/// Deployed program address. Inferred from the local IDL when omitted.
+		#[arg(long, value_name = "ADDRESS")]
+		program_id: Option<String>,
+
+		/// Directory inside the local project used for IDL generation and discovery.
+		#[arg(
+			short,
+			long,
+			default_value = ".",
+			hide_default_value = true,
+			value_name = "DIR"
+		)]
+		project: PathBuf,
+
+		/// Compare FILE instead of generating the local project IDL.
+		#[arg(long, value_name = "FILE")]
+		file: Option<PathBuf>,
+
+		/// Emit a machine-readable comparison result.
+		#[arg(long)]
+		json: bool,
+
+		/// npx-compatible runner for the pinned official package. May download version 0.9.0.
+		#[arg(
+			long,
+			default_value = "npx",
+			hide_default_value = true,
+			value_name = "COMMAND"
+		)]
+		npx: String,
+	},
+
+	/// Create or update the canonical on-chain IDL metadata account.
+	#[command(
+		after_help = "Examples:\n  pina idl publish --cluster devnet --authority \
+		              ~/.config/solana/id.json --yes\n  pina idl publish --cluster mainnet-beta \
+		              --program-id <ADDRESS> --file ./idl.json --authority \
+		              ./upgrade-authority.json --export --output ./idl-plan.txt\n  pina idl \
+		              publish --cluster mainnet-beta --program-id <ADDRESS> --file ./idl.json \
+		              --export <MULTISIG> --output ./idl-update.txt\n\nSafety:\n  Publication is \
+		              canonical, uses compressed inline JSON under the fixed 'idl' seed, and \
+		              requires explicit confirmation. --export plans every required transaction \
+		              without submitting any. An optional --export authority supports multisigs."
+	)]
+	Publish {
+		/// Solana cluster moniker or HTTP(S) RPC URL. This is always explicit.
+		#[arg(long, value_name = "CLUSTER")]
+		cluster: String,
+
+		/// Deployed program address. Inferred from the local IDL when omitted.
+		#[arg(long, value_name = "ADDRESS")]
+		program_id: Option<String>,
+
+		/// Directory inside the local project used for IDL generation and discovery.
+		#[arg(
+			short,
+			long,
+			default_value = ".",
+			hide_default_value = true,
+			value_name = "DIR"
+		)]
+		project: PathBuf,
+
+		/// Publish FILE instead of generating the local project IDL.
+		#[arg(long, value_name = "FILE")]
+		file: Option<PathBuf>,
+
+		/// Upgrade-authority keypair for direct publication.
+		#[arg(long, value_name = "KEYPAIR")]
+		authority: Option<PathBuf>,
+
+		/// Fee and rent payer keypair. Defaults to --authority.
+		#[arg(long, value_name = "KEYPAIR", requires = "authority")]
+		payer: Option<PathBuf>,
+
+		/// Export every planned transaction instead of submitting. Optionally use ADDRESS as a noop multisig authority.
+		#[arg(
+			long,
+			value_name = "ADDRESS",
+			num_args = 0..=1,
+			default_missing_value = "__pina_local_export__"
+		)]
+		export: Option<ExportArg>,
+
+		/// Write every exported transaction to FILE instead of stdout.
+		#[arg(short, long, value_name = "FILE", requires = "export")]
+		output: Option<PathBuf>,
+
+		/// Encoding for an exported multisig transaction.
+		#[arg(long, value_enum, default_value = "base64", requires = "export")]
+		export_encoding: IdlExportEncodingArg,
+
+		/// Skip the interactive publication confirmation.
+		#[arg(long, conflicts_with = "export")]
+		yes: bool,
+
+		/// Emit a machine-readable result envelope.
+		#[arg(long, conflicts_with = "export")]
+		json: bool,
+
+		/// Priority fee in micro-lamports per compute unit.
+		#[arg(long, default_value_t = 100_000, value_name = "MICROLAMPORTS")]
+		priority_fee: u64,
+
+		/// npx-compatible runner for the pinned official package. May download version 0.9.0.
+		#[arg(
+			long,
+			default_value = "npx",
+			hide_default_value = true,
+			value_name = "COMMAND"
+		)]
+		npx: String,
+	},
+}
+
+/// Supported official transaction export encodings.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub(crate) enum IdlExportEncodingArg {
+	Base58,
+	Base64,
+}
+
+/// Authority selection for no-submit transaction export.
+#[derive(Debug, Clone)]
+pub(crate) enum ExportArg {
+	Local,
+	Authority(String),
+}
+
+impl std::str::FromStr for ExportArg {
+	type Err = String;
+
+	fn from_str(value: &str) -> Result<Self, Self::Err> {
+		if value == "__pina_local_export__" {
+			Ok(Self::Local)
+		} else {
+			Ok(Self::Authority(value.to_owned()))
+		}
+	}
+}
+
+impl ExportArg {
+	pub(crate) fn authority(&self) -> Option<&str> {
+		match self {
+			Self::Local => None,
+			Self::Authority(authority) => Some(authority),
+		}
+	}
 }
 
 /// Client ecosystems supported by project-aware generation.

--- a/crates/pina_cli/src/idl_command.rs
+++ b/crates/pina_cli/src/idl_command.rs
@@ -1,0 +1,448 @@
+//! Execution and presentation for the \`pina idl\` command family.
+
+use std::io::BufRead;
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
+
+use owo_colors::OwoColorize;
+
+use crate::cli::ExportArg;
+use crate::cli::IdlCommands;
+use crate::cli::IdlExportEncodingArg;
+use crate::cli::IdlGenerateArgs;
+use crate::run_idl;
+
+pub(crate) fn run_idl_command(command: Option<IdlCommands>, generate: &IdlGenerateArgs) {
+	match command {
+		None => run_idl_generate(generate),
+		Some(IdlCommands::Generate(args)) => run_idl_generate(&args),
+		Some(IdlCommands::Fetch {
+			cluster,
+			program_id,
+			project,
+			output,
+			json,
+			npx,
+		}) => {
+			run_idl_fetch(
+				cluster,
+				program_id.as_deref(),
+				&project,
+				output.as_deref(),
+				json,
+				npx,
+			);
+		}
+		Some(IdlCommands::Diff {
+			cluster,
+			program_id,
+			project,
+			file,
+			json,
+			npx,
+		}) => {
+			run_idl_diff(
+				cluster,
+				program_id.as_deref(),
+				&project,
+				file.as_deref(),
+				json,
+				npx,
+			);
+		}
+		Some(IdlCommands::Publish {
+			cluster,
+			program_id,
+			project,
+			file,
+			authority,
+			payer,
+			export,
+			output,
+			export_encoding,
+			yes,
+			json,
+			priority_fee,
+			npx,
+		}) => {
+			run_idl_publish(IdlPublishCommand {
+				cluster,
+				program_id,
+				project,
+				file,
+				authority,
+				payer,
+				export,
+				output,
+				export_encoding,
+				yes,
+				json,
+				priority_fee,
+				npx,
+			});
+		}
+	}
+}
+
+fn run_idl_generate(args: &IdlGenerateArgs) {
+	run_idl(
+		args.path.as_path(),
+		args.output.as_deref(),
+		args.name.as_deref(),
+		!args.compact,
+	);
+}
+
+fn run_idl_fetch(
+	cluster: String,
+	program_id: Option<&str>,
+	project: &Path,
+	output: Option<&Path>,
+	json: bool,
+	npx: String,
+) {
+	let local = if program_id.is_none() {
+		Some(or_exit(pina_cli::idl_metadata::load_local_idl(
+			project, None,
+		)))
+	} else {
+		None
+	};
+	let program_id = or_exit(pina_cli::idl_metadata::resolve_program_id(
+		program_id,
+		local.as_ref(),
+	));
+	let client = pina_cli::idl_metadata::ClientOptions { npx, cluster };
+	let value = or_exit(pina_cli::idl_metadata::fetch_idl(&client, &program_id));
+	let pretty = or_exit(serde_json::to_vec_pretty(&value));
+
+	if let Some(output) = output {
+		or_exit(pina_cli::idl_metadata::write_atomic(output, &pretty));
+		println!(
+			"{} Wrote canonical IDL to {}",
+			"✔".green(),
+			safe_path_display(output)
+		);
+		return;
+	}
+
+	if json {
+		println!(
+			"{}",
+			serde_json::json!({
+				"schemaVersion": 1,
+				"programId": program_id,
+				"idl": value,
+			})
+		);
+		return;
+	}
+
+	println!("{}", String::from_utf8_lossy(&pretty));
+}
+
+fn run_idl_diff(
+	cluster: String,
+	program_id: Option<&str>,
+	project: &Path,
+	file: Option<&Path>,
+	json: bool,
+	npx: String,
+) {
+	let local = or_exit(pina_cli::idl_metadata::load_local_idl(project, file));
+	let program_id = or_exit(pina_cli::idl_metadata::resolve_program_id(
+		program_id,
+		Some(&local),
+	));
+	let client = pina_cli::idl_metadata::ClientOptions { npx, cluster };
+	let on_chain = or_exit(pina_cli::idl_metadata::fetch_idl(&client, &program_id));
+	let difference = pina_cli::idl_metadata::compare_idls(&local, on_chain);
+
+	if json {
+		println!("{}", or_exit(serde_json::to_string_pretty(&difference)));
+	} else if difference.equal {
+		println!(
+			"{} Local and canonical on-chain IDLs are equal",
+			"✔".green()
+		);
+	} else {
+		println!("{} Local and canonical on-chain IDLs differ", "✘".red());
+	}
+
+	if !difference.equal {
+		std::process::exit(2);
+	}
+}
+
+struct IdlPublishCommand {
+	cluster: String,
+	program_id: Option<String>,
+	project: PathBuf,
+	file: Option<PathBuf>,
+	authority: Option<PathBuf>,
+	payer: Option<PathBuf>,
+	export: Option<ExportArg>,
+	output: Option<PathBuf>,
+	export_encoding: IdlExportEncodingArg,
+	yes: bool,
+	json: bool,
+	priority_fee: u64,
+	npx: String,
+}
+
+fn run_idl_publish(command: IdlPublishCommand) {
+	// Validate before any confirmation or output can reflect a user-provided RPC URL.
+	or_exit(pina_cli::idl_metadata::rpc_url(&command.cluster));
+	let cluster_display = pina_cli::idl_metadata::cluster_display(&command.cluster);
+	let idl_label = command.file.as_ref().map_or_else(
+		|| format!("generated from {}", safe_path_display(&command.project)),
+		|path| safe_path_display(path),
+	);
+	let local = or_exit(pina_cli::idl_metadata::load_local_idl(
+		&command.project,
+		command.file.as_deref(),
+	));
+	let program_id = or_exit(pina_cli::idl_metadata::resolve_program_id(
+		command.program_id.as_deref(),
+		Some(&local),
+	));
+	let export_authority = command.export.as_ref().and_then(ExportArg::authority);
+	let exporting = command.export.is_some();
+
+	if export_authority.is_some() && command.payer.is_some() {
+		exit_with_error(
+			"--payer cannot be used with an exported authority because the official planner uses \
+			 the noop authority as payer",
+		);
+	}
+
+	if export_authority.is_some() && command.authority.is_some() {
+		exit_with_error(
+			"--authority cannot be used with --export <ADDRESS> because the exported authority is \
+			 a noop signer",
+		);
+	}
+
+	if !exporting && command.authority.is_none() {
+		exit_with_error("--authority is required when publication is not exported");
+	}
+
+	if exporting && export_authority.is_none() && command.authority.is_none() {
+		exit_with_error("--authority is required for --export without an authority address");
+	}
+
+	let confirmation = (!exporting && !command.yes)
+		.then(|| confirm_publication(&cluster_display, &program_id, &idl_label))
+		.transpose();
+	or_exit(confirmation);
+
+	let client = pina_cli::idl_metadata::ClientOptions {
+		npx: command.npx,
+		cluster: command.cluster.clone(),
+	};
+	let export_encoding = match command.export_encoding {
+		IdlExportEncodingArg::Base58 => "base58",
+		IdlExportEncodingArg::Base64 => "base64",
+	};
+	let options = pina_cli::idl_metadata::PublishOptions {
+		local: &local,
+		authority: command.authority.as_deref(),
+		payer: command.payer.as_deref(),
+		priority_fee: command.priority_fee,
+		export: exporting,
+		export_authority,
+		export_encoding,
+	};
+	let exported = or_exit(pina_cli::idl_metadata::publish_idl(&client, &options));
+
+	if let Some(exported) = exported {
+		if let Some(output) = command.output {
+			or_exit(pina_cli::idl_metadata::write_atomic(
+				&output,
+				exported.as_bytes(),
+			));
+			eprintln!(
+				"{} Wrote every exported transaction to {}",
+				"✔".green(),
+				safe_path_display(&output)
+			);
+		} else {
+			print!("{exported}");
+		}
+
+		return;
+	}
+
+	if command.json {
+		println!(
+			"{}",
+			serde_json::json!({
+				"schemaVersion": 1,
+				"status": "published",
+				"programId": program_id,
+				"seed": "idl",
+				"cluster": cluster_display,
+			})
+		);
+	} else {
+		println!(
+			"{} Published the canonical IDL for {}",
+			"✔".green(),
+			program_id
+		);
+	}
+}
+
+fn confirm_publication(cluster: &str, program_id: &str, idl: &str) -> Result<(), &'static str> {
+	use std::io::IsTerminal;
+
+	let stdin = std::io::stdin();
+	let mut input = stdin.lock();
+	let mut output = std::io::stderr().lock();
+	let confirmation = or_exit(prompt_publication(
+		stdin.is_terminal(),
+		&mut input,
+		&mut output,
+		cluster,
+		program_id,
+		idl,
+	));
+
+	confirmation_error(&confirmation).map_or(Ok(()), Err)
+}
+
+fn confirmation_error(confirmation: &Confirmation) -> Option<&'static str> {
+	match confirmation {
+		Confirmation::Approved => None,
+		Confirmation::NonInteractive => {
+			Some(
+				"publication requires confirmation; rerun with --yes in non-interactive \
+				 environments",
+			)
+		}
+		Confirmation::Cancelled => Some("publication cancelled"),
+	}
+}
+
+fn safe_path_display(path: &Path) -> String {
+	path.to_string_lossy()
+		.chars()
+		.fold(String::new(), |mut output, character| {
+			if character.is_control() {
+				output.extend(character.escape_default());
+			} else {
+				output.push(character);
+			}
+
+			output
+		})
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum Confirmation {
+	Approved,
+	Cancelled,
+	NonInteractive,
+}
+
+fn prompt_publication(
+	is_terminal: bool,
+	input: &mut impl BufRead,
+	output: &mut impl Write,
+	cluster: &str,
+	program_id: &str,
+	idl: &str,
+) -> std::io::Result<Confirmation> {
+	if !is_terminal {
+		return Ok(Confirmation::NonInteractive);
+	}
+
+	writeln!(output, "Publish canonical IDL metadata?")?;
+	writeln!(output, "  Cluster  {cluster}")?;
+	writeln!(output, "  Program  {program_id}")?;
+	writeln!(output, "  IDL      {idl}")?;
+	write!(output, "Type `publish` to continue: ")?;
+	output.flush()?;
+	let mut response = String::new();
+	input.read_line(&mut response)?;
+
+	if response.trim() == "publish" {
+		Ok(Confirmation::Approved)
+	} else {
+		Ok(Confirmation::Cancelled)
+	}
+}
+
+fn or_exit<T, E: std::fmt::Display>(result: Result<T, E>) -> T {
+	match result {
+		Ok(value) => value,
+		Err(error) => exit_with_error(&error.to_string()),
+	}
+}
+
+fn exit_with_error(message: &str) -> ! {
+	eprintln!("{} {}", "Error".red().bold(), message);
+	std::process::exit(1);
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn publication_prompt_covers_approval_cancellation_and_non_interactive_use() {
+		let mut output = Vec::new();
+		let decision = prompt_publication(
+			true,
+			&mut "publish\n".as_bytes(),
+			&mut output,
+			"devnet",
+			"program",
+			"idl.json",
+		)
+		.unwrap_or_else(|error| panic!("prompt failed: {error}"));
+		assert_eq!(decision, Confirmation::Approved);
+		assert_eq!(confirmation_error(&decision), None);
+		assert!(String::from_utf8_lossy(&output).contains("Type `publish`"));
+
+		let cancelled = prompt_publication(
+			true,
+			&mut "no\n".as_bytes(),
+			&mut Vec::new(),
+			"devnet",
+			"program",
+			"idl.json",
+		)
+		.unwrap_or_else(|error| panic!("prompt failed: {error}"));
+		assert_eq!(cancelled, Confirmation::Cancelled);
+		assert_eq!(
+			confirmation_error(&cancelled),
+			Some("publication cancelled")
+		);
+
+		let non_interactive = prompt_publication(
+			false,
+			&mut "".as_bytes(),
+			&mut Vec::new(),
+			"devnet",
+			"program",
+			"idl.json",
+		)
+		.unwrap_or_else(|error| panic!("prompt failed: {error}"));
+		assert_eq!(non_interactive, Confirmation::NonInteractive);
+		assert!(
+			confirmation_error(&non_interactive)
+				.unwrap_or_default()
+				.contains("requires confirmation")
+		);
+	}
+
+	#[test]
+	fn terminal_paths_escape_newlines_and_ansi_controls() {
+		let displayed = safe_path_display(Path::new("idl\n\u{1b}[31m.json"));
+		assert_eq!(displayed, "idl\\n\\u{1b}[31m.json");
+		assert!(!displayed.contains('\n'));
+		assert!(!displayed.contains('\u{1b}'));
+	}
+}

--- a/crates/pina_cli/src/idl_metadata.rs
+++ b/crates/pina_cli/src/idl_metadata.rs
@@ -1,0 +1,1793 @@
+//! Canonical IDL publication through Solana's Program Metadata program.
+//!
+//! Pina deliberately delegates transaction planning to the official client.
+//! Program Metadata may split writes across reallocations and temporary buffers;
+//! duplicating that evolving planner here would create a second, unsafe protocol
+//! implementation. The pinned adapter below was verified against upstream commit
+//! `33eb527e124cc4a09d8aae448cd306a9bd87db14` and package version `0.9.0`.
+
+use std::ffi::OsString;
+use std::fmt;
+use std::io::Read;
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+use std::process::Stdio;
+use std::str::FromStr;
+
+use atomic_write_file::AtomicWriteFile;
+use codama_nodes::RootNode;
+use ed25519_dalek::SigningKey;
+use flate2::read::ZlibDecoder;
+use serde::Serialize;
+use serde_json::Value;
+use solana_address::Address;
+use url::Host;
+use url::Url;
+
+use crate::generate_idl;
+use crate::project::Project;
+
+/// Exact official package used for Program Metadata transaction planning.
+pub const PROGRAM_METADATA_PACKAGE: &str = "@solana-program/program-metadata@0.9.0";
+
+const IDL_SEED: &str = "idl";
+
+/// Errors returned by canonical IDL network workflows.
+#[derive(Debug, thiserror::Error)]
+pub enum IdlMetadataError {
+	#[error(transparent)]
+	Project(#[from] crate::project::ProjectError),
+
+	#[error("Failed to generate the local IDL: {0}")]
+	Generate(#[from] crate::error::IdlError),
+
+	#[error("Could not read {path:?}: {source}")]
+	Read {
+		path: PathBuf,
+		source: std::io::Error,
+	},
+
+	#[error("Could not write {path:?}: {source}")]
+	Write {
+		path: PathBuf,
+		source: std::io::Error,
+	},
+
+	#[error("Invalid IDL JSON at {path:?}: {source}")]
+	Json {
+		path: PathBuf,
+		source: serde_json::Error,
+	},
+
+	#[error("Invalid Codama IDL at {path:?}: {reason}")]
+	InvalidIdl { path: PathBuf, reason: String },
+
+	#[error("Invalid program address {value:?}")]
+	InvalidAddress { value: String },
+
+	#[error("IDL program address {idl} does not match requested program {requested}")]
+	ProgramMismatch { idl: String, requested: String },
+
+	#[error("Invalid cluster `{cluster}`: {reason}")]
+	InvalidCluster { cluster: String, reason: String },
+
+	#[error("Invalid keypair file {path:?}: {reason}")]
+	InvalidKeypair { path: PathBuf, reason: String },
+
+	#[error("Invalid publication signer configuration: {reason}")]
+	InvalidSignerConfiguration { reason: &'static str },
+
+	#[error(
+		"Could not run the pinned Program Metadata client with {command:?}: {source}. Install \
+		 Node.js and npm, or pass an npx-compatible runner with --npx <COMMAND>"
+	)]
+	RunClient {
+		command: String,
+		source: std::io::Error,
+	},
+
+	#[error("The pinned Program Metadata client failed with status {status}: {details}")]
+	ClientFailed { status: i32, details: String },
+
+	#[error("The pinned Program Metadata client exceeded the {limit}-byte {stream} safety limit")]
+	ClientOutputTooLarge { stream: &'static str, limit: usize },
+
+	#[error("Program Metadata returned non-UTF-8 output")]
+	NonUtf8,
+
+	#[error("Program Metadata did not return any exported transactions")]
+	MissingExport,
+
+	#[error("Canonical IDL metadata is not direct zlib-compressed UTF-8 JSON: {reason}")]
+	UnsupportedContent { reason: String },
+
+	#[error("Unsafe filesystem path {path:?}: {reason}")]
+	UnsafePath { path: PathBuf, reason: String },
+}
+
+/// A validated local Codama IDL document.
+#[derive(Debug, Clone)]
+pub struct LocalIdl {
+	pub path: PathBuf,
+	pub program_id: String,
+	pub value: Value,
+}
+
+/// Result of semantically comparing two JSON IDLs.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IdlDiff {
+	pub equal: bool,
+	pub program_id: String,
+	pub local: Value,
+	pub on_chain: Value,
+}
+
+/// Options for the pinned official Program Metadata client.
+#[derive(Clone)]
+pub struct ClientOptions {
+	pub npx: String,
+	pub cluster: String,
+}
+
+impl fmt::Debug for ClientOptions {
+	fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+		formatter
+			.debug_struct("ClientOptions")
+			.field("npx", &self.npx)
+			.field("cluster", &"<redacted>")
+			.finish()
+	}
+}
+
+/// Options for a canonical IDL publication.
+#[derive(Debug)]
+pub struct PublishOptions<'a> {
+	pub local: &'a LocalIdl,
+	pub authority: Option<&'a Path>,
+	pub payer: Option<&'a Path>,
+	pub priority_fee: u64,
+	pub export: bool,
+	pub export_authority: Option<&'a str>,
+	pub export_encoding: &'a str,
+}
+
+/// Load a generated or file-backed IDL and enforce the Codama root contract.
+///
+/// # Errors
+///
+/// Returns an error when project discovery, generation, file access, JSON
+/// parsing, or Codama root validation fails.
+pub fn load_local_idl(
+	project_dir: &Path,
+	file: Option<&Path>,
+) -> Result<LocalIdl, IdlMetadataError> {
+	let (path, value) = if let Some(path) = file {
+		const MAX_LOCAL_IDL_BYTES: u64 = 16 * 1024 * 1024;
+		let metadata = std::fs::metadata(path).map_err(read_error(path))?;
+
+		if !metadata.is_file() {
+			return Err(IdlMetadataError::InvalidIdl {
+				path: path.to_path_buf(),
+				reason: "IDL path is not a regular file".to_owned(),
+			});
+		}
+
+		if metadata.len() > MAX_LOCAL_IDL_BYTES {
+			return Err(IdlMetadataError::InvalidIdl {
+				path: path.to_path_buf(),
+				reason: format!("IDL exceeds the {MAX_LOCAL_IDL_BYTES}-byte safety limit"),
+			});
+		}
+
+		ensure_safe_path(path, true)?;
+		let bytes = std::fs::read(path).map_err(read_error(path))?;
+		let value = serde_json::from_slice(&bytes).map_err(json_error(path))?;
+
+		(path.to_path_buf(), value)
+	} else {
+		let project = Project::discover(project_dir)?;
+		let root = generate_idl(&project.program_dir, Some(&project.library_name))?;
+		let value = serde_json::to_value(root)
+			.unwrap_or_else(|error| panic!("Codama RootNode serialization failed: {error}"));
+
+		(
+			project
+				.idl_dir
+				.join(format!("{}.json", project.library_name)),
+			value,
+		)
+	};
+	let program_id = idl_program_id(&value, &path)?;
+
+	Ok(LocalIdl {
+		path,
+		program_id,
+		value,
+	})
+}
+
+/// Resolve and validate a requested program ID against the IDL when available.
+///
+/// # Errors
+///
+/// Returns an error for malformed addresses or an IDL/target mismatch.
+pub fn resolve_program_id(
+	requested: Option<&str>,
+	local: Option<&LocalIdl>,
+) -> Result<String, IdlMetadataError> {
+	let value = requested
+		.or_else(|| local.map(|idl| idl.program_id.as_str()))
+		.ok_or_else(|| {
+			IdlMetadataError::InvalidIdl {
+				path: PathBuf::from("<local project>"),
+				reason: "program ID is unavailable; pass --program-id".to_owned(),
+			}
+		})?;
+	let normalized = parse_address(value)?;
+
+	if let Some(local) = local
+		&& local.program_id != normalized
+	{
+		return Err(IdlMetadataError::ProgramMismatch {
+			idl: local.program_id.clone(),
+			requested: normalized,
+		});
+	}
+
+	Ok(normalized)
+}
+
+/// Convert an explicit cluster moniker or safe RPC URL to the official client input.
+///
+/// # Errors
+///
+/// Returns an error for URLs containing credentials, query parameters, or
+/// fragments, which are rejected to keep secrets out of subprocess arguments.
+pub fn rpc_url(cluster: &str) -> Result<String, IdlMetadataError> {
+	let known = match cluster {
+		"mainnet" | "mainnet-beta" => Some("https://api.mainnet-beta.solana.com"),
+		"devnet" => Some("https://api.devnet.solana.com"),
+		"testnet" => Some("https://api.testnet.solana.com"),
+		"localnet" | "localhost" => Some("http://127.0.0.1:8899"),
+		_ => None,
+	};
+
+	if let Some(url) = known {
+		return Ok(url.to_owned());
+	}
+
+	if cluster.chars().any(char::is_control) {
+		return Err(IdlMetadataError::InvalidCluster {
+			cluster: "<redacted>".to_owned(),
+			reason: "RPC URLs must not contain control characters".to_owned(),
+		});
+	}
+
+	let url = Url::parse(cluster).map_err(|_| {
+		IdlMetadataError::InvalidCluster {
+			cluster: "<redacted>".to_owned(),
+			reason: "use mainnet-beta, devnet, testnet, localnet, or a valid HTTP(S) URL"
+				.to_owned(),
+		}
+	})?;
+	let is_http = url.scheme() == "http";
+	let is_https = url.scheme() == "https";
+	let is_loopback = match url.host() {
+		Some(Host::Domain(domain)) => domain == "localhost",
+		Some(Host::Ipv4(address)) => address.is_loopback(),
+		Some(Host::Ipv6(address)) => address.is_loopback(),
+		None => false,
+	};
+	let invalid_component = !url.username().is_empty()
+		|| url.password().is_some()
+		|| url.query().is_some()
+		|| url.fragment().is_some()
+		|| url.path() != "/";
+
+	if (!is_http && !is_https) || invalid_component || (is_http && !is_loopback) {
+		return Err(IdlMetadataError::InvalidCluster {
+			cluster: "<redacted>".to_owned(),
+			reason: "RPC URLs require HTTP(S), no credentials, query, fragment, or path, and \
+			         plaintext HTTP only for an exact loopback host"
+				.to_owned(),
+		});
+	}
+
+	Ok(cluster.to_owned())
+}
+
+/// Return a credential-free cluster label suitable for terminal or JSON output.
+#[must_use]
+pub fn cluster_display(cluster: &str) -> String {
+	match cluster {
+		"mainnet" | "mainnet-beta" | "devnet" | "testnet" | "localnet" | "localhost" => {
+			cluster.to_owned()
+		}
+		_ => {
+			Url::parse(cluster).ok().map_or_else(
+				|| "<redacted>".to_owned(),
+				|url| url.origin().ascii_serialization(),
+			)
+		}
+	}
+}
+
+/// Validate a Solana JSON keypair without printing its contents.
+///
+/// # Errors
+///
+/// Returns an error unless the file is a regular file containing exactly 64 bytes.
+pub fn validate_keypair(path: &Path) -> Result<String, IdlMetadataError> {
+	validated_keypair(path).map(|(_, address)| address)
+}
+
+fn validated_keypair(path: &Path) -> Result<([u8; 64], String), IdlMetadataError> {
+	let metadata = std::fs::metadata(path).map_err(read_error(path))?;
+
+	if !metadata.is_file() {
+		return Err(IdlMetadataError::InvalidKeypair {
+			path: path.to_path_buf(),
+			reason: "path is not a regular file".to_owned(),
+		});
+	}
+
+	if metadata.len() > 4_096 {
+		return Err(IdlMetadataError::InvalidKeypair {
+			path: path.to_path_buf(),
+			reason: "keypair file exceeds the 4 KiB safety limit".to_owned(),
+		});
+	}
+
+	#[cfg(unix)]
+	{
+		use std::os::unix::fs::PermissionsExt;
+
+		if metadata.permissions().mode() & 0o077 != 0 {
+			return Err(IdlMetadataError::InvalidKeypair {
+				path: path.to_path_buf(),
+				reason: "keypair file must not be readable or writable by group or other users"
+					.to_owned(),
+			});
+		}
+	}
+
+	ensure_safe_path(path, true)?;
+	let source = std::fs::read(path).map_err(read_error(path))?;
+	let bytes: Vec<u8> = serde_json::from_slice(&source).map_err(|_| {
+		IdlMetadataError::InvalidKeypair {
+			path: path.to_path_buf(),
+			reason: "expected a JSON array of 64 byte values".to_owned(),
+		}
+	})?;
+
+	if bytes.len() != 64 {
+		return Err(IdlMetadataError::InvalidKeypair {
+			path: path.to_path_buf(),
+			reason: format!("expected 64 bytes, found {}", bytes.len()),
+		});
+	}
+
+	let mut keypair = [0; 64];
+	keypair.copy_from_slice(&bytes);
+	let signing_key = SigningKey::from_keypair_bytes(&keypair).map_err(|_| {
+		IdlMetadataError::InvalidKeypair {
+			path: path.to_path_buf(),
+			reason: "secret and public key bytes do not form a valid Ed25519 keypair".to_owned(),
+		}
+	})?;
+
+	let address = Address::from(signing_key.verifying_key().to_bytes()).to_string();
+	Ok((keypair, address))
+}
+
+/// Fetch and parse the canonical on-chain IDL.
+///
+/// # Errors
+///
+/// Returns an error when RPC validation, the official client, or JSON parsing fails.
+pub fn fetch_idl(client: &ClientOptions, program_id: &str) -> Result<Value, IdlMetadataError> {
+	let rpc = rpc_url(&client.cluster)?;
+	let args = vec![
+		OsString::from("--yes"),
+		OsString::from(PROGRAM_METADATA_PACKAGE),
+		OsString::from("fetch"),
+		OsString::from(IDL_SEED),
+		OsString::from(parse_address(program_id)?),
+		OsString::from("--rpc"),
+		OsString::from(rpc),
+		OsString::from("--raw"),
+	];
+
+	let output = run_official_client(client, &args)?;
+	let compressed = extract_raw_hex(&output)?;
+	const MAX_IDL_BYTES: u64 = 16 * 1024 * 1024;
+	let decoder = ZlibDecoder::new(compressed.as_slice());
+	let mut bytes = Vec::new();
+	Read::read_to_end(&mut decoder.take(MAX_IDL_BYTES + 1), &mut bytes).map_err(|error| {
+		IdlMetadataError::UnsupportedContent {
+			reason: format!("zlib decompression failed: {error}"),
+		}
+	})?;
+
+	if bytes.len() as u64 > MAX_IDL_BYTES {
+		return Err(IdlMetadataError::UnsupportedContent {
+			reason: format!("decompressed IDL exceeds the {MAX_IDL_BYTES}-byte safety limit"),
+		});
+	}
+	let value = serde_json::from_slice(&bytes).map_err(|source| {
+		IdlMetadataError::Json {
+			path: PathBuf::from("<on-chain IDL>"),
+			source,
+		}
+	})?;
+	let fetched_program = idl_program_id(&value, Path::new("<on-chain IDL>"))?;
+
+	if fetched_program != program_id {
+		return Err(IdlMetadataError::ProgramMismatch {
+			idl: fetched_program,
+			requested: program_id.to_owned(),
+		});
+	}
+
+	Ok(value)
+}
+
+/// Compare a validated local IDL to canonical on-chain JSON semantically.
+#[must_use]
+pub fn compare_idls(local: &LocalIdl, on_chain: Value) -> IdlDiff {
+	IdlDiff {
+		equal: local.value == on_chain,
+		program_id: local.program_id.clone(),
+		local: local.value.clone(),
+		on_chain,
+	}
+}
+
+/// Publish or export a canonical IDL transaction plan.
+///
+/// # Errors
+///
+/// Returns an error when validation or the pinned official client fails.
+pub fn publish_idl(
+	client: &ClientOptions,
+	options: &PublishOptions<'_>,
+) -> Result<Option<String>, IdlMetadataError> {
+	validate_publish_signers(options)?;
+	let validated_program_id = idl_program_id(&options.local.value, &options.local.path)?;
+
+	if validated_program_id != options.local.program_id {
+		return Err(IdlMetadataError::ProgramMismatch {
+			idl: validated_program_id,
+			requested: options.local.program_id.clone(),
+		});
+	}
+
+	let rpc = rpc_url(&client.cluster)?;
+	let program_id = parse_address(&options.local.program_id)?;
+	let mut args = vec![
+		OsString::from("--yes"),
+		OsString::from(PROGRAM_METADATA_PACKAGE),
+		OsString::from("write"),
+		OsString::from(IDL_SEED),
+		OsString::from(program_id),
+	];
+	let serialized = serde_json::to_vec_pretty(&options.local.value)
+		.unwrap_or_else(|error| panic!("serde_json::Value serialization failed: {error}"));
+	let temp = tempfile::NamedTempFile::new().map_err(write_error(Path::new("<temporary IDL>")))?;
+	std::fs::write(temp.path(), serialized).map_err(write_error(temp.path()))?;
+	args.push(temp.path().as_os_str().to_owned());
+	args.extend([
+		OsString::from("--compression"),
+		OsString::from("zlib"),
+		OsString::from("--encoding"),
+		OsString::from("utf8"),
+		OsString::from("--format"),
+		OsString::from("json"),
+	]);
+
+	args.extend([
+		OsString::from("--rpc"),
+		OsString::from(rpc),
+		OsString::from("--priority-fees"),
+		OsString::from(options.priority_fee.to_string()),
+	]);
+	let authority_copy = options.authority.map(prepare_keypair).transpose()?;
+	let payer_copy = options.payer.map(prepare_keypair).transpose()?;
+
+	if let Some(authority) = &authority_copy {
+		args.push(OsString::from("--keypair"));
+		args.push(authority.path.as_os_str().to_owned());
+
+		if let Some(payer) = &payer_copy {
+			args.push(OsString::from("--payer"));
+			args.push(payer.path.as_os_str().to_owned());
+		}
+	}
+
+	if options.export {
+		args.push(OsString::from("--export"));
+
+		if let Some(authority) = options.export_authority {
+			args.push(OsString::from(parse_address(authority)?));
+		}
+
+		args.extend([
+			OsString::from("--export-encoding"),
+			OsString::from(options.export_encoding),
+		]);
+	}
+
+	let output = run_official_client(client, &args)?;
+
+	if !options.export {
+		return Ok(None);
+	}
+
+	let output = String::from_utf8(output).map_err(|_| IdlMetadataError::NonUtf8)?;
+
+	if !output.contains("Transaction #") {
+		return Err(IdlMetadataError::MissingExport);
+	}
+
+	Ok(Some(output))
+}
+
+struct PreparedKeypair {
+	_directory: tempfile::TempDir,
+	path: PathBuf,
+}
+
+fn prepare_keypair(path: &Path) -> Result<PreparedKeypair, IdlMetadataError> {
+	let (bytes, _) = validated_keypair(path)?;
+	let directory = tempfile::tempdir().map_err(write_error(Path::new("<temporary keypair>")))?;
+
+	#[cfg(unix)]
+	{
+		use std::os::unix::fs::PermissionsExt;
+
+		let mut permissions = std::fs::metadata(directory.path())
+			.map_err(read_error(directory.path()))?
+			.permissions();
+		permissions.set_mode(0o700);
+		std::fs::set_permissions(directory.path(), permissions)
+			.map_err(write_error(directory.path()))?;
+	}
+
+	let stable_path = directory.path().join("keypair.json");
+	let serialized = serde_json::to_vec(bytes.as_slice())
+		.unwrap_or_else(|error| panic!("fixed byte-array serialization failed: {error}"));
+	let mut options = std::fs::OpenOptions::new();
+	options.write(true).create_new(true);
+
+	#[cfg(unix)]
+	{
+		use std::os::unix::fs::OpenOptionsExt;
+
+		options.mode(0o600);
+	}
+
+	let mut file = options
+		.open(&stable_path)
+		.map_err(write_error(&stable_path))?;
+	file.write_all(&serialized)
+		.and_then(|()| file.flush())
+		.map_err(write_error(&stable_path))?;
+
+	Ok(PreparedKeypair {
+		_directory: directory,
+		path: stable_path,
+	})
+}
+
+fn validate_publish_signers(options: &PublishOptions<'_>) -> Result<(), IdlMetadataError> {
+	let local_authority = options.authority.is_some();
+	let exported_authority = options.export_authority.is_some();
+
+	if options.payer.is_some() && !local_authority {
+		return Err(IdlMetadataError::InvalidSignerConfiguration {
+			reason: "a payer keypair requires a local authority keypair",
+		});
+	}
+
+	if exported_authority && (local_authority || options.payer.is_some()) {
+		return Err(IdlMetadataError::InvalidSignerConfiguration {
+			reason: "an exported authority cannot be combined with local authority or payer \
+			         keypairs",
+		});
+	}
+
+	if !options.export && !local_authority {
+		return Err(IdlMetadataError::InvalidSignerConfiguration {
+			reason: "direct publication requires a local authority keypair",
+		});
+	}
+
+	if options.export && !exported_authority && !local_authority {
+		return Err(IdlMetadataError::InvalidSignerConfiguration {
+			reason: "local transaction export requires a local authority keypair",
+		});
+	}
+
+	Ok(())
+}
+
+/// Atomically write user-visible IDL or export output.
+///
+/// # Errors
+///
+/// Returns an error when the destination cannot be opened, written, or committed.
+pub fn write_atomic(path: &Path, contents: &[u8]) -> Result<(), IdlMetadataError> {
+	let parent = path.parent().unwrap_or_else(|| Path::new("."));
+	ensure_safe_path(path, false)?;
+	std::fs::create_dir_all(parent).map_err(write_error(parent))?;
+	let mut file = AtomicWriteFile::open(path).map_err(write_error(path))?;
+	file.write_all(contents)
+		.and_then(|()| file.commit())
+		.map_err(write_error(path))
+}
+
+fn idl_program_id(value: &Value, path: &Path) -> Result<String, IdlMetadataError> {
+	let root: RootNode = serde_json::from_value(value.clone()).map_err(|error| {
+		IdlMetadataError::InvalidIdl {
+			path: path.to_path_buf(),
+			reason: error.to_string(),
+		}
+	})?;
+
+	if root.standard != "codama" {
+		return Err(IdlMetadataError::InvalidIdl {
+			path: path.to_path_buf(),
+			reason: "expected the codama standard".to_owned(),
+		});
+	}
+
+	parse_address(&root.program.public_key)
+}
+
+fn parse_address(value: &str) -> Result<String, IdlMetadataError> {
+	Address::from_str(value)
+		.map(|address| address.to_string())
+		.map_err(|_| {
+			IdlMetadataError::InvalidAddress {
+				value: value.to_owned(),
+			}
+		})
+}
+
+fn run_official_client(
+	client: &ClientOptions,
+	args: &[OsString],
+) -> Result<Vec<u8>, IdlMetadataError> {
+	const MAX_STDOUT_BYTES: usize = 32 * 1024 * 1024;
+	const MAX_STDERR_BYTES: usize = 64 * 1024;
+	run_official_client_with_limits(client, args, MAX_STDOUT_BYTES, MAX_STDERR_BYTES)
+}
+
+fn run_official_client_with_limits(
+	client: &ClientOptions,
+	args: &[OsString],
+	max_stdout_bytes: usize,
+	max_stderr_bytes: usize,
+) -> Result<Vec<u8>, IdlMetadataError> {
+	let mut child = Command::new(&client.npx)
+		.args(args)
+		.stdin(Stdio::null())
+		.stdout(Stdio::piped())
+		.stderr(Stdio::piped())
+		.spawn()
+		.map_err(run_client_error(client))?;
+	let stdout = child
+		.stdout
+		.take()
+		.ok_or_else(|| std::io::Error::other("Program Metadata stdout pipe was not created"))
+		.map_err(run_client_error(client))?;
+	let stderr = child
+		.stderr
+		.take()
+		.ok_or_else(|| std::io::Error::other("Program Metadata stderr pipe was not created"))
+		.map_err(run_client_error(client))?;
+	let (status, stdout, stderr) = std::thread::scope(|scope| {
+		let stdout = scope.spawn(|| read_bounded(stdout, max_stdout_bytes));
+		let stderr = scope.spawn(|| read_bounded(stderr, max_stderr_bytes));
+		let status = child.wait()?;
+		let stdout = join_output_reader(stdout)?;
+		let stderr = join_output_reader(stderr)?;
+
+		Ok::<_, std::io::Error>((status, stdout, stderr))
+	})
+	.map_err(run_client_error(client))?;
+
+	if stdout.overflowed {
+		return Err(IdlMetadataError::ClientOutputTooLarge {
+			stream: "stdout",
+			limit: max_stdout_bytes,
+		});
+	}
+
+	if stderr.overflowed {
+		return Err(IdlMetadataError::ClientOutputTooLarge {
+			stream: "stderr",
+			limit: max_stderr_bytes,
+		});
+	}
+
+	if status.success() {
+		return Ok(stdout.bytes);
+	}
+
+	let details = sanitize_diagnostic(&String::from_utf8_lossy(&stderr.bytes));
+
+	Err(IdlMetadataError::ClientFailed {
+		status: status.code().unwrap_or(-1),
+		details,
+	})
+}
+
+struct BoundedRead {
+	bytes: Vec<u8>,
+	overflowed: bool,
+}
+
+fn read_bounded(reader: impl Read, limit: usize) -> std::io::Result<BoundedRead> {
+	let mut reader = std::io::BufReader::new(reader);
+	let mut chunk = [0; 8 * 1024];
+	let mut bytes = Vec::with_capacity(limit.min(chunk.len()));
+	let mut overflowed = false;
+
+	loop {
+		let read = reader.read(&mut chunk)?;
+
+		if read == 0 {
+			return Ok(BoundedRead { bytes, overflowed });
+		}
+
+		let remaining = limit.saturating_sub(bytes.len());
+		let retained = remaining.min(read);
+		bytes.extend_from_slice(&chunk[..retained]);
+		overflowed |= retained < read;
+	}
+}
+
+fn join_output_reader(
+	handle: std::thread::ScopedJoinHandle<'_, std::io::Result<BoundedRead>>,
+) -> std::io::Result<BoundedRead> {
+	handle
+		.join()
+		.map_err(|_| std::io::Error::other("Program Metadata output reader panicked"))?
+}
+
+fn run_client_error(
+	client: &ClientOptions,
+) -> impl FnOnce(std::io::Error) -> IdlMetadataError + '_ {
+	move |source| {
+		IdlMetadataError::RunClient {
+			command: client.npx.clone(),
+			source,
+		}
+	}
+}
+
+fn extract_raw_hex(output: &[u8]) -> Result<Vec<u8>, IdlMetadataError> {
+	let output = std::str::from_utf8(output).map_err(|_| IdlMetadataError::NonUtf8)?;
+	let line = output
+		.lines()
+		.rev()
+		.map(str::trim)
+		.find(|line| !line.is_empty())
+		.ok_or_else(|| {
+			IdlMetadataError::UnsupportedContent {
+				reason: "the official client returned no raw account data".to_owned(),
+			}
+		})?;
+
+	if line.len() > 8 * 1024 * 1024 {
+		return Err(IdlMetadataError::UnsupportedContent {
+			reason: "raw compressed IDL exceeds the 4 MiB safety limit".to_owned(),
+		});
+	}
+
+	if !line.len().is_multiple_of(2) || !line.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+		return Err(IdlMetadataError::UnsupportedContent {
+			reason: "expected direct raw hexadecimal data; URL and external-account sources are \
+			         not supported"
+				.to_owned(),
+		});
+	}
+
+	line.as_bytes()
+		.chunks_exact(2)
+		.map(|pair| {
+			let text = std::str::from_utf8(pair)
+				.unwrap_or_else(|error| panic!("validated hexadecimal was not UTF-8: {error}"));
+			Ok(u8::from_str_radix(text, 16)
+				.unwrap_or_else(|error| panic!("validated hexadecimal did not decode: {error}")))
+		})
+		.collect()
+}
+
+fn read_error(path: &Path) -> impl FnOnce(std::io::Error) -> IdlMetadataError + '_ {
+	move |source| {
+		IdlMetadataError::Read {
+			path: path.to_path_buf(),
+			source,
+		}
+	}
+}
+
+fn write_error(path: &Path) -> impl FnOnce(std::io::Error) -> IdlMetadataError + '_ {
+	move |source| {
+		IdlMetadataError::Write {
+			path: path.to_path_buf(),
+			source,
+		}
+	}
+}
+
+fn json_error(path: &Path) -> impl FnOnce(serde_json::Error) -> IdlMetadataError + '_ {
+	move |source| {
+		IdlMetadataError::Json {
+			path: path.to_path_buf(),
+			source,
+		}
+	}
+}
+
+fn sanitize_diagnostic(value: &str) -> String {
+	let sanitized = value
+		.chars()
+		.filter(|character| !character.is_control() || matches!(character, '\n' | '\t'))
+		.take(4_096)
+		.collect::<String>();
+	let sanitized = sanitized.trim();
+
+	if sanitized.is_empty() {
+		"no diagnostic output".to_owned()
+	} else {
+		sanitized.to_owned()
+	}
+}
+
+fn ensure_safe_path(path: &Path, include_self: bool) -> Result<(), IdlMetadataError> {
+	if include_self || path.exists() {
+		let metadata = std::fs::symlink_metadata(path).map_err(read_error(path))?;
+
+		if is_link_or_reparse(&metadata) {
+			return Err(IdlMetadataError::UnsafePath {
+				path: path.to_path_buf(),
+				reason: "the final path is a symbolic link or reparse point".to_owned(),
+			});
+		}
+	}
+
+	Ok(())
+}
+
+fn is_link_or_reparse(metadata: &std::fs::Metadata) -> bool {
+	if metadata.file_type().is_symlink() {
+		return true;
+	}
+
+	#[cfg(windows)]
+	{
+		use std::os::windows::fs::MetadataExt;
+
+		return metadata.file_attributes() & 0x0400 != 0;
+	}
+
+	#[cfg(not(windows))]
+	false
+}
+
+#[cfg(test)]
+mod tests {
+	#[cfg(unix)]
+	use std::fmt::Write as _;
+	use std::io::Cursor;
+
+	#[cfg(unix)]
+	use flate2::Compression;
+	#[cfg(unix)]
+	use flate2::write::ZlibEncoder;
+
+	use super::*;
+
+	fn idl(program_id: &str) -> Value {
+		serde_json::json!({
+			"kind": "rootNode",
+			"standard": "codama",
+			"version": "1.8.0",
+			"program": {
+				"kind": "programNode",
+				"name": "fixture",
+				"publicKey": program_id,
+				"version": "0.0.0",
+				"instructions": []
+			},
+			"additionalPrograms": []
+		})
+	}
+
+	#[test]
+	fn cluster_aliases_and_safe_urls_are_accepted() {
+		assert_eq!(
+			rpc_url("devnet").unwrap_or_else(|error| panic!("devnet failed: {error}")),
+			"https://api.devnet.solana.com"
+		);
+		assert_eq!(
+			rpc_url("https://rpc.example.test")
+				.unwrap_or_else(|error| panic!("URL failed: {error}")),
+			"https://rpc.example.test"
+		);
+		assert!(rpc_url("http://localhost.attacker.test").is_err());
+		assert!(rpc_url("http://127.attacker.test").is_err());
+		assert!(rpc_url("http://127.0.0.1:8899").is_ok());
+		assert!(rpc_url("http://[::1]:8899").is_ok());
+		assert!(rpc_url("file:///tmp/rpc").is_err());
+	}
+
+	#[test]
+	fn credential_bearing_rpc_urls_are_rejected_and_redacted() {
+		for cluster in [
+			"https://user:secret@rpc.example.test",
+			"https://rpc.example.test?token=secret",
+			"https://rpc.example.test/private",
+			"https://rpc.example.test:invalid",
+			"https://rpc.example.test\n.evil.test",
+			"ftp://rpc.example.test",
+		] {
+			let error = rpc_url(cluster)
+				.expect_err("unsafe URL must fail")
+				.to_string();
+			assert!(!error.contains("secret"));
+		}
+	}
+
+	#[test]
+	fn client_debug_and_cluster_display_do_not_expose_rpc_details() {
+		let client = ClientOptions {
+			npx: "npx".to_owned(),
+			cluster: "https://rpc.example.test".to_owned(),
+		};
+		let debug = format!("{client:?}");
+		assert!(debug.contains("<redacted>"));
+		assert!(!debug.contains("rpc.example.test"));
+		assert_eq!(
+			cluster_display("https://rpc.example.test:9443"),
+			"https://rpc.example.test:9443"
+		);
+		assert_eq!(cluster_display("not a URL"), "<redacted>");
+	}
+
+	#[test]
+	fn semantic_comparison_ignores_object_order_but_preserves_array_order() {
+		let program_id = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS";
+		let local = LocalIdl {
+			path: PathBuf::from("idl.json"),
+			program_id: program_id.to_owned(),
+			value: idl(program_id),
+		};
+		let reordered: Value = serde_json::from_str(
+			&serde_json::to_string(&local.value)
+				.unwrap_or_else(|error| panic!("fixture must serialize: {error}")),
+		)
+		.unwrap_or_else(|error| panic!("fixture must parse: {error}"));
+		assert!(compare_idls(&local, reordered).equal);
+
+		let mut changed = local.value.clone();
+		changed["program"]["instructions"] = serde_json::json!([2, 1]);
+		assert!(!compare_idls(&local, changed).equal);
+	}
+
+	#[test]
+	fn target_program_must_match_the_idl() {
+		let local = LocalIdl {
+			path: PathBuf::from("idl.json"),
+			program_id: "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS".to_owned(),
+			value: Value::Null,
+		};
+		let error = resolve_program_id(
+			Some("ProgM6JCCvbYkfKqJYHePx4xxSUSqJp7rh8Lyv7nk7S"),
+			Some(&local),
+		)
+		.expect_err("mismatch must fail");
+		assert!(matches!(error, IdlMetadataError::ProgramMismatch { .. }));
+	}
+
+	#[test]
+	fn malformed_codama_documents_are_rejected() {
+		let malformed = serde_json::json!({
+			"kind": "rootNode",
+			"standard": "codama",
+			"version": "1.8.0",
+			"program": { "publicKey": "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS" }
+		});
+		let error = idl_program_id(&malformed, Path::new("bad.json"))
+			.expect_err("incomplete root must fail");
+		assert!(matches!(error, IdlMetadataError::InvalidIdl { .. }));
+	}
+
+	#[test]
+	fn non_codama_roots_are_rejected_after_full_deserialization() {
+		let mut value = idl("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+		value["standard"] = Value::String("other".to_owned());
+		assert!(matches!(
+			idl_program_id(&value, Path::new("other.json")),
+			Err(IdlMetadataError::InvalidIdl { .. })
+		));
+	}
+
+	#[test]
+	fn local_idl_loading_covers_files_generation_and_input_failures() {
+		let directory = tempfile::tempdir()
+			.unwrap_or_else(|error| panic!("temporary directory failed: {error}"));
+		let missing = directory.path().join("missing.json");
+		assert!(matches!(
+			load_local_idl(directory.path(), Some(&missing)),
+			Err(IdlMetadataError::Read { .. })
+		));
+		assert!(matches!(
+			load_local_idl(directory.path(), Some(directory.path())),
+			Err(IdlMetadataError::InvalidIdl { .. })
+		));
+
+		let oversized = directory.path().join("oversized.json");
+		let oversized_file = std::fs::File::create(&oversized)
+			.unwrap_or_else(|error| panic!("oversized fixture create failed: {error}"));
+		oversized_file
+			.set_len(16 * 1024 * 1024 + 1)
+			.unwrap_or_else(|error| panic!("oversized fixture resize failed: {error}"));
+		assert!(matches!(
+			load_local_idl(directory.path(), Some(&oversized)),
+			Err(IdlMetadataError::InvalidIdl { .. })
+		));
+
+		let malformed = directory.path().join("malformed.json");
+		std::fs::write(&malformed, b"{")
+			.unwrap_or_else(|error| panic!("malformed fixture write failed: {error}"));
+		assert!(matches!(
+			load_local_idl(directory.path(), Some(&malformed)),
+			Err(IdlMetadataError::Json { .. })
+		));
+
+		let generated_program = directory.path().join("generated-program");
+		std::fs::create_dir_all(generated_program.join("src"))
+			.unwrap_or_else(|error| panic!("generated fixture directory failed: {error}"));
+		std::fs::write(
+			generated_program.join("Cargo.toml"),
+			"[package]\nname = \"anchor_declare_id\"\nversion = \"0.0.0\"\nedition = \
+			 \"2024\"\n\n[lib]\ncrate-type = [\"cdylib\", \"lib\"]\n",
+		)
+		.unwrap_or_else(|error| panic!("generated fixture manifest failed: {error}"));
+		std::fs::write(
+			generated_program.join("src/lib.rs"),
+			include_str!("../../../examples/anchor_declare_id/src/lib.rs"),
+		)
+		.unwrap_or_else(|error| panic!("generated fixture source failed: {error}"));
+		let generated = load_local_idl(&generated_program, None)
+			.unwrap_or_else(|error| panic!("generated IDL failed: {error}"));
+		assert_eq!(
+			generated.program_id,
+			"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
+		);
+
+		#[cfg(unix)]
+		{
+			use std::os::unix::fs::symlink;
+
+			let link = directory.path().join("linked.json");
+			symlink(&malformed, &link)
+				.unwrap_or_else(|error| panic!("IDL symlink failed: {error}"));
+			assert!(matches!(
+				load_local_idl(directory.path(), Some(&link)),
+				Err(IdlMetadataError::UnsafePath { .. })
+			));
+		}
+	}
+
+	#[test]
+	fn program_resolution_requires_a_valid_available_address() {
+		assert!(matches!(
+			resolve_program_id(None, None),
+			Err(IdlMetadataError::InvalidIdl { .. })
+		));
+		assert!(matches!(
+			resolve_program_id(Some("not-an-address"), None),
+			Err(IdlMetadataError::InvalidAddress { .. })
+		));
+	}
+
+	#[test]
+	fn official_package_policy_is_exactly_pinned() {
+		assert_eq!(
+			PROGRAM_METADATA_PACKAGE,
+			"@solana-program/program-metadata@0.9.0"
+		);
+	}
+
+	#[test]
+	fn valid_keypairs_are_verified_cryptographically() {
+		let directory = tempfile::tempdir()
+			.unwrap_or_else(|error| panic!("temporary directory failed: {error}"));
+		let path = directory.path().join("authority.json");
+		let keypair = SigningKey::from_bytes(&[7; 32]).to_keypair_bytes();
+		std::fs::write(
+			&path,
+			serde_json::to_vec(keypair.as_slice())
+				.unwrap_or_else(|error| panic!("keypair serialization failed: {error}")),
+		)
+		.unwrap_or_else(|error| panic!("keypair write failed: {error}"));
+		set_private_permissions(&path);
+
+		let address = validate_keypair(&path)
+			.unwrap_or_else(|error| panic!("valid keypair was rejected: {error}"));
+		assert_eq!(
+			address,
+			Address::from(keypair[32..].try_into().unwrap_or([0; 32])).to_string()
+		);
+
+		let mut mismatched = keypair;
+		mismatched[63] ^= 1;
+		std::fs::write(
+			&path,
+			serde_json::to_vec(mismatched.as_slice())
+				.unwrap_or_else(|error| panic!("keypair serialization failed: {error}")),
+		)
+		.unwrap_or_else(|error| panic!("keypair write failed: {error}"));
+		assert!(validate_keypair(&path).is_err());
+	}
+
+	#[test]
+	fn malformed_and_non_file_keypairs_are_rejected() {
+		let directory = tempfile::tempdir()
+			.unwrap_or_else(|error| panic!("temporary directory failed: {error}"));
+		assert!(matches!(
+			validate_keypair(directory.path()),
+			Err(IdlMetadataError::InvalidKeypair { .. })
+		));
+
+		let malformed = directory.path().join("malformed.json");
+		std::fs::write(&malformed, b"not json")
+			.unwrap_or_else(|error| panic!("malformed fixture write failed: {error}"));
+		set_private_permissions(&malformed);
+		assert!(matches!(
+			validate_keypair(&malformed),
+			Err(IdlMetadataError::InvalidKeypair { .. })
+		));
+
+		let short = directory.path().join("short.json");
+		std::fs::write(&short, b"[]")
+			.unwrap_or_else(|error| panic!("short fixture write failed: {error}"));
+		set_private_permissions(&short);
+		assert!(validate_keypair(&short).is_err());
+	}
+
+	#[test]
+	fn oversized_keypair_files_are_rejected_before_reading() {
+		let directory = tempfile::tempdir()
+			.unwrap_or_else(|error| panic!("temporary directory failed: {error}"));
+		let path = directory.path().join("oversized.json");
+		std::fs::write(&path, vec![b'0'; 4_097])
+			.unwrap_or_else(|error| panic!("oversized fixture write failed: {error}"));
+		set_private_permissions(&path);
+		let error = validate_keypair(&path).expect_err("oversized keypair must fail");
+		assert!(error.to_string().contains("4 KiB"));
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn shared_unix_keypair_files_are_rejected() {
+		use std::os::unix::fs::PermissionsExt;
+
+		let directory = tempfile::tempdir()
+			.unwrap_or_else(|error| panic!("temporary directory failed: {error}"));
+		let path = directory.path().join("shared.json");
+		std::fs::write(&path, b"[]")
+			.unwrap_or_else(|error| panic!("shared fixture write failed: {error}"));
+		let mut permissions = std::fs::metadata(&path)
+			.unwrap_or_else(|error| panic!("keypair metadata failed: {error}"))
+			.permissions();
+		permissions.set_mode(0o640);
+		std::fs::set_permissions(&path, permissions)
+			.unwrap_or_else(|error| panic!("keypair permissions failed: {error}"));
+		let error = validate_keypair(&path).expect_err("shared keypair must fail");
+		assert!(error.to_string().contains("group or other users"));
+	}
+
+	#[cfg(unix)]
+	fn set_private_permissions(path: &Path) {
+		use std::os::unix::fs::PermissionsExt;
+
+		let mut permissions = std::fs::metadata(path)
+			.unwrap_or_else(|error| panic!("keypair metadata failed: {error}"))
+			.permissions();
+		permissions.set_mode(0o600);
+		std::fs::set_permissions(path, permissions)
+			.unwrap_or_else(|error| panic!("keypair permissions failed: {error}"));
+	}
+
+	#[cfg(not(unix))]
+	fn set_private_permissions(_path: &Path) {}
+
+	#[cfg(unix)]
+	#[test]
+	fn fetch_uses_raw_mode_and_decodes_direct_zlib_json() {
+		let directory = tempfile::tempdir()
+			.unwrap_or_else(|error| panic!("temporary directory failed: {error}"));
+		let program_id = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS";
+		let value = idl(program_id);
+		let source = serde_json::to_vec(&value)
+			.unwrap_or_else(|error| panic!("IDL serialization failed: {error}"));
+		let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+		encoder
+			.write_all(&source)
+			.unwrap_or_else(|error| panic!("compression failed: {error}"));
+		let compressed = encoder
+			.finish()
+			.unwrap_or_else(|error| panic!("compression finish failed: {error}"));
+		let hex = compressed.iter().fold(String::new(), |mut output, byte| {
+			write!(output, "{byte:02x}")
+				.unwrap_or_else(|error| panic!("hex formatting failed: {error}"));
+			output
+		});
+		let capture = directory.path().join("args.txt");
+		let runner = fake_runner(directory.path(), &capture, &format!("heading\n{hex}"));
+		let client = ClientOptions {
+			npx: runner.display().to_string(),
+			cluster: "devnet".to_owned(),
+		};
+
+		let fetched =
+			fetch_idl(&client, program_id).unwrap_or_else(|error| panic!("fetch failed: {error}"));
+		assert_eq!(fetched, value);
+		let args = std::fs::read_to_string(capture)
+			.unwrap_or_else(|error| panic!("capture read failed: {error}"));
+		assert!(args.contains("@solana-program/program-metadata@0.9.0"));
+		assert!(args.contains("--raw"));
+		assert!(!args.contains("latest"));
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn publish_forwards_structured_arguments_without_secret_contents() {
+		let directory = tempfile::tempdir()
+			.unwrap_or_else(|error| panic!("temporary directory failed: {error}"));
+		let capture = directory.path().join("args.txt");
+		let runner = fake_runner(directory.path(), &capture, "planned");
+		let keypair = SigningKey::from_bytes(&[19; 32]).to_keypair_bytes();
+		let authority = directory.path().join("authority.json");
+		std::fs::write(
+			&authority,
+			serde_json::to_vec(keypair.as_slice())
+				.unwrap_or_else(|error| panic!("keypair serialization failed: {error}")),
+		)
+		.unwrap_or_else(|error| panic!("keypair write failed: {error}"));
+		set_private_permissions(&authority);
+		let program_id = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS";
+		let local = LocalIdl {
+			path: PathBuf::from("idl.json"),
+			program_id: program_id.to_owned(),
+			value: idl(program_id),
+		};
+		let client = ClientOptions {
+			npx: runner.display().to_string(),
+			cluster: "devnet".to_owned(),
+		};
+		let options = PublishOptions {
+			local: &local,
+			authority: Some(&authority),
+			payer: None,
+			priority_fee: 42,
+			export: false,
+			export_authority: None,
+			export_encoding: "base64",
+		};
+
+		assert!(
+			publish_idl(&client, &options)
+				.unwrap_or_else(|error| panic!("publish failed: {error}"))
+				.is_none()
+		);
+		let args = std::fs::read_to_string(capture)
+			.unwrap_or_else(|error| panic!("capture read failed: {error}"));
+		assert!(args.contains("write\nidl\n"));
+		assert!(args.contains("--compression\nzlib\n--encoding\nutf8\n--format\njson"));
+		assert!(args.contains("--priority-fees\n42"));
+		assert!(!args.contains(&authority.display().to_string()));
+		assert!(!args.contains(&serde_json::to_string(keypair.as_slice()).unwrap_or_default()));
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn publication_signs_from_a_stable_private_keypair_copy() {
+		let directory = tempfile::tempdir()
+			.unwrap_or_else(|error| panic!("temporary directory failed: {error}"));
+		let keypair = SigningKey::from_bytes(&[29; 32]).to_keypair_bytes();
+		let authority = directory.path().join("authority.json");
+		let captured = directory.path().join("captured.json");
+		let serialized = serde_json::to_vec(keypair.as_slice()).unwrap_or_default();
+		std::fs::write(&authority, &serialized)
+			.unwrap_or_else(|error| panic!("keypair write failed: {error}"));
+		set_private_permissions(&authority);
+		let body = format!(
+			"rm -f '{}'\nprevious=''\nfor argument in \"$@\"; do\n  if [ \"$previous\" = \
+			 \"--keypair\" ]; then cp \"$argument\" '{}'; fi\n  \
+			 previous=\"$argument\"\ndone\nprintf 'published'",
+			authority.display(),
+			captured.display(),
+		);
+		let runner = fake_runner_script(directory.path(), &body);
+		let program_id = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS";
+		let local = LocalIdl {
+			path: PathBuf::from("idl.json"),
+			program_id: program_id.to_owned(),
+			value: idl(program_id),
+		};
+		let client = ClientOptions {
+			npx: runner.display().to_string(),
+			cluster: "devnet".to_owned(),
+		};
+		let options = PublishOptions {
+			local: &local,
+			authority: Some(&authority),
+			payer: None,
+			priority_fee: 0,
+			export: false,
+			export_authority: None,
+			export_encoding: "base64",
+		};
+
+		publish_idl(&client, &options)
+			.unwrap_or_else(|error| panic!("publication failed: {error}"));
+		assert!(!authority.exists());
+		assert_eq!(std::fs::read(captured).unwrap_or_default(), serialized);
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn publish_supports_separate_payer_and_local_export() {
+		let directory = tempfile::tempdir()
+			.unwrap_or_else(|error| panic!("temporary directory failed: {error}"));
+		let capture = directory.path().join("args.txt");
+		let runner = fake_runner(
+			directory.path(),
+			&capture,
+			"Exporting 1 transaction:\n[Transaction #1]\nAAAA\n",
+		);
+		let keypair = SigningKey::from_bytes(&[23; 32]).to_keypair_bytes();
+		let authority = directory.path().join("authority.json");
+		let payer = directory.path().join("payer.json");
+		for path in [&authority, &payer] {
+			std::fs::write(
+				path,
+				serde_json::to_vec(keypair.as_slice()).unwrap_or_default(),
+			)
+			.unwrap_or_else(|error| panic!("keypair write failed: {error}"));
+			set_private_permissions(path);
+		}
+		let program_id = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS";
+		let local = LocalIdl {
+			path: PathBuf::from("idl.json"),
+			program_id: program_id.to_owned(),
+			value: idl(program_id),
+		};
+		let client = ClientOptions {
+			npx: runner.display().to_string(),
+			cluster: "devnet".to_owned(),
+		};
+		let options = PublishOptions {
+			local: &local,
+			authority: Some(&authority),
+			payer: Some(&payer),
+			priority_fee: 0,
+			export: true,
+			export_authority: None,
+			export_encoding: "base58",
+		};
+		let exported = publish_idl(&client, &options)
+			.unwrap_or_else(|error| panic!("export failed: {error}"))
+			.unwrap_or_default();
+		assert!(exported.contains("[Transaction #1]"));
+		let args = std::fs::read_to_string(capture)
+			.unwrap_or_else(|error| panic!("capture read failed: {error}"));
+		assert!(args.contains("--payer"));
+		assert!(args.contains("--export\n--export-encoding\nbase58"));
+	}
+
+	#[test]
+	fn library_publication_rejects_invalid_signer_combinations_before_spawning() {
+		let program_id = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS";
+		let local = LocalIdl {
+			path: PathBuf::from("idl.json"),
+			program_id: program_id.to_owned(),
+			value: idl(program_id),
+		};
+		let client = ClientOptions {
+			npx: "a runner that must never start".to_owned(),
+			cluster: "devnet".to_owned(),
+		};
+		let keypair = Path::new("authority.json");
+		let multisig = "ProgM6JCCvbYkfKqJYHePx4xxSUSqJp7rh8Lyv7nk7S";
+		let cases = [
+			PublishOptions {
+				local: &local,
+				authority: None,
+				payer: Some(keypair),
+				priority_fee: 0,
+				export: false,
+				export_authority: None,
+				export_encoding: "base64",
+			},
+			PublishOptions {
+				local: &local,
+				authority: Some(keypair),
+				payer: None,
+				priority_fee: 0,
+				export: true,
+				export_authority: Some(multisig),
+				export_encoding: "base64",
+			},
+			PublishOptions {
+				local: &local,
+				authority: None,
+				payer: None,
+				priority_fee: 0,
+				export: false,
+				export_authority: None,
+				export_encoding: "base64",
+			},
+			PublishOptions {
+				local: &local,
+				authority: None,
+				payer: None,
+				priority_fee: 0,
+				export: true,
+				export_authority: None,
+				export_encoding: "base64",
+			},
+		];
+
+		for options in cases {
+			assert!(matches!(
+				publish_idl(&client, &options),
+				Err(IdlMetadataError::InvalidSignerConfiguration { .. })
+			));
+		}
+	}
+
+	#[test]
+	fn library_publication_revalidates_forged_local_idl_values_before_spawning() {
+		let client = ClientOptions {
+			npx: "a runner that must never start".to_owned(),
+			cluster: "devnet".to_owned(),
+		};
+		let victim = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS";
+		let other = "ProgM6JCCvbYkfKqJYHePx4xxSUSqJp7rh8Lyv7nk7S";
+		let local = LocalIdl {
+			path: PathBuf::from("forged.json"),
+			program_id: victim.to_owned(),
+			value: idl(other),
+		};
+		let options = PublishOptions {
+			local: &local,
+			authority: None,
+			payer: None,
+			priority_fee: 0,
+			export: true,
+			export_authority: Some(other),
+			export_encoding: "base64",
+		};
+		assert!(matches!(
+			publish_idl(&client, &options),
+			Err(IdlMetadataError::ProgramMismatch { .. })
+		));
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn export_rejects_missing_or_non_utf8_transaction_framing() {
+		let directory = tempfile::tempdir()
+			.unwrap_or_else(|error| panic!("temporary directory failed: {error}"));
+		let program_id = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS";
+		let local = LocalIdl {
+			path: PathBuf::from("idl.json"),
+			program_id: program_id.to_owned(),
+			value: idl(program_id),
+		};
+		let options = PublishOptions {
+			local: &local,
+			authority: None,
+			payer: None,
+			priority_fee: 0,
+			export: true,
+			export_authority: Some("ProgM6JCCvbYkfKqJYHePx4xxSUSqJp7rh8Lyv7nk7S"),
+			export_encoding: "base64",
+		};
+
+		let capture = directory.path().join("args-empty.txt");
+		let runner = fake_runner(directory.path(), &capture, "no plan");
+		let client = ClientOptions {
+			npx: runner.display().to_string(),
+			cluster: "devnet".to_owned(),
+		};
+		assert!(matches!(
+			publish_idl(&client, &options),
+			Err(IdlMetadataError::MissingExport)
+		));
+
+		let runner = fake_runner_script(directory.path(), "printf '\\377'");
+		let client = ClientOptions {
+			npx: runner.display().to_string(),
+			cluster: "devnet".to_owned(),
+		};
+		assert!(matches!(
+			publish_idl(&client, &options),
+			Err(IdlMetadataError::NonUtf8)
+		));
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn official_client_failures_are_sanitized_and_bounded() {
+		let directory = tempfile::tempdir()
+			.unwrap_or_else(|error| panic!("temporary directory failed: {error}"));
+		let runner =
+			fake_runner_script(directory.path(), "printf 'bad\\001diagnostic' >&2\nexit 7");
+		let client = ClientOptions {
+			npx: runner.display().to_string(),
+			cluster: "devnet".to_owned(),
+		};
+		let error = run_official_client(&client, &[]).expect_err("client failure must propagate");
+		assert!(error.to_string().contains("baddiagnostic"));
+		assert!(!error.to_string().contains('\u{1}'));
+	}
+
+	#[test]
+	fn missing_official_client_executable_is_reported_without_a_shell_fallback() {
+		let directory = tempfile::tempdir()
+			.unwrap_or_else(|error| panic!("temporary directory failed: {error}"));
+		let client = ClientOptions {
+			npx: directory
+				.path()
+				.join("missing & untrusted npx")
+				.display()
+				.to_string(),
+			cluster: "devnet".to_owned(),
+		};
+		assert!(matches!(
+			run_official_client(&client, &[OsString::from("; touch never")]),
+			Err(IdlMetadataError::RunClient { .. })
+		));
+		assert!(!directory.path().join("never").exists());
+	}
+
+	#[test]
+	fn bounded_output_reader_drains_without_retaining_overflow() {
+		let output = read_bounded(Cursor::new(b"abcdef"), 4)
+			.unwrap_or_else(|error| panic!("bounded read failed: {error}"));
+		assert_eq!(output.bytes, b"abcd");
+		assert!(output.overflowed);
+
+		let exact = read_bounded(Cursor::new(b"abcd"), 4)
+			.unwrap_or_else(|error| panic!("bounded read failed: {error}"));
+		assert_eq!(exact.bytes, b"abcd");
+		assert!(!exact.overflowed);
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn official_client_rejects_output_overflow_and_preserves_signal_status() {
+		let directory = tempfile::tempdir()
+			.unwrap_or_else(|error| panic!("temporary directory failed: {error}"));
+		for (body, stream) in [
+			("printf '12345'", "stdout"),
+			("printf '12345' >&2", "stderr"),
+		] {
+			let runner = fake_runner_script(directory.path(), body);
+			let client = ClientOptions {
+				npx: runner.display().to_string(),
+				cluster: "devnet".to_owned(),
+			};
+			let result = if stream == "stdout" {
+				run_official_client_with_limits(&client, &[], 4, 64)
+			} else {
+				run_official_client_with_limits(&client, &[], 64, 4)
+			};
+			assert!(matches!(
+				result,
+				Err(IdlMetadataError::ClientOutputTooLarge { stream: actual, .. }) if actual == stream
+			));
+		}
+
+		let runner = fake_runner_script(directory.path(), "kill -TERM $$");
+		let client = ClientOptions {
+			npx: runner.display().to_string(),
+			cluster: "devnet".to_owned(),
+		};
+		assert!(matches!(
+			run_official_client(&client, &[]),
+			Err(IdlMetadataError::ClientFailed { status: -1, .. })
+		));
+	}
+
+	#[test]
+	fn path_error_helpers_preserve_context() {
+		let io = || std::io::Error::other("fixture");
+		assert!(matches!(
+			read_error(Path::new("read"))(io()),
+			IdlMetadataError::Read { path, .. } if path == Path::new("read")
+		));
+		assert!(matches!(
+			write_error(Path::new("write"))(io()),
+			IdlMetadataError::Write { path, .. } if path == Path::new("write")
+		));
+		let json = serde_json::from_str::<Value>("{").expect_err("malformed JSON must fail");
+		assert!(matches!(
+			json_error(Path::new("json"))(json),
+			IdlMetadataError::Json { path, .. } if path == Path::new("json")
+		));
+	}
+
+	#[test]
+	fn safe_path_check_reports_a_missing_required_entry() {
+		let directory = tempfile::tempdir()
+			.unwrap_or_else(|error| panic!("temporary directory failed: {error}"));
+		assert!(matches!(
+			ensure_safe_path(&directory.path().join("missing"), true),
+			Err(IdlMetadataError::Read { .. })
+		));
+	}
+
+	#[test]
+	fn raw_metadata_parsing_fails_closed() {
+		assert!(matches!(
+			extract_raw_hex(b""),
+			Err(IdlMetadataError::UnsupportedContent { .. })
+		));
+		assert!(matches!(
+			extract_raw_hex(&[0xff]),
+			Err(IdlMetadataError::NonUtf8)
+		));
+		assert!(extract_raw_hex(b"abc\n").is_err());
+		assert!(extract_raw_hex(b"zz\n").is_err());
+		assert!(extract_raw_hex(&vec![b'a'; 8 * 1024 * 1024 + 1]).is_err());
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn fetch_rejects_invalid_compression_json_and_program_identity() {
+		let directory = tempfile::tempdir()
+			.unwrap_or_else(|error| panic!("temporary directory failed: {error}"));
+		let program_id = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS";
+		for (index, raw) in [
+			"00".to_owned(),
+			"789cff".to_owned(),
+			compressed_hex(b"not json"),
+		]
+		.into_iter()
+		.enumerate()
+		{
+			let capture = directory.path().join(format!("args-{index}.txt"));
+			let runner = fake_runner(directory.path(), &capture, &raw);
+			let client = ClientOptions {
+				npx: runner.display().to_string(),
+				cluster: "devnet".to_owned(),
+			};
+			assert!(fetch_idl(&client, program_id).is_err());
+		}
+
+		let other = idl("ProgM6JCCvbYkfKqJYHePx4xxSUSqJp7rh8Lyv7nk7S");
+		let source = serde_json::to_vec(&other).unwrap_or_default();
+		let capture = directory.path().join("args-mismatch.txt");
+		let runner = fake_runner(directory.path(), &capture, &compressed_hex(&source));
+		let client = ClientOptions {
+			npx: runner.display().to_string(),
+			cluster: "devnet".to_owned(),
+		};
+		assert!(matches!(
+			fetch_idl(&client, program_id),
+			Err(IdlMetadataError::ProgramMismatch { .. })
+		));
+
+		let oversized = vec![0; 16 * 1024 * 1024 + 1];
+		let capture = directory.path().join("args-oversized.txt");
+		let runner = fake_runner(directory.path(), &capture, &compressed_hex(&oversized));
+		let client = ClientOptions {
+			npx: runner.display().to_string(),
+			cluster: "devnet".to_owned(),
+		};
+		let error = fetch_idl(&client, program_id).expect_err("oversized IDL must fail");
+		assert!(error.to_string().contains("safety limit"));
+	}
+
+	#[test]
+	fn atomic_output_rejects_links_and_writes_regular_files() {
+		let directory = tempfile::tempdir()
+			.unwrap_or_else(|error| panic!("temporary directory failed: {error}"));
+		let output = directory.path().join("nested/output.json");
+		write_atomic(&output, b"first")
+			.unwrap_or_else(|error| panic!("atomic write failed: {error}"));
+		write_atomic(&output, b"second")
+			.unwrap_or_else(|error| panic!("atomic replace failed: {error}"));
+		assert_eq!(std::fs::read(&output).unwrap_or_default(), b"second");
+
+		#[cfg(unix)]
+		{
+			use std::os::unix::fs::symlink;
+
+			let target = directory.path().join("target.json");
+			std::fs::write(&target, b"target")
+				.unwrap_or_else(|error| panic!("target write failed: {error}"));
+			let link = directory.path().join("link.json");
+			symlink(&target, &link).unwrap_or_else(|error| panic!("symlink failed: {error}"));
+			assert!(matches!(
+				write_atomic(&link, b"replacement"),
+				Err(IdlMetadataError::UnsafePath { .. })
+			));
+		}
+	}
+
+	#[cfg(unix)]
+	fn compressed_hex(source: &[u8]) -> String {
+		let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+		encoder.write_all(source).unwrap_or_default();
+		encoder
+			.finish()
+			.unwrap_or_default()
+			.iter()
+			.fold(String::new(), |mut output, byte| {
+				write!(output, "{byte:02x}").unwrap_or_default();
+				output
+			})
+	}
+
+	#[cfg(unix)]
+	fn fake_runner(directory: &Path, capture: &Path, stdout: &str) -> PathBuf {
+		use std::os::unix::fs::PermissionsExt;
+
+		let runner = directory.join("fake-npx.sh");
+		let script = format!(
+			"#!/bin/sh\nprintf '%s\\n' \"$@\" > '{}'\nprintf '{}'\n",
+			capture.display(),
+			stdout.replace('\\', "\\\\").replace('\'', "'\\''")
+		);
+		std::fs::write(&runner, script)
+			.unwrap_or_else(|error| panic!("runner write failed: {error}"));
+		let mut permissions = std::fs::metadata(&runner)
+			.unwrap_or_else(|error| panic!("runner metadata failed: {error}"))
+			.permissions();
+		permissions.set_mode(0o755);
+		std::fs::set_permissions(&runner, permissions)
+			.unwrap_or_else(|error| panic!("runner permissions failed: {error}"));
+
+		runner
+	}
+
+	#[cfg(unix)]
+	fn fake_runner_script(directory: &Path, body: &str) -> PathBuf {
+		use std::os::unix::fs::PermissionsExt;
+
+		let runner = directory.join("fake-script.sh");
+		std::fs::write(&runner, format!("#!/bin/sh\n{body}\n"))
+			.unwrap_or_else(|error| panic!("runner write failed: {error}"));
+		let mut permissions = std::fs::metadata(&runner)
+			.unwrap_or_else(|error| panic!("runner metadata failed: {error}"))
+			.permissions();
+		permissions.set_mode(0o755);
+		std::fs::set_permissions(&runner, permissions)
+			.unwrap_or_else(|error| panic!("runner permissions failed: {error}"));
+
+		runner
+	}
+
+	#[test]
+	fn transaction_export_preserves_official_multi_transaction_framing() {
+		let output = b"Writing metadata account...\nExporting 2 transactions:\n[Transaction #1]\n3mJr7AoUXx2WqdTBLBvMtttP7aB9o8X\n[Transaction #2]\n4SUZkH3cK1vPabJv9RkWmN2CdEfGhL\n";
+		let exported = String::from_utf8(output.to_vec())
+			.unwrap_or_else(|error| panic!("fixture must be UTF-8: {error}"));
+		assert!(exported.contains("[Transaction #1]"));
+		assert!(exported.contains("[Transaction #2]"));
+	}
+}

--- a/crates/pina_cli/src/lib.rs
+++ b/crates/pina_cli/src/lib.rs
@@ -2,6 +2,7 @@ pub mod build;
 pub mod codama;
 pub mod codegen;
 pub mod error;
+pub mod idl_metadata;
 pub mod init;
 pub mod ir;
 pub mod parse;

--- a/crates/pina_cli/src/main.rs
+++ b/crates/pina_cli/src/main.rs
@@ -1,4 +1,5 @@
 mod cli;
+mod idl_command;
 
 use std::fs;
 use std::io::IsTerminal;
@@ -42,13 +43,7 @@ fn main() {
 			output,
 			npx,
 		} => run_generate(project, clients, output, npx),
-		Commands::Idl {
-			path,
-			output,
-			name,
-			compact,
-			pretty: _,
-		} => run_idl(path.as_path(), output.as_deref(), name.as_deref(), !compact),
+		Commands::Idl { command, generate } => idl_command::run_idl_command(command, &generate),
 		Commands::Docs { topic } => run_docs(topic.as_deref()),
 		Commands::Init { name, path, force } => run_init(name.as_str(), path.as_deref(), force),
 		Commands::Profile { path, json, output } => run_profile(&path, json, output.as_deref()),

--- a/crates/pina_cli/tests/cli_snapshots.rs
+++ b/crates/pina_cli/tests/cli_snapshots.rs
@@ -101,6 +101,34 @@ fn idl_help_snapshot() {
 }
 
 #[test]
+fn idl_generate_help_snapshot() {
+	let mut command = Command::new(env!("CARGO_BIN_EXE_pina"));
+	command.args(["idl", "generate", "--help"]);
+	assert_cmd_snapshot!("idl_generate_help", command);
+}
+
+#[test]
+fn idl_fetch_help_snapshot() {
+	let mut command = Command::new(env!("CARGO_BIN_EXE_pina"));
+	command.args(["idl", "fetch", "--help"]);
+	assert_cmd_snapshot!("idl_fetch_help", command);
+}
+
+#[test]
+fn idl_diff_help_snapshot() {
+	let mut command = Command::new(env!("CARGO_BIN_EXE_pina"));
+	command.args(["idl", "diff", "--help"]);
+	assert_cmd_snapshot!("idl_diff_help", command);
+}
+
+#[test]
+fn idl_publish_help_snapshot() {
+	let mut command = Command::new(env!("CARGO_BIN_EXE_pina"));
+	command.args(["idl", "publish", "--help"]);
+	assert_cmd_snapshot!("idl_publish_help", command);
+}
+
+#[test]
 fn docs_help_snapshot() {
 	let mut command = Command::new(env!("CARGO_BIN_EXE_pina"));
 	command.args(["docs", "--help"]);
@@ -238,6 +266,30 @@ fn idl_legacy_pretty_flag_remains_accepted() {
 	assert!(output.status.success());
 	serde_json::from_slice::<serde_json::Value>(&output.stdout)
 		.unwrap_or_else(|error| panic!("IDL stdout was not valid JSON: {error}"));
+}
+
+#[test]
+fn explicit_idl_generate_matches_bare_idl() {
+	let bare = Command::new(env!("CARGO_BIN_EXE_pina"))
+		.current_dir(workspace_root())
+		.args(["idl", "--path", "examples/anchor_declare_id", "--compact"])
+		.output()
+		.unwrap_or_else(|error| panic!("failed to run bare pina idl: {error}"));
+	let explicit = Command::new(env!("CARGO_BIN_EXE_pina"))
+		.current_dir(workspace_root())
+		.args([
+			"idl",
+			"generate",
+			"--path",
+			"examples/anchor_declare_id",
+			"--compact",
+		])
+		.output()
+		.unwrap_or_else(|error| panic!("failed to run pina idl generate: {error}"));
+
+	assert!(bare.status.success());
+	assert!(explicit.status.success());
+	assert_eq!(bare.stdout, explicit.stdout);
 }
 
 #[test]

--- a/crates/pina_cli/tests/idl_metadata_command.rs
+++ b/crates/pina_cli/tests/idl_metadata_command.rs
@@ -1,0 +1,588 @@
+#![cfg(unix)]
+
+use std::fmt::Write as _;
+use std::fs;
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+use std::process::Stdio;
+
+use ed25519_dalek::SigningKey;
+use flate2::Compression;
+use flate2::write::ZlibEncoder;
+use serde_json::Value;
+
+const PROGRAM_ID: &str = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS";
+
+fn workspace_root() -> PathBuf {
+	Path::new(env!("CARGO_MANIFEST_DIR"))
+		.parent()
+		.and_then(Path::parent)
+		.unwrap_or_else(|| Path::new("."))
+		.to_path_buf()
+}
+
+fn fixture_idl() -> Value {
+	let root = pina_cli::generate_idl(&workspace_root().join("examples/anchor_declare_id"), None)
+		.unwrap_or_else(|error| panic!("fixture generation failed: {error}"));
+	serde_json::to_value(root)
+		.unwrap_or_else(|error| panic!("fixture serialization failed: {error}"))
+}
+
+fn write_idl(directory: &Path, value: &Value) -> PathBuf {
+	let path = directory.join("idl.json");
+	fs::write(
+		&path,
+		serde_json::to_vec_pretty(value)
+			.unwrap_or_else(|error| panic!("fixture serialization failed: {error}")),
+	)
+	.unwrap_or_else(|error| panic!("fixture write failed: {error}"));
+	path
+}
+
+fn raw_zlib(value: &Value) -> String {
+	let source = serde_json::to_vec(value)
+		.unwrap_or_else(|error| panic!("fixture serialization failed: {error}"));
+	let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+	encoder
+		.write_all(&source)
+		.unwrap_or_else(|error| panic!("fixture compression failed: {error}"));
+	let compressed = encoder
+		.finish()
+		.unwrap_or_else(|error| panic!("fixture compression finish failed: {error}"));
+
+	compressed.iter().fold(String::new(), |mut output, byte| {
+		write!(output, "{byte:02x}")
+			.unwrap_or_else(|error| panic!("hex formatting failed: {error}"));
+		output
+	})
+}
+
+fn fake_npx(directory: &Path, stdout: &str, status: i32) -> (PathBuf, PathBuf) {
+	let runner = directory.join("fake-npx.sh");
+	let capture = directory.join("args.txt");
+	let escaped_stdout = stdout.replace('\\', "\\\\").replace('\'', "'\\''");
+	let script = format!(
+		"#!/bin/sh\nprintf '%s\\n' \"$@\" > '{}'\nprintf '{}'\nexit {status}\n",
+		capture.display(),
+		escaped_stdout,
+	);
+	fs::write(&runner, script).unwrap_or_else(|error| panic!("fake runner write failed: {error}"));
+	let mut permissions = fs::metadata(&runner)
+		.unwrap_or_else(|error| panic!("fake runner metadata failed: {error}"))
+		.permissions();
+	permissions.set_mode(0o755);
+	fs::set_permissions(&runner, permissions)
+		.unwrap_or_else(|error| panic!("fake runner permissions failed: {error}"));
+
+	(runner, capture)
+}
+
+fn keypair(directory: &Path) -> PathBuf {
+	let path = directory.join("authority.json");
+	let bytes = SigningKey::from_bytes(&[41; 32]).to_keypair_bytes();
+	fs::write(
+		&path,
+		serde_json::to_vec(bytes.as_slice())
+			.unwrap_or_else(|error| panic!("keypair serialization failed: {error}")),
+	)
+	.unwrap_or_else(|error| panic!("keypair write failed: {error}"));
+	let mut permissions = fs::metadata(&path)
+		.unwrap_or_else(|error| panic!("keypair metadata failed: {error}"))
+		.permissions();
+	permissions.set_mode(0o600);
+	fs::set_permissions(&path, permissions)
+		.unwrap_or_else(|error| panic!("keypair permissions failed: {error}"));
+	path
+}
+
+#[test]
+fn fetch_outputs_validated_json_and_uses_the_pinned_raw_client() {
+	let directory =
+		tempfile::tempdir().unwrap_or_else(|error| panic!("temporary directory failed: {error}"));
+	let value = fixture_idl();
+	let (runner, capture) = fake_npx(
+		directory.path(),
+		&format!("Fetching metadata...\n{}", raw_zlib(&value)),
+		0,
+	);
+	let output = Command::new(env!("CARGO_BIN_EXE_pina"))
+		.args([
+			"idl",
+			"fetch",
+			"--cluster",
+			"devnet",
+			"--program-id",
+			PROGRAM_ID,
+			"--npx",
+			runner.to_str().unwrap_or_default(),
+			"--json",
+		])
+		.output()
+		.unwrap_or_else(|error| panic!("fetch command failed to start: {error}"));
+
+	assert!(
+		output.status.success(),
+		"{}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+	let envelope: Value = serde_json::from_slice(&output.stdout)
+		.unwrap_or_else(|error| panic!("fetch JSON failed: {error}"));
+	assert_eq!(envelope["idl"], value);
+	let args =
+		fs::read_to_string(capture).unwrap_or_else(|error| panic!("capture read failed: {error}"));
+	assert!(args.contains("@solana-program/program-metadata@0.9.0"));
+	assert!(args.contains("--raw"));
+}
+
+#[test]
+fn official_client_receives_eof_instead_of_operator_input() {
+	let directory =
+		tempfile::tempdir().unwrap_or_else(|error| panic!("temporary directory failed: {error}"));
+	let value = fixture_idl();
+	let raw = raw_zlib(&value)
+		.replace('\\', "\\\\")
+		.replace('\'', "'\\''");
+	let runner = directory.path().join("stdin-probe.sh");
+	let script = format!(
+		"#!/bin/sh\nif IFS= read -r input; then\n  printf 'client inherited stdin: %s\\n' \
+		 \"$input\" >&2\n  exit 91\nfi\nprintf '{raw}\\n'\n"
+	);
+	fs::write(&runner, script).unwrap_or_else(|error| panic!("stdin probe write failed: {error}"));
+	let mut permissions = fs::metadata(&runner)
+		.unwrap_or_else(|error| panic!("stdin probe metadata failed: {error}"))
+		.permissions();
+	permissions.set_mode(0o755);
+	fs::set_permissions(&runner, permissions)
+		.unwrap_or_else(|error| panic!("stdin probe permissions failed: {error}"));
+
+	let mut child = Command::new(env!("CARGO_BIN_EXE_pina"))
+		.args([
+			"idl",
+			"fetch",
+			"--cluster",
+			"devnet",
+			"--program-id",
+			PROGRAM_ID,
+			"--npx",
+			runner.to_str().unwrap_or_default(),
+		])
+		.stdin(Stdio::piped())
+		.stdout(Stdio::piped())
+		.stderr(Stdio::piped())
+		.spawn()
+		.unwrap_or_else(|error| panic!("fetch command failed to start: {error}"));
+	child
+		.stdin
+		.take()
+		.expect("stdin pipe must exist")
+		.write_all(b"operator input must stay private\n")
+		.unwrap_or_else(|error| panic!("stdin write failed: {error}"));
+	let output = child
+		.wait_with_output()
+		.unwrap_or_else(|error| panic!("fetch command wait failed: {error}"));
+
+	assert!(
+		output.status.success(),
+		"{}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+	let fetched: Value = serde_json::from_slice(&output.stdout)
+		.unwrap_or_else(|error| panic!("fetched IDL failed to parse: {error}"));
+	assert_eq!(fetched, value);
+	assert!(!String::from_utf8_lossy(&output.stderr).contains("operator input"));
+}
+
+#[test]
+fn fetch_supports_plain_stdout_and_atomic_output() {
+	let directory =
+		tempfile::tempdir().unwrap_or_else(|error| panic!("temporary directory failed: {error}"));
+	let value = fixture_idl();
+	let (runner, _) = fake_npx(directory.path(), &raw_zlib(&value), 0);
+	let plain = Command::new(env!("CARGO_BIN_EXE_pina"))
+		.args([
+			"idl",
+			"fetch",
+			"--cluster",
+			"devnet",
+			"--program-id",
+			PROGRAM_ID,
+			"--npx",
+			runner.to_str().unwrap_or_default(),
+		])
+		.output()
+		.unwrap_or_else(|error| panic!("plain fetch failed to start: {error}"));
+	assert!(plain.status.success());
+	let parsed: Value = serde_json::from_slice(&plain.stdout)
+		.unwrap_or_else(|error| panic!("plain IDL failed to parse: {error}"));
+	assert_eq!(parsed, value);
+
+	let output_path = directory.path().join("nested/fetched.json");
+	let written = Command::new(env!("CARGO_BIN_EXE_pina"))
+		.args([
+			"idl",
+			"fetch",
+			"--cluster",
+			"devnet",
+			"--program-id",
+			PROGRAM_ID,
+			"--output",
+			output_path.to_str().unwrap_or_default(),
+			"--npx",
+			runner.to_str().unwrap_or_default(),
+		])
+		.output()
+		.unwrap_or_else(|error| panic!("output fetch failed to start: {error}"));
+	assert!(written.status.success());
+	let parsed: Value = serde_json::from_slice(&fs::read(output_path).unwrap_or_default())
+		.unwrap_or_else(|error| panic!("written IDL failed to parse: {error}"));
+	assert_eq!(parsed, value);
+}
+
+#[test]
+fn fetch_infers_the_program_from_a_generated_project_idl() {
+	let directory =
+		tempfile::tempdir().unwrap_or_else(|error| panic!("temporary directory failed: {error}"));
+	let value = fixture_idl();
+	let (runner, _) = fake_npx(directory.path(), &raw_zlib(&value), 0);
+	let project = workspace_root().join("examples/anchor_declare_id");
+	let output = Command::new(env!("CARGO_BIN_EXE_pina"))
+		.args([
+			"idl",
+			"fetch",
+			"--cluster",
+			"devnet",
+			"--project",
+			project.to_str().unwrap_or_default(),
+			"--npx",
+			runner.to_str().unwrap_or_default(),
+		])
+		.output()
+		.unwrap_or_else(|error| panic!("inferred fetch failed to start: {error}"));
+	assert!(
+		output.status.success(),
+		"{}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+}
+
+#[test]
+fn semantic_diff_has_distinct_equal_and_different_statuses() {
+	let directory =
+		tempfile::tempdir().unwrap_or_else(|error| panic!("temporary directory failed: {error}"));
+	let value = fixture_idl();
+	let local = write_idl(directory.path(), &value);
+	let (equal_runner, _) = fake_npx(directory.path(), &raw_zlib(&value), 0);
+	let equal = Command::new(env!("CARGO_BIN_EXE_pina"))
+		.args([
+			"idl",
+			"diff",
+			"--cluster",
+			"devnet",
+			"--program-id",
+			PROGRAM_ID,
+			"--file",
+			local.to_str().unwrap_or_default(),
+			"--npx",
+			equal_runner.to_str().unwrap_or_default(),
+		])
+		.output()
+		.unwrap_or_else(|error| panic!("equal diff failed to start: {error}"));
+	assert_eq!(equal.status.code(), Some(0));
+
+	let mut changed = value.clone();
+	changed["program"]["version"] = Value::String("99.0.0".to_owned());
+	let (different_runner, _) = fake_npx(directory.path(), &raw_zlib(&changed), 0);
+	let different = Command::new(env!("CARGO_BIN_EXE_pina"))
+		.args([
+			"idl",
+			"diff",
+			"--cluster",
+			"devnet",
+			"--program-id",
+			PROGRAM_ID,
+			"--file",
+			local.to_str().unwrap_or_default(),
+			"--npx",
+			different_runner.to_str().unwrap_or_default(),
+			"--json",
+		])
+		.output()
+		.unwrap_or_else(|error| panic!("different diff failed to start: {error}"));
+	assert_eq!(different.status.code(), Some(2));
+	let report: Value = serde_json::from_slice(&different.stdout)
+		.unwrap_or_else(|error| panic!("diff JSON failed: {error}"));
+	assert_eq!(report["equal"], false);
+}
+
+#[test]
+fn publish_export_preserves_all_framing_and_never_submits() {
+	let directory =
+		tempfile::tempdir().unwrap_or_else(|error| panic!("temporary directory failed: {error}"));
+	let local = write_idl(directory.path(), &fixture_idl());
+	let framed = "Exporting 2 transactions:\n[Transaction #1]\nAAAA\n[Transaction #2]\nBBBB";
+	let (runner, capture) = fake_npx(directory.path(), framed, 0);
+	let output = Command::new(env!("CARGO_BIN_EXE_pina"))
+		.args([
+			"idl",
+			"publish",
+			"--cluster",
+			"mainnet-beta",
+			"--program-id",
+			PROGRAM_ID,
+			"--file",
+			local.to_str().unwrap_or_default(),
+			"--export",
+			"ProgM6JCCvbYkfKqJYHePx4xxSUSqJp7rh8Lyv7nk7S",
+			"--npx",
+			runner.to_str().unwrap_or_default(),
+		])
+		.output()
+		.unwrap_or_else(|error| panic!("export failed to start: {error}"));
+
+	assert!(
+		output.status.success(),
+		"{}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+	assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), framed);
+	let args =
+		fs::read_to_string(capture).unwrap_or_else(|error| panic!("capture read failed: {error}"));
+	assert!(args.contains("--export\nProgM6JCCvbYkfKqJYHePx4xxSUSqJp7rh8Lyv7nk7S"));
+	assert!(!args.contains("--keypair"));
+}
+
+#[test]
+fn bare_export_uses_a_local_authority_and_writes_every_transaction() {
+	let directory =
+		tempfile::tempdir().unwrap_or_else(|error| panic!("temporary directory failed: {error}"));
+	let local = write_idl(directory.path(), &fixture_idl());
+	let authority = keypair(directory.path());
+	let framed = "Exporting 2 transactions:\n[Transaction #1]\nAAAA\n[Transaction #2]\nBBBB\n";
+	let (runner, capture) = fake_npx(directory.path(), framed, 0);
+	let export_path = directory.path().join("plans/all.txt");
+	let output = Command::new(env!("CARGO_BIN_EXE_pina"))
+		.args([
+			"idl",
+			"publish",
+			"--cluster",
+			"mainnet-beta",
+			"--file",
+			local.to_str().unwrap_or_default(),
+			"--authority",
+			authority.to_str().unwrap_or_default(),
+			"--export",
+			"--export-encoding",
+			"base58",
+			"--output",
+			export_path.to_str().unwrap_or_default(),
+			"--npx",
+			runner.to_str().unwrap_or_default(),
+		])
+		.output()
+		.unwrap_or_else(|error| panic!("local export failed to start: {error}"));
+
+	assert!(
+		output.status.success(),
+		"{}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+	assert!(output.stdout.is_empty());
+	assert_eq!(fs::read_to_string(export_path).unwrap_or_default(), framed);
+	let args = fs::read_to_string(capture).unwrap_or_default();
+	assert!(args.contains("--keypair"));
+	assert!(args.contains("--export\n--export-encoding\nbase58"));
+}
+
+#[test]
+fn direct_publish_requires_confirmation_before_starting_the_client() {
+	let directory =
+		tempfile::tempdir().unwrap_or_else(|error| panic!("temporary directory failed: {error}"));
+	let local = write_idl(directory.path(), &fixture_idl());
+	let authority = keypair(directory.path());
+	let (runner, capture) = fake_npx(directory.path(), "must not run", 0);
+	let output = Command::new(env!("CARGO_BIN_EXE_pina"))
+		.args([
+			"idl",
+			"publish",
+			"--cluster",
+			"mainnet-beta",
+			"--file",
+			local.to_str().unwrap_or_default(),
+			"--authority",
+			authority.to_str().unwrap_or_default(),
+			"--npx",
+			runner.to_str().unwrap_or_default(),
+		])
+		.output()
+		.unwrap_or_else(|error| panic!("publish failed to start: {error}"));
+
+	assert_eq!(output.status.code(), Some(1));
+	assert!(String::from_utf8_lossy(&output.stderr).contains("requires confirmation"));
+	assert!(!capture.exists());
+}
+
+#[test]
+fn confirmed_publish_returns_a_machine_readable_result() {
+	let directory =
+		tempfile::tempdir().unwrap_or_else(|error| panic!("temporary directory failed: {error}"));
+	let local = write_idl(directory.path(), &fixture_idl());
+	let authority = keypair(directory.path());
+	let (runner, _) = fake_npx(directory.path(), "published", 0);
+	let output = Command::new(env!("CARGO_BIN_EXE_pina"))
+		.args([
+			"idl",
+			"publish",
+			"--cluster",
+			"devnet",
+			"--file",
+			local.to_str().unwrap_or_default(),
+			"--authority",
+			authority.to_str().unwrap_or_default(),
+			"--npx",
+			runner.to_str().unwrap_or_default(),
+			"--yes",
+			"--json",
+		])
+		.output()
+		.unwrap_or_else(|error| panic!("publish failed to start: {error}"));
+
+	assert!(
+		output.status.success(),
+		"{}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+	let result: Value = serde_json::from_slice(&output.stdout)
+		.unwrap_or_else(|error| panic!("publish JSON failed: {error}"));
+	assert_eq!(result["status"], "published");
+}
+
+#[test]
+fn confirmed_publish_supports_text_and_redacts_custom_rpc_output() {
+	let directory =
+		tempfile::tempdir().unwrap_or_else(|error| panic!("temporary directory failed: {error}"));
+	let local = write_idl(directory.path(), &fixture_idl());
+	let authority = keypair(directory.path());
+	let (runner, _) = fake_npx(directory.path(), "published", 0);
+	let text = Command::new(env!("CARGO_BIN_EXE_pina"))
+		.args([
+			"idl",
+			"publish",
+			"--cluster",
+			"https://rpc.example.test:9443",
+			"--file",
+			local.to_str().unwrap_or_default(),
+			"--authority",
+			authority.to_str().unwrap_or_default(),
+			"--npx",
+			runner.to_str().unwrap_or_default(),
+			"--yes",
+		])
+		.output()
+		.unwrap_or_else(|error| panic!("text publish failed to start: {error}"));
+	assert!(text.status.success());
+	assert!(String::from_utf8_lossy(&text.stdout).contains("Published the canonical IDL"));
+}
+
+#[test]
+fn confirmed_publish_can_generate_the_project_idl_in_memory() {
+	let directory =
+		tempfile::tempdir().unwrap_or_else(|error| panic!("temporary directory failed: {error}"));
+	let authority = keypair(directory.path());
+	let (runner, _) = fake_npx(directory.path(), "published", 0);
+	let project = workspace_root().join("examples/anchor_declare_id");
+	let output = Command::new(env!("CARGO_BIN_EXE_pina"))
+		.args([
+			"idl",
+			"publish",
+			"--cluster",
+			"devnet",
+			"--project",
+			project.to_str().unwrap_or_default(),
+			"--authority",
+			authority.to_str().unwrap_or_default(),
+			"--npx",
+			runner.to_str().unwrap_or_default(),
+			"--yes",
+		])
+		.output()
+		.unwrap_or_else(|error| panic!("generated publish failed to start: {error}"));
+	assert!(
+		output.status.success(),
+		"{}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+}
+
+#[test]
+fn publish_rejects_incompatible_authority_modes_before_spawning() {
+	let directory =
+		tempfile::tempdir().unwrap_or_else(|error| panic!("temporary directory failed: {error}"));
+	let local = write_idl(directory.path(), &fixture_idl());
+	let authority = keypair(directory.path());
+	let (runner, capture) = fake_npx(directory.path(), "must not run", 0);
+	let multisig = "ProgM6JCCvbYkfKqJYHePx4xxSUSqJp7rh8Lyv7nk7S";
+
+	for extra in [
+		vec![
+			"--export",
+			multisig,
+			"--authority",
+			authority.to_str().unwrap_or_default(),
+		],
+		vec![
+			"--export",
+			multisig,
+			"--authority",
+			authority.to_str().unwrap_or_default(),
+			"--payer",
+			authority.to_str().unwrap_or_default(),
+		],
+		vec!["--export"],
+		Vec::new(),
+	] {
+		let mut args = vec![
+			"idl",
+			"publish",
+			"--cluster",
+			"devnet",
+			"--file",
+			local.to_str().unwrap_or_default(),
+			"--npx",
+			runner.to_str().unwrap_or_default(),
+		];
+		args.extend(extra);
+		let output = Command::new(env!("CARGO_BIN_EXE_pina"))
+			.args(args)
+			.output()
+			.unwrap_or_else(|error| panic!("invalid publish failed to start: {error}"));
+		assert_eq!(output.status.code(), Some(1));
+	}
+	assert!(!capture.exists());
+}
+
+#[test]
+fn official_client_errors_have_status_one() {
+	let directory =
+		tempfile::tempdir().unwrap_or_else(|error| panic!("temporary directory failed: {error}"));
+	let local = write_idl(directory.path(), &fixture_idl());
+	let (runner, _) = fake_npx(directory.path(), "failure", 9);
+	let output = Command::new(env!("CARGO_BIN_EXE_pina"))
+		.args([
+			"idl",
+			"diff",
+			"--cluster",
+			"devnet",
+			"--file",
+			local.to_str().unwrap_or_default(),
+			"--npx",
+			runner.to_str().unwrap_or_default(),
+		])
+		.output()
+		.unwrap_or_else(|error| panic!("failing diff failed to start: {error}"));
+
+	assert_eq!(output.status.code(), Some(1));
+	assert!(String::from_utf8_lossy(&output.stderr).contains("status 9"));
+}

--- a/crates/pina_cli/tests/idl_metadata_windows.rs
+++ b/crates/pina_cli/tests/idl_metadata_windows.rs
@@ -1,0 +1,78 @@
+#![cfg(windows)]
+
+use std::fmt::Write as _;
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+
+use flate2::Compression;
+use flate2::write::ZlibEncoder;
+
+const PROGRAM_ID: &str = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS";
+
+fn workspace_root() -> PathBuf {
+	Path::new(env!("CARGO_MANIFEST_DIR"))
+		.parent()
+		.and_then(Path::parent)
+		.unwrap_or_else(|| Path::new("."))
+		.to_path_buf()
+}
+
+#[test]
+fn npx_cmd_receives_the_exact_pinned_raw_fetch_arguments() {
+	let directory =
+		tempfile::tempdir().unwrap_or_else(|error| panic!("temporary directory failed: {error}"));
+	let root = pina_cli::generate_idl(&workspace_root().join("examples/anchor_declare_id"), None)
+		.unwrap_or_else(|error| panic!("fixture generation failed: {error}"));
+	let source = serde_json::to_vec(&root)
+		.unwrap_or_else(|error| panic!("fixture serialization failed: {error}"));
+	let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+	encoder
+		.write_all(&source)
+		.unwrap_or_else(|error| panic!("fixture compression failed: {error}"));
+	let hex = encoder
+		.finish()
+		.unwrap_or_else(|error| panic!("fixture compression finish failed: {error}"))
+		.iter()
+		.fold(String::new(), |mut output, byte| {
+			write!(output, "{byte:02x}")
+				.unwrap_or_else(|error| panic!("hex formatting failed: {error}"));
+			output
+		});
+	let runner = directory.path().join("fake npx.cmd");
+	let capture = directory.path().join("args.txt");
+	fs::write(
+		&runner,
+		format!(
+			"@echo off\r\necho %* > \"{}\"\r\necho {hex}\r\n",
+			capture.display()
+		),
+	)
+	.unwrap_or_else(|error| panic!("runner write failed: {error}"));
+
+	let output = Command::new(env!("CARGO_BIN_EXE_pina"))
+		.args([
+			"idl",
+			"fetch",
+			"--cluster",
+			"devnet",
+			"--program-id",
+			PROGRAM_ID,
+			"--npx",
+			runner.to_str().unwrap_or_default(),
+		])
+		.output()
+		.unwrap_or_else(|error| panic!("fetch failed to start: {error}"));
+	assert!(
+		output.status.success(),
+		"{}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+	let args =
+		fs::read_to_string(capture).unwrap_or_else(|error| panic!("capture read failed: {error}"));
+	assert!(args.contains("@solana-program/program-metadata@0.9.0"));
+	assert!(args.contains("fetch idl"));
+	assert!(args.contains("--raw"));
+}

--- a/crates/pina_cli/tests/snapshots/cli_snapshots__idl_diff_help.snap
+++ b/crates/pina_cli/tests/snapshots/cli_snapshots__idl_diff_help.snap
@@ -1,0 +1,40 @@
+---
+source: crates/pina_cli/tests/cli_snapshots.rs
+info:
+  program: pina
+  args:
+    - idl
+    - diff
+    - "--help"
+---
+success: true
+exit_code: 0
+----- stdout -----
+Compare a local IDL with canonical on-chain metadata
+
+Usage: pina idl diff [OPTIONS] --cluster <CLUSTER>
+
+Options:
+      --cluster <CLUSTER>
+          Solana cluster moniker or HTTP(S) RPC URL. This is always explicit
+      --program-id <ADDRESS>
+          Deployed program address. Inferred from the local IDL when omitted
+  -p, --project <DIR>
+          Directory inside the local project used for IDL generation and discovery
+      --file <FILE>
+          Compare FILE instead of generating the local project IDL
+      --json
+          Emit a machine-readable comparison result
+      --npx <COMMAND>
+          npx-compatible runner for the pinned official package. May download version 0.9.0
+  -h, --help
+          Print help
+
+Examples:
+  pina idl diff --cluster devnet --program-id <ADDRESS>
+  pina idl diff --cluster mainnet-beta --file ./target/idl/program.json --program-id <ADDRESS> --json
+
+Comparison:
+  JSON object key order and whitespace are ignored. A difference exits with status 2, making the command useful in CI.
+
+----- stderr -----

--- a/crates/pina_cli/tests/snapshots/cli_snapshots__idl_fetch_help.snap
+++ b/crates/pina_cli/tests/snapshots/cli_snapshots__idl_fetch_help.snap
@@ -1,0 +1,40 @@
+---
+source: crates/pina_cli/tests/cli_snapshots.rs
+info:
+  program: pina
+  args:
+    - idl
+    - fetch
+    - "--help"
+---
+success: true
+exit_code: 0
+----- stdout -----
+Fetch a direct zlib/UTF-8 canonical on-chain IDL for a deployed program
+
+Usage: pina idl fetch [OPTIONS] --cluster <CLUSTER>
+
+Options:
+      --cluster <CLUSTER>
+          Solana cluster moniker or HTTP(S) RPC URL. This is always explicit
+      --program-id <ADDRESS>
+          Deployed program address. Inferred from the local IDL when omitted
+  -p, --project <DIR>
+          Directory inside the local project used for program ID inference
+  -o, --output <FILE>
+          Write the fetched IDL to FILE instead of stdout
+      --json
+          Emit a machine-readable result envelope
+      --npx <COMMAND>
+          npx-compatible runner for the pinned official package. May download version 0.9.0
+  -h, --help
+          Print help
+
+Examples:
+  pina idl fetch --cluster devnet --program-id <ADDRESS>
+  pina idl fetch --cluster mainnet-beta --program-id <ADDRESS> --output ./idl.json
+
+Requirements:
+  Uses the pinned official @solana-program/program-metadata package through npx. The canonical metadata seed is always 'idl'. URL, external-account, and other encoding formats fail closed in this initial workflow.
+
+----- stderr -----

--- a/crates/pina_cli/tests/snapshots/cli_snapshots__idl_generate_help.snap
+++ b/crates/pina_cli/tests/snapshots/cli_snapshots__idl_generate_help.snap
@@ -1,0 +1,36 @@
+---
+source: crates/pina_cli/tests/cli_snapshots.rs
+info:
+  program: pina
+  args:
+    - idl
+    - generate
+    - "--help"
+---
+success: true
+exit_code: 0
+----- stdout -----
+Generate a Codama IDL from local Pina source
+
+Usage: pina idl generate [OPTIONS]
+
+Options:
+  -p, --path <DIR>
+          Program crate directory containing Cargo.toml and src/lib.rs. Defaults to the current directory
+  -o, --output <FILE>
+          Write the JSON document to FILE instead of stdout
+  -n, --name <NAME>
+          Override the program name inferred from Cargo.toml
+      --compact
+          Emit compact JSON instead of the default pretty-printed JSON
+  -h, --help
+          Print help
+
+Examples:
+  pina idl generate
+  pina idl generate --path ./programs/counter --output ./target/idl/counter.json
+
+Compatibility:
+  Bare 'pina idl [OPTIONS]' remains equivalent to this command.
+
+----- stderr -----

--- a/crates/pina_cli/tests/snapshots/cli_snapshots__idl_help.snap
+++ b/crates/pina_cli/tests/snapshots/cli_snapshots__idl_help.snap
@@ -9,11 +9,23 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-Generate a Codama IDL from a Pina program crate.
+Generate, inspect, and publish canonical Codama IDLs.
 
-Parses the crate rooted at PATH, follows Rust modules from src/lib.rs, and emits a Codama root-node JSON document. JSON is written to stdout unless OUTPUT is supplied; progress and the extraction summary are written to stderr.
+Bare invocation preserves local generation: it parses PATH and emits a Codama root-node JSON document. The generate subcommand spells that action explicitly. Fetch, diff, and publish manage canonical `idl` metadata for a deployed program through the pinned official Program Metadata client.
 
-Usage: pina idl [OPTIONS]
+Usage: pina idl [OPTIONS] [COMMAND]
+
+Commands:
+  generate
+          Generate a Codama IDL from local Pina source
+  fetch
+          Fetch a direct zlib/UTF-8 canonical on-chain IDL for a deployed program
+  diff
+          Compare a local IDL with canonical on-chain metadata
+  publish
+          Create or update the canonical on-chain IDL metadata account
+  help
+          Print this message or the help of the given subcommand(s)
 
 Options:
   -p, --path <DIR>

--- a/crates/pina_cli/tests/snapshots/cli_snapshots__idl_publish_help.snap
+++ b/crates/pina_cli/tests/snapshots/cli_snapshots__idl_publish_help.snap
@@ -1,0 +1,55 @@
+---
+source: crates/pina_cli/tests/cli_snapshots.rs
+info:
+  program: pina
+  args:
+    - idl
+    - publish
+    - "--help"
+---
+success: true
+exit_code: 0
+----- stdout -----
+Create or update the canonical on-chain IDL metadata account
+
+Usage: pina idl publish [OPTIONS] --cluster <CLUSTER>
+
+Options:
+      --cluster <CLUSTER>
+          Solana cluster moniker or HTTP(S) RPC URL. This is always explicit
+      --program-id <ADDRESS>
+          Deployed program address. Inferred from the local IDL when omitted
+  -p, --project <DIR>
+          Directory inside the local project used for IDL generation and discovery
+      --file <FILE>
+          Publish FILE instead of generating the local project IDL
+      --authority <KEYPAIR>
+          Upgrade-authority keypair for direct publication
+      --payer <KEYPAIR>
+          Fee and rent payer keypair. Defaults to --authority
+      --export [<ADDRESS>]
+          Export every planned transaction instead of submitting. Optionally use ADDRESS as a noop multisig authority
+  -o, --output <FILE>
+          Write every exported transaction to FILE instead of stdout
+      --export-encoding <EXPORT_ENCODING>
+          Encoding for an exported multisig transaction [default: base64] [possible values: base58, base64]
+      --yes
+          Skip the interactive publication confirmation
+      --json
+          Emit a machine-readable result envelope
+      --priority-fee <MICROLAMPORTS>
+          Priority fee in micro-lamports per compute unit [default: 100000]
+      --npx <COMMAND>
+          npx-compatible runner for the pinned official package. May download version 0.9.0
+  -h, --help
+          Print help
+
+Examples:
+  pina idl publish --cluster devnet --authority ~/.config/solana/id.json --yes
+  pina idl publish --cluster mainnet-beta --program-id <ADDRESS> --file ./idl.json --authority ./upgrade-authority.json --export --output ./idl-plan.txt
+  pina idl publish --cluster mainnet-beta --program-id <ADDRESS> --file ./idl.json --export <MULTISIG> --output ./idl-update.txt
+
+Safety:
+  Publication is canonical, uses compressed inline JSON under the fixed 'idl' seed, and requires explicit confirmation. --export plans every required transaction without submitting any. An optional --export authority supports multisigs.
+
+----- stderr -----

--- a/crates/pina_cli/tests/snapshots/cli_snapshots__root_help.snap
+++ b/crates/pina_cli/tests/snapshots/cli_snapshots__root_help.snap
@@ -20,7 +20,7 @@ Commands:
   generate
           Generate configured clients for the current Pina program
   idl
-          Generate a Codama IDL from a Pina program crate
+          Generate, inspect, and publish canonical Codama IDLs
   docs
           Read bundled Pina reference documentation in the terminal
   init

--- a/docs/src/cli/idl.md
+++ b/docs/src/cli/idl.md
@@ -1,12 +1,20 @@
-# `pina idl`
+# Generate and publish IDLs
 
-Parse a Pina program crate and emit a Codama root-node JSON document.
+`pina idl` owns the complete IDL lifecycle without adding another top-level command: generate a Codama document, compare it with canonical Program Metadata, fetch it, or publish an update.
 
 ## Synopsis
 
 ```text
 pina idl [OPTIONS]
+pina idl generate [OPTIONS]
+pina idl fetch --cluster <CLUSTER> [OPTIONS]
+pina idl diff --cluster <CLUSTER> [OPTIONS]
+pina idl publish --cluster <CLUSTER> [OPTIONS]
 ```
+
+Bare `pina idl [OPTIONS]` remains exactly equivalent to `pina idl generate [OPTIONS]`. Existing scripts do not need to change.
+
+## Generate a local IDL
 
 | Option                | Default            | Meaning                                                 |
 | --------------------- | ------------------ | ------------------------------------------------------- |
@@ -64,3 +72,130 @@ pina idl -p ./programs/counter_program --name counter_v2
 The command exits unsuccessfully when the path is not a readable program crate, `[package].name` is absent, modules cannot be resolved, more than one source file defines `process_instruction`, declarations conflict, PDA attributes or validation links cannot be resolved, a supported schema cannot be represented safely, or JSON/output-file writing fails. Diagnostics include source or path context where available. These checks are fail-closed: the CLI does not silently omit malformed PDA metadata or choose one of several entrypoint dispatch sources.
 
 For complete client generation, continue with [`pina codama generate`](./codama-generate.md).
+
+## Canonical Program Metadata
+
+Pina publishes an IDL to Solana's [Program Metadata program](https://github.com/solana-program/program-metadata) with these fixed semantics:
+
+- seed: `idl`;
+- account type: canonical metadata;
+- authority: the deployed program's upgrade authority;
+- source: direct, inline account data;
+- encoding: UTF-8;
+- compression: zlib;
+- format: JSON.
+
+The canonical PDA is derived from the program address and the fixed `idl` seed. This gives each program one authoritative IDL. Pina does not expose third-party metadata, custom seeds, URL data, external-account data, immutability, or account closure in this initial workflow.
+
+The adapter delegates transaction planning to the exact official npm package `@solana-program/program-metadata@0.9.0`. The behavior was cross-checked against upstream commit `33eb527e124cc4a09d8aae448cd306a9bd87db14`. Pina does not duplicate the upstream allocation, reallocation, buffer, rent, or transaction-packing rules.
+
+### Runtime requirement
+
+Network IDL commands require Node.js, npm, and an npx-compatible runner. By default Pina executes:
+
+```text
+npx --yes @solana-program/program-metadata@0.9.0 ...
+```
+
+The package version is pinned, never `latest`. `npx` may download that pinned package if it is not already cached. Use `--npx <COMMAND>` only for a runner that accepts the same npx argument contract; it is not an arbitrary shell command. Pina constructs an argument vector and never invokes a shell.
+
+Client stdout and stderr are drained concurrently into bounded buffers. Oversized output fails explicitly; Pina never truncates a transaction export and presents it as a valid plan.
+
+## Clusters and RPC safety
+
+Every network operation requires `--cluster`. Accepted aliases are `mainnet-beta`, `mainnet`, `devnet`, `testnet`, `localnet`, and `localhost`. An HTTPS RPC origin may also be supplied. Loopback HTTP is accepted for local testing; remote plaintext HTTP is rejected.
+
+Custom RPC URLs may not contain user information, query parameters, fragments, or a path. This is intentional: RPC API credentials placed in a URL would otherwise be exposed to the child process argument list. Configure an authenticated local proxy and pass its credential-free origin when a provider requires secrets.
+
+## Fetch
+
+```bash
+pina idl fetch \
+  --cluster mainnet-beta \
+  --program-id <PROGRAM_ADDRESS> \
+  --output ./target/fetched/program.json
+```
+
+`--program-id` may be omitted inside a discoverable Pina project. Pina then generates the local IDL only to infer `program.publicKey`.
+
+Fetch is deliberately fail-closed. Pina asks the official client for the raw stored bytes, then locally applies a bounded zlib decode, UTF-8/JSON parsing, complete Codama root-node deserialization, and target-program comparison. It does not follow URL or external-account metadata. Accounts using another otherwise-valid Program Metadata representation produce an actionable unsupported-content error instead of triggering an unexpected outbound request.
+
+The decompressed IDL is capped at 16 MiB. `--output` is written atomically. Without it, stdout is the IDL JSON. `--json` wraps the document in a versioned result envelope for agents.
+
+## Semantic diff
+
+```bash
+pina idl diff --cluster devnet
+
+pina idl diff \
+  --cluster mainnet-beta \
+  --program-id <PROGRAM_ADDRESS> \
+  --file ./target/idl/program.json \
+  --json
+```
+
+The comparison parses both documents as JSON. Object key order and whitespace do not matter; array order does. Exit statuses are:
+
+| Status | Meaning                                                    |
+| ------ | ---------------------------------------------------------- |
+| `0`    | Local and canonical on-chain IDLs are semantically equal.  |
+| `1`    | Discovery, validation, RPC, decoding, or subprocess error. |
+| `2`    | Both IDLs are valid, but their semantic values differ.     |
+
+This makes `pina idl diff --cluster <CLUSTER> --json` suitable for deployment and release checks.
+
+## Publish directly
+
+```bash
+pina idl publish \
+  --cluster devnet \
+  --authority ~/.config/solana/upgrade-authority.json
+```
+
+Pina generates the project IDL unless `--file` is supplied. If `--program-id` is also supplied, it must equal `program.publicKey` inside that complete Codama document. Pina cryptographically checks that a keypair file's public half matches its Ed25519 secret half, then gives the official client a stable private temporary copy so replacing the original path cannot change the signer after validation. Files larger than 4 KiB are rejected; on Unix, group or other permissions are also rejected and temporary copies use a `0700` directory with a `0600` file. Windows copies inherit the current user's protected temporary-directory ACL; Windows keypair validation does not attempt to interpret arbitrary source-file ACLs. Key material is never printed.
+
+`--payer <KEYPAIR>` separates transaction fees and metadata-account rent from the upgrade authority. When omitted, the authority also pays. `--priority-fee <MICROLAMPORTS>` defaults to `100000`, matching the official client.
+
+Interactive publication prints the cluster, program, and local IDL source, then requires the exact word `publish`. In CI, pass `--yes`. Export mode never submits and therefore does not require this confirmation.
+
+The Program Metadata account must remain rent-exempt. Creation funds its 96-byte header and packed IDL content. Updates may transfer additional rent, extend the account in bounded steps, write through temporary buffers when a transaction cannot hold the content, trim unused bytes, and close temporary buffers. Those decisions belong to the pinned official planner.
+
+## Export for review or a multisig
+
+Export every planned transaction without submitting anything:
+
+```bash
+pina idl publish \
+  --cluster mainnet-beta \
+  --authority ./upgrade-authority.json \
+  --export \
+  --output ./idl-plan.txt
+```
+
+For a Squads vault or another multisig, provide its public address instead of a secret keypair:
+
+```bash
+pina idl publish \
+  --cluster mainnet-beta \
+  --program-id <PROGRAM_ADDRESS> \
+  --file ./target/idl/program.json \
+  --export <MULTISIG_AUTHORITY> \
+  --export-encoding base58 \
+  --output ./idl-update.txt
+```
+
+An exported authority is a noop signer used only to plan the transaction messages. Do not pass `--authority` or `--payer` with `--export <ADDRESS>`; the multisig must authorize and pay when it imports the plan. The export contains every transaction in the upstream order, including allocation, buffer, write, initialization/update, trim, and cleanup transactions where required. Pina preserves the official `[Transaction #N]` framing rather than pretending the workflow is one transaction.
+
+The default export encoding is base64. Use base58 when the receiving multisig requires it. Without `--output`, the complete export is written to stdout and Pina writes no status text there.
+
+Exported transactions contain a recent blockhash. If approval takes too long, regenerate the export; do not submit a partially approved subset from an old plan.
+
+## Failure recovery
+
+- **The authority is rejected:** verify the deployed program is upgradeable and the supplied signer is its current upgrade authority. Pina never falls back to non-canonical metadata.
+- **The process stops during a multi-transaction write:** rerun `pina idl diff` first. If it differs, rerun the same publish command. The official planner inspects current state and creates an update plan; do not manually guess which write transaction was last confirmed.
+- **An exported blockhash expires:** discard the complete export and regenerate it.
+- **A buffer transaction succeeds but a later transaction fails:** retain logs and rerun publication. The upstream planner owns buffer lifecycle and recovery behavior.
+- **Fetch reports unsupported content:** the canonical account is not direct zlib/UTF-8 JSON. Use the official Program Metadata tooling to inspect it. Pina will not follow its URL or external account.
+- **IDL program mismatch:** regenerate from the correct program or pass the correct target. Never publish by editing only `program.publicKey` to bypass the check.
+- **npx fails:** confirm Node.js and npm are installed and that the pinned package can be resolved. Corporate/offline environments should pre-cache version `0.9.0` or supply an npx-compatible runner.

--- a/packages/pina__skill/references/cli-and-codegen.md
+++ b/packages/pina__skill/references/cli-and-codegen.md
@@ -9,6 +9,10 @@ pina --help
 pina build --help
 pina generate --help
 pina idl --help
+pina idl generate --help
+pina idl fetch --help
+pina idl diff --help
+pina idl publish --help
 pina docs --help
 pina init --help
 pina profile --help
@@ -57,10 +61,11 @@ The successful command prints the canonical `target/deploy` artifact, the genera
 
 ## IDL extraction
 
-Generate a Codama root-node document from a program crate:
+Generate a Codama root-node document from a program crate. Bare invocation remains compatible; `generate` makes the operation explicit:
 
 ```sh
 pina idl --path ./programs/counter_program --output ./idls/counter_program.json
+pina idl generate --path ./programs/counter_program --output ./idls/counter_program.json
 ```
 
 Without `--output`, JSON is the only stdout content; progress and extraction counts go to stderr. This makes the command safe in pipelines:
@@ -70,6 +75,33 @@ pina idl --path ./programs/counter_program --compact | jq -e '.program'
 ```
 
 Treat the IDL as a public contract. Review instruction, account, PDA, error, and type changes rather than accepting generated churn wholesale.
+
+## Canonical on-chain IDLs
+
+Network IDL operations always require an explicit cluster. Fetch the canonical direct, zlib-compressed UTF-8 Codama IDL under the fixed `idl` seed:
+
+```sh
+pina idl fetch --cluster devnet --program-id <PROGRAM_ADDRESS> --output ./idl.json
+pina idl diff --cluster devnet --program-id <PROGRAM_ADDRESS> --file ./idl.json
+```
+
+`diff` compares parsed JSON: object order and whitespace are ignored, but array order is preserved. Exit status `0` means equal, `2` means different, and `1` means the command failed.
+
+Direct publication requires the canonical upgrade-authority keypair and explicit confirmation (`--yes` in automation):
+
+```sh
+pina idl publish --cluster devnet --file ./idl.json \
+  --authority ~/.config/solana/upgrade-authority.json --yes
+```
+
+For review, multisig, or DAO signing, export every transaction the official planner requires without submitting any:
+
+```sh
+pina idl publish --cluster mainnet-beta --file ./idl.json \
+  --export <MULTISIG_ADDRESS> --output ./idl-plan.txt
+```
+
+Do not describe an export as one transaction. Preserve the complete upstream `[Transaction #N]` framing and order. An exported authority is a noop signer; do not combine `--export <ADDRESS>` with local authority or payer keypairs.
 
 ## Repository-wide client generation
 

--- a/templates/pina-idl.t.md
+++ b/templates/pina-idl.t.md
@@ -175,6 +175,41 @@ That last count-parity check is important because it catches silent extraction r
 
 <!-- {/pinaIdlVerificationContract} -->
 
+<!-- {@pinaIdlProgramMetadata} -->
+
+## Canonical on-chain IDLs
+
+The existing `pina idl` generation command also provides explicit lifecycle subcommands:
+
+```text
+pina idl generate
+pina idl fetch --cluster <CLUSTER> [--program-id <ADDRESS>]
+pina idl diff --cluster <CLUSTER> [--program-id <ADDRESS>]
+pina idl publish --cluster <CLUSTER> --authority <KEYPAIR>
+```
+
+Bare `pina idl [OPTIONS]` is unchanged and remains equivalent to `pina idl generate [OPTIONS]`.
+
+Publication uses the canonical `idl` seed with direct zlib-compressed UTF-8 JSON. Pina validates the complete Codama document and requires its `program.publicKey` to match the target. Network commands always require an explicit cluster.
+
+The transaction planner is the pinned official package `@solana-program/program-metadata@0.9.0`, invoked through an npx-compatible runner without a shell. `npx` may download that exact version when it is not cached. The adapter was cross-checked against upstream commit `33eb527e124cc4a09d8aae448cd306a9bd87db14`.
+
+Use export mode to inspect or multisig-sign every planned transaction without submitting:
+
+```text
+pina idl publish --cluster mainnet-beta --authority ./authority.json --export
+pina idl publish --cluster mainnet-beta --file ./idl.json \
+  --export <MULTISIG_AUTHORITY> --export-encoding base58 --output ./idl-plan.txt
+```
+
+The output preserves every `[Transaction #N]` block from the official planner. An export authority is a noop signer; it does not require or accept a local authority/payer secret.
+
+Fetch uses raw mode and locally performs bounded zlib, UTF-8, JSON, Codama-schema, and program-address validation. URL/external-account metadata and alternate encodings fail closed rather than causing an unexpected outbound request.
+
+See the mdBook chapter **Pina CLI → Generate and publish IDLs** for authority, rent, buffer, RPC, multisig, exit-status, and failure-recovery details.
+
+<!-- {/pinaIdlProgramMetadata} -->
+
 <!-- {@pinaDiscriminatorLayoutDecisionMatrix} -->
 
 ## Discriminator layout decision matrix


### PR DESCRIPTION
## Summary

- preserve legacy `pina idl` generation while adding `generate`, `fetch`, `diff`, and `publish` subcommands
- publish through pinned `@solana-program/program-metadata@0.9.0`
- support non-submitting multi-transaction export for DAO and multisig workflows
- document the complete Program Metadata lifecycle, RPC requirements, exit codes, output formats, and agent-oriented examples

## Safety

- validates complete Codama roots and requires the IDL program address to match the requested program
- keeps payer and authority semantics explicit and cryptographically validates local keypairs
- bounds subprocess output, raw metadata, and zlib decompression
- rejects unsafe RPC URLs and avoids following external metadata URLs during strict fetch
- uses atomic output publication and preserves official multi-transaction export framing

## Verification

- full CLI, library, integration, and help-snapshot suites
- `lint:all` and `verify:docs`
- Monochange validation and affected-package policy
- exact patch coverage: **1,569/1,569 executable Rust lines (100%)**
- independent architecture/security review cleared commit `a99f504a`

Created on behalf of Ifiok Jr. (`@ifiokjr`) using Codex (GPT-5, high reasoning).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a complete IDL lifecycle: generate, fetch, compare, and publish canonical on-chain IDLs.
  * Added semantic diffing with clear status results.
  * Added transaction export for multisig or DAO signing.
  * Added validation for networks, IDLs, keypairs, and publication settings.
  * Preserved compatibility with the existing bare `pina idl` command.

* **Documentation**
  * Added CLI reference, operational guidance, safety details, and recovery instructions for on-chain IDL workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->