### PR TITLE
feat(cli): add safe program deployment

### DIFF
--- a/.changeset/cli-deploy.md
+++ b/.changeset/cli-deploy.md
@@ -1,0 +1,10 @@
+---
+pina_cli: feat
+pina_skill: feat
+---
+
+# Add safe, inspectable program deployment
+
+`pina deploy` now resolves conventional Cargo deployment artifacts, verifies the declared program address against its keypair, and delegates deployment to the Agave Solana CLI only after showing the exact operation. Every invocation requires an explicit cluster or RPC URL, every remote write requires interactive confirmation or `--yes`, and named mainnet or an identity-unknown custom remote requires a second explicit acknowledgement.
+
+Agents and CI can use `--dry-run --json` to inspect the canonical artifact, program ID, program keypair, upgrade authority, fee payer, operator-supplied endpoint, acknowledgement policy, and structured command plan without building, contacting a cluster, or invoking the Solana CLI. Custom URL user information, queries, and fragments fail closed. Accepted hosts and paths remain visible in plans and process listings, so operators must never place secrets anywhere in a custom URL and should prefer named clusters. Bounded, owner-private keypair reads and streamed artifact fingerprints let Pina reject unsafe files and changes detected during final pre-execution validation. The fully parameterized Solana child receives closed standard input because Pina owns operator confirmation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1460,6 +1460,7 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
+ "pkcs8",
  "signature",
 ]
 
@@ -1471,8 +1472,10 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
+ "serde",
  "sha2 0.10.9",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,7 @@ quote = { default-features = false, version = "^1" }
 semver = { default-features = false, version = "^1" }
 serde = { default-features = false, version = "^1" }
 serde_json = { default-features = false, version = "^1", features = ["std"] }
+sha2 = { default-features = false, version = "^0.10", features = ["std"] }
 solana-account = { version = "^4", default-features = false }
 solana-account-info = { version = "^3", default-features = false }
 solana-address = { default-features = false, version = "^2.0", features = ["bytemuck", "curve25519", "decode"] }

--- a/crates/pina_cli/Cargo.toml
+++ b/crates/pina_cli/Cargo.toml
@@ -23,7 +23,7 @@ cargo_metadata = { workspace = true, default-features = true }
 clap = { workspace = true, default-features = true }
 codama-nodes = { workspace = true, default-features = true }
 comfy-table = "8.0.0"
-ed25519-dalek = { workspace = true }
+ed25519-dalek = { workspace = true, default-features = true }
 flate2 = { workspace = true }
 fs2 = { workspace = true, default-features = true }
 heck = { workspace = true, default-features = true }
@@ -37,7 +37,7 @@ rayon = "1.10"
 semver = { workspace = true, default-features = true }
 serde = { workspace = true, features = ["derive"], default-features = true }
 serde_json = { workspace = true, default-features = true }
-sha2 = { version = "0.10.9", default-features = true }
+sha2 = { workspace = true, default-features = true }
 solana-address = { workspace = true, default-features = true }
 syn = { workspace = true, default-features = true, features = ["full", "extra-traits", "visit", "printing"] }
 tempfile = { workspace = true, default-features = true }

--- a/crates/pina_cli/readme.md
+++ b/crates/pina_cli/readme.md
@@ -152,6 +152,18 @@ pina profile target/deploy/my_program.so --json
 pina profile target/deploy/my_program.so --output report.json
 ```
 
+### `pina deploy`
+
+Plan an explicit deployment without contacting a cluster:
+
+```bash
+pina deploy --project ./programs/my_program --cluster devnet \
+  --upgrade-authority ./keys/devnet-authority.json \
+  --payer ./keys/devnet-payer.json --dry-run --json
+```
+
+Every remote write requires confirmation or `--yes`; named mainnet and custom remote endpoints also require `--allow-mainnet`. Query-bearing RPC URLs are rejected because the external Agave `solana` executable receives its endpoint through process arguments. Keypair reads are size-bounded and, on Unix, require owner-private permissions. The program keypair is validated against `declare_id!` before planning and revalidated immediately before deployment.
+
 ### `pina codama generate`
 
 <br>

--- a/crates/pina_cli/src/cli.rs
+++ b/crates/pina_cli/src/cli.rs
@@ -18,19 +18,21 @@ use clap::ValueEnum;
 	              'pina init' to start a program, 'pina build' for its SBF binary and IDL, 'pina \
 	              test' for SBF integration, 'pina test --unit' for the fast native/Mollusk loop, \
 	              'pina dev' for a persistent Surfpool network, 'pina generate' for selected \
-	              client ecosystems, and 'pina verify' for deployed-program verification. \
-	              Low-level IDL, profiling, terminal documentation, and the legacy \
-	              repository-wide Codama workflow remain available.",
+	              client ecosystems, 'pina deploy' for explicit cluster deployment, and 'pina \
+	              verify' for deployed-program verification. Low-level IDL, profiling, terminal \
+	              documentation, and the legacy repository-wide Codama workflow remain available.",
 	next_line_help = true,
 	arg_required_else_help = true,
 	after_help = "Examples:\n  pina init counter_program\n  cd counter_program && pina build\n  \
 	              pina test\n  pina test --unit\n  pina dev --yes\n  pina generate --client rust \
 	              --client typescript\n  pina idl --path ./programs/counter_program --output \
 	              ./idls/counter_program.json\n  pina profile ./target/deploy/counter_program.so \
-	              --json\n\nAgent discovery:\n  Run 'pina <command> --help' for command-specific \
-	              inputs, outputs, and examples.\n  Run 'pina docs' to list the bundled \
-	              architecture and IDL reference topics.\n  For deployment verification, run \
-	              'pina verify --help' and then inspect the selected leaf command."
+	              --json\n  pina deploy --cluster localnet --payer ~/.config/solana/id.json \
+	              --upgrade-authority ~/.config/solana/id.json --dry-run\n\nAgent discovery:\n  \
+	              Run 'pina <command> --help' for command-specific inputs, outputs, and \
+	              examples.\n  Run 'pina docs' to list the bundled architecture and IDL reference \
+	              topics.\n  For deployment verification, run 'pina verify --help' and then \
+	              inspect the selected leaf command."
 )]
 pub(crate) struct Cli {
 	#[command(subcommand)]
@@ -324,6 +326,87 @@ pub(crate) enum Commands {
 			value_name = "COMMAND"
 		)]
 		solana_verify: OsString,
+	},
+
+	/// Deploy a compiled Pina program through the Solana CLI.
+	///
+	/// Resolves the program artifact from a Cargo program crate or an explicit
+	/// --program path, validates every keypair, prints the complete plan,
+	/// and invokes `solana program deploy`. A cluster or RPC URL is always
+	/// required. Remote writes require confirmation or --yes; mainnet also
+	/// requires --allow-mainnet. Custom remote URLs require the same acknowledgement
+	/// because their cluster identity cannot be proven.
+	#[command(after_help = r"Examples:
+  pina deploy --cluster localnet \
+    --payer ~/.config/solana/id.json \
+    --upgrade-authority ~/.config/solana/id.json
+  pina deploy --build --cluster devnet \
+    --payer ./keys/devnet-payer.json \
+    --upgrade-authority ./keys/devnet-authority.json
+  pina deploy --program ./artifacts/my_program.so \
+    --program-keypair ./keys/my_program.json \
+    --cluster http://127.0.0.1:8899 \
+    --payer ./keys/local-payer.json \
+    --upgrade-authority ./keys/local-authority.json --dry-run --json
+
+Safety:
+  No cluster is selected by default. --cluster accepts a named cluster or explicit RPC URL.
+  Custom URL user information, queries, and fragments are rejected. Accepted hosts and paths
+  remain visible in plans and process listings, so never put a secret anywhere in the URL.
+  Prefer a named cluster when possible.
+  Remote deployment prompts for the word deploy; use --yes only in reviewed automation.
+  Mainnet and custom remote deployment additionally require --allow-mainnet.
+  --dry-run never builds or deploys and --json is available only with --dry-run.")]
+	Deploy {
+		/// Directory used for Pina.toml or Cargo metadata project discovery.
+		#[arg(
+			short,
+			long,
+			default_value = ".",
+			hide_default_value = true,
+			value_name = "DIR"
+		)]
+		project: PathBuf,
+
+		/// Existing SBF shared object. Conflicts with --build.
+		#[arg(long, value_name = "PROGRAM.SO", conflicts_with = "build")]
+		program: Option<PathBuf>,
+
+		/// Run Pina's project-aware SBF build before final deployment planning.
+		#[arg(long, conflicts_with = "dry_run")]
+		build: bool,
+
+		/// Keypair whose public key is the deployed program address.
+		#[arg(long, value_name = "KEYPAIR")]
+		program_keypair: Option<PathBuf>,
+
+		/// Keypair authorized to upgrade the deployed program.
+		#[arg(long, value_name = "KEYPAIR")]
+		upgrade_authority: PathBuf,
+
+		/// Keypair that pays the deployment transaction fees.
+		#[arg(long, value_name = "KEYPAIR")]
+		payer: PathBuf,
+
+		/// Named cluster or explicit HTTP(S) RPC URL. No target is selected by default.
+		#[arg(long, value_name = "CLUSTER|URL")]
+		cluster: String,
+
+		/// Print the resolved deployment plan without building or deploying.
+		#[arg(long, conflicts_with = "yes")]
+		dry_run: bool,
+
+		/// Emit the dry-run plan as JSON. Requires --dry-run.
+		#[arg(long, requires = "dry_run")]
+		json: bool,
+
+		/// Skip the remote deployment confirmation prompt.
+		#[arg(long)]
+		yes: bool,
+
+		/// Acknowledge that mainnet-beta or a custom remote endpoint can affect real assets.
+		#[arg(long, conflicts_with = "dry_run")]
+		allow_mainnet: bool,
 	},
 
 	/// Run Codama IDL and client-generation workflows.

--- a/crates/pina_cli/src/deploy.rs
+++ b/crates/pina_cli/src/deploy.rs
@@ -1,0 +1,2033 @@
+//! Safe planning and execution for `pina deploy`.
+
+use std::ffi::OsStr;
+use std::ffi::OsString;
+use std::fmt;
+use std::fmt::Write as _;
+use std::fs;
+use std::io;
+use std::io::BufRead;
+use std::io::Read;
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+use std::process::Stdio;
+
+use ed25519_dalek::SigningKey;
+use serde::Serialize;
+use serde::Serializer;
+use sha2::Digest as _;
+use sha2::Sha256;
+use thiserror::Error;
+use url::Host;
+use url::Url;
+
+use crate::project::Project;
+
+const LOCALNET_URL: &str = "http://127.0.0.1:8899";
+const DEVNET_URL: &str = "https://api.devnet.solana.com";
+const TESTNET_URL: &str = "https://api.testnet.solana.com";
+const MAINNET_URL: &str = "https://api.mainnet-beta.solana.com";
+const MAX_KEYPAIR_FILE_BYTES: u64 = 4 * 1024;
+
+/// A named Solana cluster or an explicit RPC endpoint.
+#[derive(Clone, Eq, PartialEq)]
+pub enum DeploymentTarget {
+	/// A well-known Solana cluster.
+	Cluster(Cluster),
+	/// A caller-supplied RPC endpoint.
+	RpcUrl(String),
+}
+
+impl fmt::Debug for DeploymentTarget {
+	fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+		match self {
+			Self::Cluster(cluster) => formatter.debug_tuple("Cluster").field(cluster).finish(),
+			Self::RpcUrl(url) => {
+				formatter
+					.debug_tuple("RpcUrl")
+					.field(&redact_rpc_for_diagnostic(url))
+					.finish()
+			}
+		}
+	}
+}
+
+impl DeploymentTarget {
+	/// Parse the value accepted by `pina deploy --cluster`.
+	#[must_use]
+	pub fn from_cluster_arg(value: &str) -> Self {
+		match value {
+			"localnet" => Self::Cluster(Cluster::Localnet),
+			"devnet" => Self::Cluster(Cluster::Devnet),
+			"testnet" => Self::Cluster(Cluster::Testnet),
+			"mainnet-beta" => Self::Cluster(Cluster::MainnetBeta),
+			url => Self::RpcUrl(url.to_owned()),
+		}
+	}
+}
+
+/// Well-known Solana deployment clusters.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Cluster {
+	/// A validator running on the local machine.
+	Localnet,
+	/// Solana devnet.
+	Devnet,
+	/// Solana testnet.
+	Testnet,
+	/// Solana mainnet beta.
+	MainnetBeta,
+}
+
+impl Cluster {
+	fn name(self) -> &'static str {
+		match self {
+			Self::Localnet => "localnet",
+			Self::Devnet => "devnet",
+			Self::Testnet => "testnet",
+			Self::MainnetBeta => "mainnet-beta",
+		}
+	}
+
+	fn rpc_url(self) -> &'static str {
+		match self {
+			Self::Localnet => LOCALNET_URL,
+			Self::Devnet => DEVNET_URL,
+			Self::Testnet => TESTNET_URL,
+			Self::MainnetBeta => MAINNET_URL,
+		}
+	}
+}
+
+/// Inputs used to resolve a deployment plan.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DeploymentRequest {
+	/// Project directory or a directory below it.
+	pub project: PathBuf,
+	/// Explicit existing SBF artifact, if conventional discovery is not desired.
+	pub program: Option<PathBuf>,
+	/// Explicit program keypair, if the conventional keypair is not desired.
+	pub program_keypair: Option<PathBuf>,
+	/// Required upgrade-authority keypair.
+	pub upgrade_authority: PathBuf,
+	/// Required deployment fee-payer keypair.
+	pub payer: PathBuf,
+	/// Explicit cluster or RPC target.
+	pub target: DeploymentTarget,
+}
+
+/// A command that will be executed as part of a deployment.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct CommandPlan {
+	/// Executable selected by Pina.
+	pub program: String,
+	/// Arguments passed directly to the executable without a shell.
+	pub args: Vec<String>,
+}
+
+/// Complete, immutable deployment plan.
+#[derive(Clone, Eq, PartialEq)]
+pub struct DeploymentPlan {
+	project_root: String,
+	program_dir: String,
+	library_name: String,
+	program: String,
+	program_keypair: String,
+	upgrade_authority: String,
+	payer: String,
+	program_id: String,
+	target: ResolvedTarget,
+	input_fingerprint: InputFingerprint,
+}
+
+#[derive(Clone, Eq, PartialEq)]
+struct InputFingerprint {
+	program: [u8; 32],
+	program_keypair: [u8; 32],
+	upgrade_authority: [u8; 32],
+	payer: [u8; 32],
+}
+
+#[derive(Serialize)]
+struct SerializableDeploymentPlan<'a> {
+	project_root: &'a str,
+	program: &'a str,
+	program_keypair: &'a str,
+	upgrade_authority: &'a str,
+	payer: &'a str,
+	program_id: &'a str,
+	cluster: &'a str,
+	rpc_url: &'a str,
+	is_local: bool,
+	requires_mainnet_acknowledgement: bool,
+	commands: Vec<CommandPlan>,
+}
+
+impl Serialize for DeploymentPlan {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		self.serializable().serialize(serializer)
+	}
+}
+
+impl fmt::Debug for DeploymentPlan {
+	fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+		formatter
+			.debug_struct("DeploymentPlan")
+			.field("project_root", &self.project_root())
+			.field("program", &self.program())
+			.field("program_keypair", &self.program_keypair())
+			.field("upgrade_authority", &self.upgrade_authority())
+			.field("payer", &self.payer())
+			.field("program_id", &self.program_id())
+			.field("cluster", &self.cluster())
+			.field("rpc_url", &self.rpc_url())
+			.field("is_local", &self.is_local())
+			.field(
+				"requires_mainnet_acknowledgement",
+				&self.requires_mainnet_acknowledgement(),
+			)
+			.field("commands", &self.commands())
+			.finish_non_exhaustive()
+	}
+}
+
+impl DeploymentPlan {
+	/// Canonical project root used for discovery and command execution.
+	#[must_use]
+	pub fn project_root(&self) -> &str {
+		&self.project_root
+	}
+
+	/// SBF artifact that will be deployed.
+	#[must_use]
+	pub fn program(&self) -> &str {
+		&self.program
+	}
+
+	/// Keypair defining the program address.
+	#[must_use]
+	pub fn program_keypair(&self) -> &str {
+		&self.program_keypair
+	}
+
+	/// Keypair authorized to upgrade the program.
+	#[must_use]
+	pub fn upgrade_authority(&self) -> &str {
+		&self.upgrade_authority
+	}
+
+	/// Keypair that pays deployment transaction fees.
+	#[must_use]
+	pub fn payer(&self) -> &str {
+		&self.payer
+	}
+
+	/// Program address declared by the source and verified against the program keypair.
+	#[must_use]
+	pub fn program_id(&self) -> &str {
+		&self.program_id
+	}
+
+	/// Named cluster, or `custom` for an explicit URL.
+	#[must_use]
+	pub fn cluster(&self) -> &str {
+		&self.target.cluster
+	}
+
+	/// Exact operator-supplied RPC URL exposed in the plan and Solana CLI arguments.
+	#[must_use]
+	pub fn rpc_url(&self) -> &str {
+		&self.target.rpc_url
+	}
+
+	/// Whether the endpoint is provably local.
+	#[must_use]
+	pub fn is_local(&self) -> bool {
+		self.target.policy == TargetPolicy::Local
+	}
+
+	/// Whether execution requires the explicit mainnet-risk acknowledgement.
+	#[must_use]
+	pub fn requires_mainnet_acknowledgement(&self) -> bool {
+		self.target.policy == TargetPolicy::MainnetOrUnknown
+	}
+
+	/// Exact modeled command derived from the validated plan state.
+	#[must_use]
+	pub fn commands(&self) -> Vec<CommandPlan> {
+		vec![deploy_command(
+			self.program(),
+			self.program_keypair(),
+			self.upgrade_authority(),
+			self.payer(),
+			self.rpc_url(),
+		)]
+	}
+
+	fn serializable(&self) -> SerializableDeploymentPlan<'_> {
+		SerializableDeploymentPlan {
+			project_root: self.project_root(),
+			program: self.program(),
+			program_keypair: self.program_keypair(),
+			upgrade_authority: self.upgrade_authority(),
+			payer: self.payer(),
+			program_id: self.program_id(),
+			cluster: self.cluster(),
+			rpc_url: self.rpc_url(),
+			is_local: self.is_local(),
+			requires_mainnet_acknowledgement: self.requires_mainnet_acknowledgement(),
+			commands: self.commands(),
+		}
+	}
+
+	fn revalidate(&self) -> Result<(), DeployError> {
+		let program = Path::new(self.program());
+		let program_keypair = Path::new(self.program_keypair());
+		let upgrade_authority = Path::new(self.upgrade_authority());
+		let payer = Path::new(self.payer());
+		canonical_file(program, "program", None)?;
+		canonical_file(program_keypair, "program keypair", Some("program keypair"))?;
+		canonical_file(
+			upgrade_authority,
+			"upgrade authority",
+			Some("upgrade authority"),
+		)?;
+		canonical_file(payer, "fee payer", Some("fee payer"))?;
+		let current_program_id =
+			crate::generate_idl(Path::new(&self.program_dir), Some(&self.library_name))
+				.map_err(|error| {
+					DeployError::Project {
+						path: PathBuf::from(self.project_root()),
+						reason: format!("could not revalidate the declared program ID: {error}"),
+					}
+				})?
+				.program
+				.public_key;
+		let program_keypair_bytes = read_keypair(program_keypair, "program keypair")?;
+		let keypair_program_id = bs58::encode(&program_keypair_bytes[32..]).into_string();
+		let fingerprint = InputFingerprint {
+			program: file_digest(program, "program")?,
+			program_keypair: file_digest(program_keypair, "program keypair")?,
+			upgrade_authority: file_digest(upgrade_authority, "upgrade authority")?,
+			payer: file_digest(payer, "fee payer")?,
+		};
+
+		if current_program_id != self.program_id
+			|| keypair_program_id != self.program_id
+			|| fingerprint != self.input_fingerprint
+		{
+			return Err(DeployError::InputsChanged);
+		}
+
+		Ok(())
+	}
+
+	/// Render a stable human-readable deployment plan.
+	#[must_use]
+	pub fn render_text(&self) -> String {
+		let mut output = String::new();
+		output.push_str("Deployment plan\n");
+		let _ = writeln!(
+			output,
+			"  Project:           {}",
+			diagnostic_quote(self.project_root())
+		);
+		let _ = writeln!(
+			output,
+			"  Program:           {}",
+			diagnostic_quote(self.program())
+		);
+		let _ = writeln!(
+			output,
+			"  Program keypair:   {}",
+			diagnostic_quote(self.program_keypair())
+		);
+		let _ = writeln!(
+			output,
+			"  Upgrade authority: {}",
+			diagnostic_quote(self.upgrade_authority())
+		);
+		let _ = writeln!(
+			output,
+			"  Fee payer:         {}",
+			diagnostic_quote(self.payer())
+		);
+		let _ = writeln!(
+			output,
+			"  Program ID:        {}",
+			diagnostic_quote(self.program_id())
+		);
+		let _ = writeln!(
+			output,
+			"  Cluster:           {}",
+			diagnostic_quote(self.cluster())
+		);
+		let _ = writeln!(
+			output,
+			"  RPC URL:           {}",
+			diagnostic_quote(self.rpc_url())
+		);
+		output.push_str("  Commands:\n");
+
+		for command in self.commands() {
+			output.push_str("    ");
+			output.push_str(&diagnostic_quote(&command.program));
+
+			for arg in command.args {
+				output.push(' ');
+				output.push_str(&diagnostic_quote(&arg));
+			}
+
+			output.push('\n');
+		}
+
+		output
+	}
+}
+
+/// Result of a child process invocation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CommandStatus {
+	/// Whether the child exited successfully.
+	pub success: bool,
+	/// Child exit code, if one was available.
+	pub code: Option<i32>,
+}
+
+/// Boundary used to execute planned commands without a shell.
+pub trait CommandRunner {
+	/// Run one executable with its exact argument vector.
+	fn run(
+		&mut self,
+		program: &OsStr,
+		args: &[OsString],
+		current_dir: &Path,
+	) -> io::Result<CommandStatus>;
+}
+
+/// Boundary used to request consequential remote-deployment confirmation.
+pub trait DeploymentConfirmer {
+	/// Return `true` only when the operator explicitly confirms the prompt.
+	fn confirm(&mut self, prompt: &str) -> io::Result<bool>;
+}
+
+/// Read the exact interactive confirmation word from a terminal stream.
+pub fn read_deployment_confirmation(
+	prompt: &str,
+	is_terminal: bool,
+	input: &mut impl BufRead,
+	output: &mut impl Write,
+) -> io::Result<bool> {
+	if !is_terminal {
+		return Ok(false);
+	}
+
+	write!(output, "{prompt}")?;
+	output.flush()?;
+	let mut response = String::new();
+	input.read_line(&mut response)?;
+
+	Ok(response.trim() == "deploy")
+}
+
+/// Real child-process implementation used by the CLI.
+pub struct SystemCommandRunner;
+
+impl CommandRunner for SystemCommandRunner {
+	fn run(
+		&mut self,
+		program: &OsStr,
+		args: &[OsString],
+		current_dir: &Path,
+	) -> io::Result<CommandStatus> {
+		let status = Command::new(program)
+			.args(args)
+			.current_dir(current_dir)
+			.stdin(Stdio::null())
+			.status()?;
+
+		Ok(CommandStatus {
+			success: status.success(),
+			code: status.code(),
+		})
+	}
+}
+
+/// Deployment planning or execution failure.
+#[derive(Debug, Error)]
+pub enum DeployError {
+	/// Project discovery did not find a usable Cargo program crate.
+	#[error("could not resolve a Pina program project from {path:?}: {reason:?}")]
+	Project { path: PathBuf, reason: String },
+
+	/// A required path was absent or did not identify a regular file.
+	#[error("{kind} is not a readable regular file: {path:?}")]
+	InvalidFile { kind: &'static str, path: PathBuf },
+
+	/// A keypair file was not a valid Solana keypair JSON array.
+	#[error("{kind} is not a valid 64-byte Solana keypair JSON file: {path:?}")]
+	InvalidKeypair { kind: &'static str, path: PathBuf },
+
+	/// A Unix keypair file is readable by its group or other users.
+	#[cfg(unix)]
+	#[error(
+		"{kind} keypair has unsafe Unix permissions {mode:#o}: {path:?}; remove all group and \
+		 other permissions (for example, chmod 600)"
+	)]
+	InsecureKeypairPermissions {
+		kind: &'static str,
+		path: PathBuf,
+		mode: u32,
+	},
+
+	/// The validated program keypair does not match the source declaration.
+	#[error("declared program ID {declared:?} does not match program keypair address {keypair:?}")]
+	ProgramIdMismatch { declared: String, keypair: String },
+
+	/// An explicit RPC URL was invalid or unsafe to pass through.
+	#[error("invalid RPC URL {url:?}: {reason}")]
+	InvalidRpcUrl { url: String, reason: String },
+
+	/// A path cannot be represented in the machine-readable plan.
+	#[error("{kind} path is not valid UTF-8: {path:?}")]
+	NonUtf8Path { kind: &'static str, path: PathBuf },
+
+	/// Mainnet execution was not explicitly acknowledged.
+	#[error(
+		"mainnet and custom remote deployment require --allow-mainnet in addition to confirmation \
+		 or --yes"
+	)]
+	MainnetNotAllowed,
+
+	/// Mainnet acknowledgement was supplied for another target.
+	#[error("--allow-mainnet is valid only for mainnet-beta or a custom remote endpoint")]
+	UnexpectedMainnetAcknowledgement,
+
+	/// A validated input changed after the plan was displayed.
+	#[error("deployment inputs changed after planning; review a new plan before deploying")]
+	InputsChanged,
+
+	/// A consequential remote deployment was rejected or could not be confirmed.
+	#[error(
+		"remote deployment was not confirmed; rerun interactively or pass --yes after reviewing \
+		 the plan"
+	)]
+	ConfirmationRequired,
+
+	/// A child process could not be started.
+	#[error("failed to start {program:?}: {source}")]
+	CommandStart {
+		program: String,
+		#[source]
+		source: io::Error,
+	},
+
+	/// A child process exited unsuccessfully.
+	#[error("{program:?} exited unsuccessfully with status {status}")]
+	CommandFailed { program: String, status: String },
+
+	/// The project-aware SBF build failed before deployment planning.
+	#[error("deployment build failed: {0}")]
+	Build(#[from] crate::build::BuildError),
+}
+
+/// Resolve and validate an inspectable deployment plan without executing it.
+pub fn prepare_deployment(request: &DeploymentRequest) -> Result<DeploymentPlan, DeployError> {
+	let project = Project::discover(&request.project).map_err(|error| {
+		DeployError::Project {
+			path: request.project.clone(),
+			reason: error.to_string(),
+		}
+	})?;
+	let deploy_dir = project.target_dir.join("deploy");
+	let program_path = request.program.as_deref().map_or_else(
+		|| {
+			canonical_file(
+				&deploy_dir.join(format!("{}.so", project.library_name)),
+				"program",
+				None,
+			)
+		},
+		|path| canonical_file(path, "program", None),
+	)?;
+	let program_keypair_path = request.program_keypair.as_deref().map_or_else(
+		|| {
+			canonical_file(
+				&deploy_dir.join(format!("{}-keypair.json", project.library_name)),
+				"program keypair",
+				Some("program keypair"),
+			)
+		},
+		|path| canonical_file(path, "program keypair", Some("program keypair")),
+	)?;
+	let upgrade_authority_path = canonical_file(
+		&request.upgrade_authority,
+		"upgrade authority",
+		Some("upgrade authority"),
+	)?;
+	let payer_path = canonical_file(&request.payer, "fee payer", Some("fee payer"))?;
+	let declared_program_id =
+		crate::generate_idl(&project.program_dir, Some(&project.library_name))
+			.map_err(|error| {
+				DeployError::Project {
+					path: project.root.clone(),
+					reason: format!("could not resolve the declared program ID: {error}"),
+				}
+			})?
+			.program
+			.public_key;
+	let program_keypair_bytes = read_keypair(&program_keypair_path, "program keypair")?;
+	let keypair_program_id = bs58::encode(&program_keypair_bytes[32..]).into_string();
+
+	if declared_program_id != keypair_program_id {
+		return Err(DeployError::ProgramIdMismatch {
+			declared: declared_program_id,
+			keypair: keypair_program_id,
+		});
+	}
+
+	let target = ResolvedTarget::resolve(&request.target)?;
+	let program = path_string(&program_path, "program")?;
+	let program_keypair = path_string(&program_keypair_path, "program keypair")?;
+	let upgrade_authority = path_string(&upgrade_authority_path, "upgrade authority")?;
+	let payer = path_string(&payer_path, "fee payer")?;
+	let project_root = path_string(&project.root, "project root")?;
+	let program_dir = path_string(&project.program_dir, "program directory")?;
+	let input_fingerprint = InputFingerprint {
+		program: file_digest(&program_path, "program")?,
+		program_keypair: file_digest(&program_keypair_path, "program keypair")?,
+		upgrade_authority: file_digest(&upgrade_authority_path, "upgrade authority")?,
+		payer: file_digest(&payer_path, "fee payer")?,
+	};
+
+	Ok(DeploymentPlan {
+		project_root,
+		program_dir,
+		library_name: project.library_name,
+		program,
+		program_keypair,
+		upgrade_authority,
+		payer,
+		program_id: declared_program_id,
+		target,
+		input_fingerprint,
+	})
+}
+
+/// Validate an explicit deployment target before project discovery, building, or execution.
+pub fn validate_deployment_target(target: &DeploymentTarget) -> Result<(), DeployError> {
+	ResolvedTarget::resolve(target).map(|_| ())
+}
+
+/// Build the project before resolving and displaying its final deployment plan.
+pub fn build_deployment_program(project: &Path) -> Result<(), DeployError> {
+	build_deployment_program_with(project, crate::build::build_project)
+}
+
+fn build_deployment_program_with(
+	project: &Path,
+	build: impl FnOnce(&Path) -> Result<crate::build::BuildOutput, crate::build::BuildError>,
+) -> Result<(), DeployError> {
+	build(project).map(|_| ()).map_err(DeployError::Build)
+}
+
+fn deploy_command(
+	program: &str,
+	program_keypair: &str,
+	upgrade_authority: &str,
+	payer: &str,
+	rpc_url: &str,
+) -> CommandPlan {
+	CommandPlan {
+		program: "solana".to_owned(),
+		args: vec![
+			"program".to_owned(),
+			"deploy".to_owned(),
+			program.to_owned(),
+			"--program-id".to_owned(),
+			program_keypair.to_owned(),
+			"--upgrade-authority".to_owned(),
+			upgrade_authority.to_owned(),
+			"--fee-payer".to_owned(),
+			payer.to_owned(),
+			"--url".to_owned(),
+			rpc_url.to_owned(),
+		],
+	}
+}
+
+/// Execute an already-reviewed deployment plan.
+pub fn execute_deployment(
+	plan: &DeploymentPlan,
+	yes: bool,
+	allow_mainnet: bool,
+	runner: &mut impl CommandRunner,
+	confirmer: &mut impl DeploymentConfirmer,
+) -> Result<(), DeployError> {
+	if allow_mainnet && !plan.requires_mainnet_acknowledgement() {
+		return Err(DeployError::UnexpectedMainnetAcknowledgement);
+	}
+
+	if plan.requires_mainnet_acknowledgement() && !allow_mainnet {
+		return Err(DeployError::MainnetNotAllowed);
+	}
+
+	if !plan.is_local() && !yes {
+		let prompt = format!(
+			"Type `deploy` to deploy {} to {} ({}): ",
+			diagnostic_quote(plan.program()),
+			diagnostic_quote(plan.cluster()),
+			diagnostic_quote(plan.rpc_url())
+		);
+		let approved = confirmer
+			.confirm(&prompt)
+			.map_err(|_| DeployError::ConfirmationRequired)?;
+
+		if !approved {
+			return Err(DeployError::ConfirmationRequired);
+		}
+	}
+
+	plan.revalidate()?;
+	let command = deploy_command(
+		plan.program(),
+		plan.program_keypair(),
+		plan.upgrade_authority(),
+		plan.payer(),
+		plan.rpc_url(),
+	);
+	run_command(&command, Path::new(plan.project_root()), runner)
+}
+
+fn run_command(
+	command: &CommandPlan,
+	current_dir: &Path,
+	runner: &mut impl CommandRunner,
+) -> Result<(), DeployError> {
+	let args = command.args.iter().map(OsString::from).collect::<Vec<_>>();
+	let status = runner
+		.run(OsStr::new(&command.program), &args, current_dir)
+		.map_err(|source| {
+			DeployError::CommandStart {
+				program: command.program.clone(),
+				source,
+			}
+		})?;
+
+	if !status.success {
+		return Err(DeployError::CommandFailed {
+			program: command.program.clone(),
+			status: status.code.map_or_else(
+				|| "terminated by signal".to_owned(),
+				|code| code.to_string(),
+			),
+		});
+	}
+
+	Ok(())
+}
+
+#[derive(Clone, Eq, PartialEq)]
+struct ResolvedTarget {
+	cluster: String,
+	rpc_url: String,
+	policy: TargetPolicy,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum TargetPolicy {
+	Local,
+	KnownRemote,
+	MainnetOrUnknown,
+}
+
+impl ResolvedTarget {
+	fn resolve(target: &DeploymentTarget) -> Result<Self, DeployError> {
+		match target {
+			DeploymentTarget::Cluster(cluster) => {
+				Ok(Self {
+					cluster: cluster.name().to_owned(),
+					rpc_url: cluster.rpc_url().to_owned(),
+					policy: match cluster {
+						Cluster::Localnet => TargetPolicy::Local,
+						Cluster::Devnet | Cluster::Testnet => TargetPolicy::KnownRemote,
+						Cluster::MainnetBeta => TargetPolicy::MainnetOrUnknown,
+					},
+				})
+			}
+			DeploymentTarget::RpcUrl(value) => Self::custom(value),
+		}
+	}
+
+	fn custom(value: &str) -> Result<Self, DeployError> {
+		let diagnostic_url = redact_rpc_for_diagnostic(value);
+		if value.chars().any(char::is_control) {
+			return Err(DeployError::InvalidRpcUrl {
+				url: diagnostic_url,
+				reason: "control characters are not accepted".to_owned(),
+			});
+		}
+
+		let parsed = Url::parse(value).map_err(|error| {
+			DeployError::InvalidRpcUrl {
+				url: diagnostic_url.clone(),
+				reason: error.to_string(),
+			}
+		})?;
+
+		if parsed.scheme() != "http" && parsed.scheme() != "https" {
+			return Err(DeployError::InvalidRpcUrl {
+				url: diagnostic_url.clone(),
+				reason: "only http and https endpoints are accepted".to_owned(),
+			});
+		}
+
+		if !parsed.username().is_empty() || parsed.password().is_some() {
+			return Err(DeployError::InvalidRpcUrl {
+				url: diagnostic_url.clone(),
+				reason: "embedded credentials are not accepted".to_owned(),
+			});
+		}
+
+		let host = require_rpc_host(parsed.host(), &diagnostic_url)?;
+
+		if parsed.fragment().is_some() {
+			return Err(DeployError::InvalidRpcUrl {
+				url: diagnostic_url,
+				reason: "URL fragments are not accepted".to_owned(),
+			});
+		}
+
+		if parsed.query().is_some() {
+			return Err(DeployError::InvalidRpcUrl {
+				url: diagnostic_url,
+				reason: "query parameters are rejected because RPC URLs are visible in process \
+				         arguments"
+					.to_owned(),
+			});
+		}
+
+		let is_local = match host {
+			Host::Domain(domain) => domain.eq_ignore_ascii_case("localhost"),
+			Host::Ipv4(address) => address.is_loopback(),
+			Host::Ipv6(address) => address.is_loopback(),
+		};
+
+		let rpc_url = parsed.to_string();
+
+		Ok(Self {
+			cluster: "custom".to_owned(),
+			rpc_url,
+			policy: if is_local {
+				TargetPolicy::Local
+			} else {
+				TargetPolicy::MainnetOrUnknown
+			},
+		})
+	}
+}
+
+fn require_rpc_host<'a>(
+	host: Option<Host<&'a str>>,
+	diagnostic_url: &str,
+) -> Result<Host<&'a str>, DeployError> {
+	host.ok_or_else(|| {
+		DeployError::InvalidRpcUrl {
+			url: diagnostic_url.to_owned(),
+			reason: "an endpoint host is required".to_owned(),
+		}
+	})
+}
+
+fn canonical_file(
+	path: &Path,
+	kind: &'static str,
+	keypair_kind: Option<&'static str>,
+) -> Result<PathBuf, DeployError> {
+	let canonical = fs::canonicalize(path).map_err(|_| {
+		DeployError::InvalidFile {
+			kind,
+			path: path.to_path_buf(),
+		}
+	})?;
+	if !canonical.is_file() {
+		return Err(DeployError::InvalidFile {
+			kind,
+			path: path.to_path_buf(),
+		});
+	}
+
+	if let Some(keypair_kind) = keypair_kind {
+		validate_keypair(&canonical, keypair_kind)?;
+	}
+
+	Ok(canonical)
+}
+
+fn validate_keypair(path: &Path, kind: &'static str) -> Result<(), DeployError> {
+	read_keypair(path, kind).map(|_| ())
+}
+
+fn file_digest(path: &Path, kind: &'static str) -> Result<[u8; 32], DeployError> {
+	let file = fs::File::open(path).map_err(|_| {
+		DeployError::InvalidFile {
+			kind,
+			path: path.to_path_buf(),
+		}
+	})?;
+	digest_reader(file).map_err(|_| {
+		DeployError::InvalidFile {
+			kind,
+			path: path.to_path_buf(),
+		}
+	})
+}
+
+fn digest_reader(mut reader: impl Read) -> io::Result<[u8; 32]> {
+	let mut digest = Sha256::new();
+	let mut buffer = [0_u8; 8 * 1024];
+
+	loop {
+		let read = reader.read(&mut buffer)?;
+		if read == 0 {
+			break;
+		}
+		digest.update(&buffer[..read]);
+	}
+
+	Ok(digest.finalize().into())
+}
+
+fn read_keypair(path: &Path, kind: &'static str) -> Result<Vec<u8>, DeployError> {
+	let file = fs::File::open(path).map_err(|_| {
+		DeployError::InvalidKeypair {
+			kind,
+			path: path.to_path_buf(),
+		}
+	})?;
+	let metadata = keypair_metadata(file.metadata(), path, kind)?;
+
+	if !metadata.is_file() || metadata.len() > MAX_KEYPAIR_FILE_BYTES {
+		return Err(DeployError::InvalidKeypair {
+			kind,
+			path: path.to_path_buf(),
+		});
+	}
+
+	#[cfg(unix)]
+	validate_keypair_permissions(path, kind, &metadata)?;
+
+	let bytes = read_keypair_content(file, path, kind)?;
+	let keypair = serde_json::from_slice::<Vec<u8>>(&bytes).map_err(|_| {
+		DeployError::InvalidKeypair {
+			kind,
+			path: path.to_path_buf(),
+		}
+	})?;
+
+	if keypair.len() != 64 {
+		return Err(DeployError::InvalidKeypair {
+			kind,
+			path: path.to_path_buf(),
+		});
+	}
+	let mut secret = [0_u8; 32];
+	secret.copy_from_slice(&keypair[..32]);
+	let public = SigningKey::from_bytes(&secret).verifying_key().to_bytes();
+
+	if keypair[32..] != public {
+		return Err(DeployError::InvalidKeypair {
+			kind,
+			path: path.to_path_buf(),
+		});
+	}
+
+	Ok(keypair)
+}
+
+fn keypair_metadata(
+	metadata: io::Result<fs::Metadata>,
+	path: &Path,
+	kind: &'static str,
+) -> Result<fs::Metadata, DeployError> {
+	metadata.map_err(|_| {
+		DeployError::InvalidKeypair {
+			kind,
+			path: path.to_path_buf(),
+		}
+	})
+}
+
+fn read_keypair_content(
+	mut reader: impl Read,
+	path: &Path,
+	kind: &'static str,
+) -> Result<Vec<u8>, DeployError> {
+	let mut bytes = Vec::with_capacity(MAX_KEYPAIR_FILE_BYTES as usize);
+	reader
+		.by_ref()
+		.take(MAX_KEYPAIR_FILE_BYTES + 1)
+		.read_to_end(&mut bytes)
+		.map_err(|_| {
+			DeployError::InvalidKeypair {
+				kind,
+				path: path.to_path_buf(),
+			}
+		})?;
+
+	if bytes.len() as u64 > MAX_KEYPAIR_FILE_BYTES {
+		return Err(DeployError::InvalidKeypair {
+			kind,
+			path: path.to_path_buf(),
+		});
+	}
+
+	Ok(bytes)
+}
+
+#[cfg(unix)]
+fn validate_keypair_permissions(
+	path: &Path,
+	kind: &'static str,
+	metadata: &fs::Metadata,
+) -> Result<(), DeployError> {
+	use std::os::unix::fs::PermissionsExt as _;
+
+	let mode = metadata.permissions().mode() & 0o777;
+	if mode & 0o077 != 0 {
+		return Err(DeployError::InsecureKeypairPermissions {
+			kind,
+			path: path.to_path_buf(),
+			mode,
+		});
+	}
+
+	Ok(())
+}
+
+fn redact_rpc_for_diagnostic(value: &str) -> String {
+	let without_userinfo = if let Some(scheme_end) = value.find("://") {
+		let authority_start = scheme_end + 3;
+		let authority_end = value[authority_start..]
+			.find(['/', '?', '#'])
+			.map_or(value.len(), |offset| authority_start + offset);
+		let authority = &value[authority_start..authority_end];
+
+		if let Some(at) = authority.rfind('@') {
+			format!(
+				"{}<redacted>@{}{}",
+				&value[..authority_start],
+				&authority[at + 1..],
+				&value[authority_end..]
+			)
+		} else {
+			value.to_owned()
+		}
+	} else {
+		value.to_owned()
+	};
+	let query_start = without_userinfo.find('?');
+	let fragment_start = without_userinfo.find('#');
+
+	match (query_start, fragment_start) {
+		(Some(query), Some(fragment)) if query < fragment => {
+			format!("{}?<redacted>#<redacted>", &without_userinfo[..query])
+		}
+		(Some(query), _) => format!("{}?<redacted>", &without_userinfo[..query]),
+		(None, Some(fragment)) => format!("{}#<redacted>", &without_userinfo[..fragment]),
+		(None, None) => without_userinfo,
+	}
+}
+
+fn diagnostic_quote(value: &str) -> String {
+	format!("{value:?}")
+}
+
+fn path_string(path: &Path, kind: &'static str) -> Result<String, DeployError> {
+	path.to_str().map(str::to_owned).ok_or_else(|| {
+		DeployError::NonUtf8Path {
+			kind,
+			path: path.to_path_buf(),
+		}
+	})
+}
+
+#[cfg(test)]
+mod tests {
+	use std::collections::VecDeque;
+	use std::fs;
+	use std::io;
+	use std::path::Path;
+
+	use tempfile::TempDir;
+
+	use super::*;
+
+	struct Fixture {
+		_temp: TempDir,
+		root: PathBuf,
+		program: PathBuf,
+		program_keypair: PathBuf,
+		authority: PathBuf,
+		payer: PathBuf,
+	}
+
+	impl Fixture {
+		fn new() -> Self {
+			let temp = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+			let root = temp.path().join("project");
+			let deploy = root.join("target/deploy");
+			let program = deploy.join("example_program.so");
+			let program_keypair = deploy.join("example_program-keypair.json");
+			let authority = root.join("authority.json");
+			let payer = root.join("payer.json");
+			fs::create_dir_all(&deploy).unwrap_or_else(|error| panic!("create fixture: {error}"));
+			fs::create_dir_all(root.join("src"))
+				.unwrap_or_else(|error| panic!("create source fixture: {error}"));
+			fs::write(
+				root.join("Cargo.toml"),
+				"[package]\nname = \"example-program\"\nversion = \"0.1.0\"\n",
+			)
+			.unwrap_or_else(|error| panic!("write manifest: {error}"));
+			fs::write(&program, b"SBF").unwrap_or_else(|error| panic!("write program: {error}"));
+			write_keypair(&program_keypair);
+			write_keypair(&authority);
+			write_keypair(&payer);
+			let keypair = read_keypair(&program_keypair, "fixture")
+				.unwrap_or_else(|error| panic!("read fixture keypair: {error}"));
+			let program_id = bs58::encode(&keypair[32..]).into_string();
+			fs::write(
+				root.join("src/lib.rs"),
+				format!("use pina::prelude::*;\ndeclare_id!(\"{program_id}\");\n"),
+			)
+			.unwrap_or_else(|error| panic!("write source: {error}"));
+
+			Self {
+				_temp: temp,
+				root,
+				program,
+				program_keypair,
+				authority,
+				payer,
+			}
+		}
+
+		fn request(&self, target: DeploymentTarget) -> DeploymentRequest {
+			DeploymentRequest {
+				project: self.root.clone(),
+				program: None,
+				program_keypair: None,
+				upgrade_authority: self.authority.clone(),
+				payer: self.payer.clone(),
+				target,
+			}
+		}
+	}
+
+	fn write_keypair(path: &Path) {
+		let signing_key = SigningKey::from_bytes(&[7u8; 32]);
+		let mut bytes = signing_key.to_bytes().to_vec();
+		bytes.extend_from_slice(&signing_key.verifying_key().to_bytes());
+		fs::write(
+			path,
+			serde_json::to_vec(&bytes).unwrap_or_else(|error| panic!("serialize keypair: {error}")),
+		)
+		.unwrap_or_else(|error| panic!("write keypair: {error}"));
+		make_keypair_private(path);
+	}
+
+	#[cfg(unix)]
+	fn make_keypair_private(path: &Path) {
+		use std::os::unix::fs::PermissionsExt as _;
+
+		fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+			.unwrap_or_else(|error| panic!("protect keypair: {error}"));
+	}
+
+	#[cfg(not(unix))]
+	fn make_keypair_private(_: &Path) {}
+
+	#[derive(Default)]
+	struct FakeRunner {
+		calls: Vec<(String, Vec<String>, PathBuf)>,
+		results: VecDeque<io::Result<CommandStatus>>,
+	}
+
+	struct FailingReader;
+
+	impl Read for FailingReader {
+		fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+			Err(io::Error::other("synthetic failure"))
+		}
+	}
+
+	impl CommandRunner for FakeRunner {
+		fn run(
+			&mut self,
+			program: &OsStr,
+			args: &[OsString],
+			current_dir: &Path,
+		) -> io::Result<CommandStatus> {
+			self.calls.push((
+				program.to_string_lossy().into_owned(),
+				args.iter()
+					.map(|arg| arg.to_string_lossy().into_owned())
+					.collect(),
+				current_dir.to_path_buf(),
+			));
+			self.results.pop_front().unwrap_or(Ok(CommandStatus {
+				success: true,
+				code: Some(0),
+			}))
+		}
+	}
+
+	struct FakeConfirmer {
+		confirmed: io::Result<bool>,
+		prompts: Vec<String>,
+	}
+
+	impl DeploymentConfirmer for FakeConfirmer {
+		fn confirm(&mut self, prompt: &str) -> io::Result<bool> {
+			self.prompts.push(prompt.to_owned());
+			match &self.confirmed {
+				Ok(confirmed) => Ok(*confirmed),
+				Err(error) => Err(io::Error::new(error.kind(), error.to_string())),
+			}
+		}
+	}
+
+	fn rejecting_confirmer() -> FakeConfirmer {
+		FakeConfirmer {
+			confirmed: Ok(false),
+			prompts: Vec::new(),
+		}
+	}
+
+	#[test]
+	fn cluster_argument_recognizes_named_targets_and_preserves_urls() {
+		assert_eq!(
+			DeploymentTarget::from_cluster_arg("localnet"),
+			DeploymentTarget::Cluster(Cluster::Localnet)
+		);
+		assert_eq!(
+			DeploymentTarget::from_cluster_arg("devnet"),
+			DeploymentTarget::Cluster(Cluster::Devnet)
+		);
+		assert_eq!(
+			DeploymentTarget::from_cluster_arg("testnet"),
+			DeploymentTarget::Cluster(Cluster::Testnet)
+		);
+		assert_eq!(
+			DeploymentTarget::from_cluster_arg("mainnet-beta"),
+			DeploymentTarget::Cluster(Cluster::MainnetBeta)
+		);
+		assert_eq!(
+			DeploymentTarget::from_cluster_arg("https://rpc.example.com"),
+			DeploymentTarget::RpcUrl("https://rpc.example.com".to_owned())
+		);
+	}
+
+	#[test]
+	fn plan_resolves_conventional_project_inputs_and_exact_command() {
+		let fixture = Fixture::new();
+		let plan = prepare_deployment(&fixture.request(DeploymentTarget::Cluster(Cluster::Devnet)))
+			.unwrap_or_else(|error| panic!("prepare deployment: {error}"));
+
+		assert_eq!(plan.program(), canonical(&fixture.program));
+		assert_eq!(plan.program_keypair(), canonical(&fixture.program_keypair));
+		assert_eq!(plan.upgrade_authority(), canonical(&fixture.authority));
+		assert_eq!(plan.payer(), canonical(&fixture.payer));
+		assert_eq!(plan.cluster(), "devnet");
+		assert_eq!(plan.rpc_url(), DEVNET_URL);
+		assert!(!plan.is_local());
+		assert!(!plan.requires_mainnet_acknowledgement());
+		assert_eq!(plan.commands().len(), 1);
+		assert_eq!(
+			plan.commands()[0],
+			CommandPlan {
+				program: "solana".to_owned(),
+				args: vec![
+					"program".to_owned(),
+					"deploy".to_owned(),
+					canonical(&fixture.program),
+					"--program-id".to_owned(),
+					canonical(&fixture.program_keypair),
+					"--upgrade-authority".to_owned(),
+					canonical(&fixture.authority),
+					"--fee-payer".to_owned(),
+					canonical(&fixture.payer),
+					"--url".to_owned(),
+					DEVNET_URL.to_owned(),
+				],
+			}
+		);
+	}
+
+	#[test]
+	fn foundation_build_boundary_runs_before_plan_and_uses_library_name() {
+		let fixture = Fixture::new();
+		fs::write(
+			fixture.root.join("Cargo.toml"),
+			"[package]\nname = \"package-name\"\nversion = \"0.1.0\"\n\n[lib]\nname = \
+			 \"program_lib\"\n",
+		)
+		.unwrap_or_else(|error| panic!("write manifest: {error}"));
+		let lib_keypair = fixture.root.join("target/deploy/program_lib-keypair.json");
+		let lib_program = fixture.root.join("target/deploy/program_lib.so");
+		write_keypair(&lib_keypair);
+		fs::write(&lib_program, b"built SBF")
+			.unwrap_or_else(|error| panic!("write built program: {error}"));
+		let request = fixture.request(DeploymentTarget::Cluster(Cluster::Localnet));
+		let mut built_from = None;
+		build_deployment_program_with(&fixture.root, |project| {
+			built_from = Some(project.to_path_buf());
+			Ok(crate::build::BuildOutput {
+				package_name: "package-name".to_owned(),
+				sbf_artifact: lib_program.clone(),
+				idl: fixture.root.join("target/idl/program_lib.json"),
+			})
+		})
+		.unwrap_or_else(|error| panic!("build deployment: {error}"));
+		let plan = prepare_deployment(&request)
+			.unwrap_or_else(|error| panic!("prepare deployment: {error}"));
+		let expected_program = fs::canonicalize(&lib_program)
+			.unwrap_or_else(|error| panic!("canonicalize program: {error}"));
+
+		assert_eq!(plan.program(), path(&expected_program));
+		assert_eq!(plan.program_keypair(), canonical(&lib_keypair));
+		assert_eq!(plan.commands().len(), 1);
+		assert_eq!(built_from.as_deref(), Some(fixture.root.as_path()));
+		assert_eq!(plan.commands()[0].program, "solana");
+	}
+
+	#[test]
+	fn foundation_build_failures_stop_deployment_workflow() {
+		let error = build_deployment_program_with(Path::new("project"), |_| {
+			Err(crate::build::BuildError::MissingArtifact {
+				path: PathBuf::from("missing.so"),
+			})
+		})
+		.unwrap_err();
+
+		assert!(matches!(error, DeployError::Build(_)));
+		assert!(error.to_string().contains("missing.so"));
+	}
+
+	#[test]
+	fn explicit_paths_override_conventional_paths() {
+		let fixture = Fixture::new();
+		let explicit_program = fixture.root.join("artifact.so");
+		let explicit_keypair = fixture.root.join("program.json");
+		fs::write(&explicit_program, b"SBF")
+			.unwrap_or_else(|error| panic!("write program: {error}"));
+		write_keypair(&explicit_keypair);
+		let mut request = fixture.request(DeploymentTarget::Cluster(Cluster::Testnet));
+		request.program = Some(explicit_program.clone());
+		request.program_keypair = Some(explicit_keypair.clone());
+		let plan = prepare_deployment(&request)
+			.unwrap_or_else(|error| panic!("prepare deployment: {error}"));
+
+		assert_eq!(plan.program(), canonical(&explicit_program));
+		assert_eq!(plan.program_keypair(), canonical(&explicit_keypair));
+		assert_eq!(plan.rpc_url(), TESTNET_URL);
+	}
+
+	#[test]
+	fn configured_program_uses_foundation_metadata_target_directory() {
+		let fixture = Fixture::new();
+		let program_dir = fixture.root.join("programs/example");
+		fs::create_dir_all(&program_dir)
+			.unwrap_or_else(|error| panic!("create configured program: {error}"));
+		fs::rename(
+			fixture.root.join("Cargo.toml"),
+			program_dir.join("Cargo.toml"),
+		)
+		.unwrap_or_else(|error| panic!("move manifest: {error}"));
+		fs::rename(fixture.root.join("src"), program_dir.join("src"))
+			.unwrap_or_else(|error| panic!("move source: {error}"));
+		fs::write(
+			fixture.root.join("Pina.toml"),
+			"[project]\nprogram = \"programs/example\"\n",
+		)
+		.unwrap_or_else(|error| panic!("write Pina config: {error}"));
+		let project = Project::discover(&fixture.root)
+			.unwrap_or_else(|error| panic!("discover configured project: {error}"));
+		let deploy_dir = project.target_dir.join("deploy");
+		let program = deploy_dir.join("example_program.so");
+		let program_keypair = deploy_dir.join("example_program-keypair.json");
+		fs::create_dir_all(&deploy_dir)
+			.unwrap_or_else(|error| panic!("create metadata deploy directory: {error}"));
+		fs::write(&program, b"configured SBF")
+			.unwrap_or_else(|error| panic!("write configured artifact: {error}"));
+		write_keypair(&program_keypair);
+		let plan =
+			prepare_deployment(&fixture.request(DeploymentTarget::Cluster(Cluster::Localnet)))
+				.unwrap_or_else(|error| panic!("prepare configured deployment: {error}"));
+
+		assert_eq!(plan.project_root(), canonical(&fixture.root));
+		assert_eq!(plan.program(), canonical(&program));
+		assert_eq!(plan.program_keypair(), canonical(&program_keypair));
+	}
+
+	#[test]
+	fn custom_url_is_normalized_and_classified() {
+		let fixture = Fixture::new();
+		let local = prepare_deployment(
+			&fixture.request(DeploymentTarget::RpcUrl("http://localhost:8899".to_owned())),
+		)
+		.unwrap_or_else(|error| panic!("prepare local deployment: {error}"));
+		let remote = prepare_deployment(&fixture.request(DeploymentTarget::RpcUrl(
+			"https://rpc.example.com/solana".to_owned(),
+		)))
+		.unwrap_or_else(|error| panic!("prepare remote deployment: {error}"));
+
+		assert!(local.is_local());
+		assert_eq!(local.cluster(), "custom");
+		assert_eq!(local.rpc_url(), "http://localhost:8899/");
+		assert!(!remote.is_local());
+		assert!(remote.requires_mainnet_acknowledgement());
+		assert_eq!(remote.rpc_url(), "https://rpc.example.com/solana");
+
+		for loopback in ["http://127.0.0.1:8899", "http://[::1]:8899"] {
+			let plan =
+				prepare_deployment(&fixture.request(DeploymentTarget::RpcUrl(loopback.to_owned())))
+					.unwrap_or_else(|error| panic!("prepare loopback deployment: {error}"));
+			assert!(plan.is_local());
+		}
+	}
+
+	#[test]
+	fn accepted_custom_url_paths_remain_visible_in_plans_and_child_arguments() {
+		let fixture = Fixture::new();
+		let rpc_url = "https://rpc.example.com/operator-visible-path";
+		let plan =
+			prepare_deployment(&fixture.request(DeploymentTarget::RpcUrl(rpc_url.to_owned())))
+				.unwrap_or_else(|error| panic!("prepare remote deployment: {error}"));
+		let json = serde_json::to_string(&plan)
+			.unwrap_or_else(|error| panic!("serialize deployment plan: {error}"));
+		let commands = plan.commands();
+
+		assert_eq!(plan.rpc_url(), rpc_url);
+		assert!(plan.render_text().contains(rpc_url));
+		assert!(json.contains(rpc_url));
+		assert!(commands[0].args.iter().any(|argument| argument == rpc_url));
+	}
+
+	#[test]
+	fn custom_url_query_is_rejected_without_leaking_the_value() {
+		let fixture = Fixture::new();
+		let request = fixture.request(DeploymentTarget::RpcUrl(
+			"https://rpc.example.com/?api-key=sentinel-secret".to_owned(),
+		));
+		let error = prepare_deployment(&request).unwrap_err();
+		let request_debug = format!("{request:?}");
+		let error_display = error.to_string();
+		let error_debug = format!("{error:?}");
+
+		for public_output in [&request_debug, &error_display, &error_debug] {
+			assert!(!public_output.contains("sentinel-secret"));
+		}
+		assert!(error_display.contains("process arguments"));
+	}
+
+	#[test]
+	fn custom_url_rejects_unsupported_schemes_and_embedded_credentials() {
+		let fixture = Fixture::new();
+
+		for url in [
+			"not a URL",
+			"file:///tmp/rpc",
+			"https://user:secret@rpc.example.com",
+			"https://rpc.example.com/#fragment",
+			"https://rpc.example.com/\nstripped-by-url-parser",
+		] {
+			let error =
+				prepare_deployment(&fixture.request(DeploymentTarget::RpcUrl(url.to_owned())))
+					.unwrap_err();
+			assert!(matches!(error, DeployError::InvalidRpcUrl { .. }));
+		}
+
+		let error = require_rpc_host(None, "https://<missing>").unwrap_err();
+		assert!(matches!(error, DeployError::InvalidRpcUrl { .. }));
+	}
+
+	#[test]
+	fn project_discovery_reports_missing_malformed_and_invalid_sources() {
+		let fixture = Fixture::new();
+		let nested = fixture.root.join("src");
+		let mut nested_request = fixture.request(DeploymentTarget::Cluster(Cluster::Localnet));
+		nested_request.project = nested;
+		prepare_deployment(&nested_request)
+			.unwrap_or_else(|error| panic!("discover ancestor project: {error}"));
+
+		let missing = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let mut missing_request = fixture.request(DeploymentTarget::Cluster(Cluster::Localnet));
+		missing_request.project = missing.path().to_path_buf();
+		assert!(matches!(
+			prepare_deployment(&missing_request),
+			Err(DeployError::Project { .. })
+		));
+
+		fs::write(fixture.root.join("Cargo.toml"), "not valid TOML = [")
+			.unwrap_or_else(|error| panic!("write malformed manifest: {error}"));
+		assert!(matches!(
+			prepare_deployment(&fixture.request(DeploymentTarget::Cluster(Cluster::Localnet))),
+			Err(DeployError::Project { .. })
+		));
+
+		fs::write(
+			fixture.root.join("Cargo.toml"),
+			"[package]\nname = \"example-program\"\nversion = \"0.1.0\"\n",
+		)
+		.unwrap_or_else(|error| panic!("restore manifest: {error}"));
+		fs::write(
+			fixture.root.join("src/lib.rs"),
+			"pub fn missing_program_id() {}",
+		)
+		.unwrap_or_else(|error| panic!("write invalid source: {error}"));
+		assert!(matches!(
+			prepare_deployment(&fixture.request(DeploymentTarget::Cluster(Cluster::Localnet))),
+			Err(DeployError::Project { .. })
+		));
+	}
+
+	#[test]
+	fn project_discovery_rejects_nonexistent_start_and_directory_artifact() {
+		let fixture = Fixture::new();
+		let mut request = fixture.request(DeploymentTarget::Cluster(Cluster::Localnet));
+		request.project = fixture.root.join("missing");
+		assert!(matches!(
+			prepare_deployment(&request),
+			Err(DeployError::Project { .. })
+		));
+
+		fs::remove_file(&fixture.program)
+			.unwrap_or_else(|error| panic!("remove artifact: {error}"));
+		fs::create_dir(&fixture.program)
+			.unwrap_or_else(|error| panic!("create artifact directory: {error}"));
+		assert!(matches!(
+			prepare_deployment(&fixture.request(DeploymentTarget::Cluster(Cluster::Localnet))),
+			Err(DeployError::InvalidFile { .. })
+		));
+	}
+
+	#[test]
+	fn invalid_rpc_error_redacts_credentials_query_and_fragment() {
+		let fixture = Fixture::new();
+		let error = prepare_deployment(&fixture.request(DeploymentTarget::RpcUrl(
+			"https://user:sentinel-secret@rpc.example.com/?token=sentinel-secret#sentinel-secret"
+				.to_owned(),
+		)))
+		.unwrap_err();
+		let display = error.to_string();
+		let debug = format!("{error:?}");
+
+		assert!(!display.contains("sentinel-secret"));
+		assert!(!debug.contains("sentinel-secret"));
+		assert!(display.contains("<redacted>"));
+	}
+
+	#[test]
+	fn missing_project_artifact_and_keys_fail_closed() {
+		let fixture = Fixture::new();
+		fs::remove_file(&fixture.program).unwrap_or_else(|error| panic!("remove program: {error}"));
+		let error =
+			prepare_deployment(&fixture.request(DeploymentTarget::Cluster(Cluster::Localnet)))
+				.unwrap_err();
+		assert!(matches!(
+			error,
+			DeployError::InvalidFile {
+				kind: "program",
+				..
+			}
+		));
+
+		fs::write(&fixture.program, b"SBF")
+			.unwrap_or_else(|error| panic!("restore program: {error}"));
+		fs::remove_file(&fixture.program_keypair)
+			.unwrap_or_else(|error| panic!("remove keypair: {error}"));
+		let error =
+			prepare_deployment(&fixture.request(DeploymentTarget::Cluster(Cluster::Localnet)))
+				.unwrap_err();
+		assert!(matches!(
+			error,
+			DeployError::InvalidFile {
+				kind: "program keypair",
+				..
+			}
+		));
+	}
+
+	#[test]
+	fn malformed_keypairs_fail_closed() {
+		let fixture = Fixture::new();
+		assert!(matches!(
+			read_keypair(&fixture.root.join("missing-keypair.json"), "missing"),
+			Err(DeployError::InvalidKeypair { .. })
+		));
+
+		fs::write(&fixture.authority, "not JSON")
+			.unwrap_or_else(|error| panic!("write invalid JSON keypair: {error}"));
+		assert!(matches!(
+			prepare_deployment(&fixture.request(DeploymentTarget::Cluster(Cluster::Localnet))),
+			Err(DeployError::InvalidKeypair { .. })
+		));
+
+		fs::write(&fixture.authority, "[1, 2, 3]")
+			.unwrap_or_else(|error| panic!("write malformed keypair: {error}"));
+		let error =
+			prepare_deployment(&fixture.request(DeploymentTarget::Cluster(Cluster::Localnet)))
+				.unwrap_err();
+
+		assert!(matches!(
+			error,
+			DeployError::InvalidKeypair {
+				kind: "upgrade authority",
+				..
+			}
+		));
+
+		let inconsistent = serde_json::to_vec(&vec![1u8; 64])
+			.unwrap_or_else(|error| panic!("serialize inconsistent keypair: {error}"));
+		fs::write(&fixture.authority, inconsistent)
+			.unwrap_or_else(|error| panic!("write inconsistent keypair: {error}"));
+		let error =
+			prepare_deployment(&fixture.request(DeploymentTarget::Cluster(Cluster::Localnet)))
+				.unwrap_err();
+		assert!(matches!(error, DeployError::InvalidKeypair { .. }));
+	}
+
+	#[test]
+	fn oversized_and_non_regular_keypairs_fail_before_json_parsing() {
+		let fixture = Fixture::new();
+		fs::write(
+			&fixture.authority,
+			vec![b' '; (MAX_KEYPAIR_FILE_BYTES + 1) as usize],
+		)
+		.unwrap_or_else(|error| panic!("write oversized keypair: {error}"));
+		make_keypair_private(&fixture.authority);
+
+		assert!(matches!(
+			prepare_deployment(&fixture.request(DeploymentTarget::Cluster(Cluster::Localnet))),
+			Err(DeployError::InvalidKeypair {
+				kind: "upgrade authority",
+				..
+			})
+		));
+		assert!(matches!(
+			read_keypair(&fixture.root, "directory"),
+			Err(DeployError::InvalidKeypair { .. })
+		));
+		assert!(matches!(
+			keypair_metadata(
+				Err(io::Error::other("synthetic metadata failure")),
+				Path::new("keypair.json"),
+				"synthetic",
+			),
+			Err(DeployError::InvalidKeypair { .. })
+		));
+		assert!(matches!(
+			read_keypair_content(
+				io::Cursor::new(vec![0_u8; (MAX_KEYPAIR_FILE_BYTES + 1) as usize]),
+				Path::new("keypair.json"),
+				"synthetic",
+			),
+			Err(DeployError::InvalidKeypair { .. })
+		));
+		assert!(matches!(
+			read_keypair_content(FailingReader, Path::new("keypair.json"), "synthetic",),
+			Err(DeployError::InvalidKeypair { .. })
+		));
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn group_or_world_accessible_keypairs_fail_closed() {
+		use std::os::unix::fs::PermissionsExt as _;
+
+		let fixture = Fixture::new();
+		fs::set_permissions(&fixture.authority, fs::Permissions::from_mode(0o640))
+			.unwrap_or_else(|error| panic!("weaken keypair permissions: {error}"));
+		let error =
+			prepare_deployment(&fixture.request(DeploymentTarget::Cluster(Cluster::Localnet)))
+				.unwrap_err();
+
+		assert!(matches!(
+			error,
+			DeployError::InsecureKeypairPermissions {
+				kind: "upgrade authority",
+				mode: 0o640,
+				..
+			}
+		));
+		assert!(error.to_string().contains("chmod 600"));
+	}
+
+	#[test]
+	fn artifact_digest_streams_large_inputs_and_propagates_read_failures() {
+		let bytes = vec![7_u8; 2 * 64 * 1024 + 17];
+		let digest = digest_reader(io::Cursor::new(&bytes))
+			.unwrap_or_else(|error| panic!("digest large input: {error}"));
+		let expected: [u8; 32] = Sha256::digest(&bytes).into();
+
+		assert_eq!(digest, expected);
+		assert!(digest_reader(FailingReader).is_err());
+		assert!(matches!(
+			file_digest(Path::new("missing-artifact.so"), "program"),
+			Err(DeployError::InvalidFile { .. })
+		));
+		let directory =
+			tempfile::tempdir().unwrap_or_else(|error| panic!("create digest directory: {error}"));
+		assert!(matches!(
+			file_digest(directory.path(), "program"),
+			Err(DeployError::InvalidFile { .. })
+		));
+	}
+
+	#[test]
+	fn program_keypair_must_match_the_declared_program_id() {
+		let fixture = Fixture::new();
+		let signing_key = SigningKey::from_bytes(&[9u8; 32]);
+		let mut different = signing_key.to_bytes().to_vec();
+		different.extend_from_slice(&signing_key.verifying_key().to_bytes());
+		fs::write(
+			&fixture.program_keypair,
+			serde_json::to_vec(&different)
+				.unwrap_or_else(|error| panic!("serialize keypair: {error}")),
+		)
+		.unwrap_or_else(|error| panic!("write different keypair: {error}"));
+		let error =
+			prepare_deployment(&fixture.request(DeploymentTarget::Cluster(Cluster::Localnet)))
+				.unwrap_err();
+
+		assert!(matches!(error, DeployError::ProgramIdMismatch { .. }));
+	}
+
+	#[test]
+	fn virtual_workspace_is_rejected_as_ambiguous() {
+		let fixture = Fixture::new();
+		fs::write(
+			fixture.root.join("Cargo.toml"),
+			"[workspace]\nmembers = []\n",
+		)
+		.unwrap_or_else(|error| panic!("write workspace manifest: {error}"));
+		let error =
+			prepare_deployment(&fixture.request(DeploymentTarget::Cluster(Cluster::Localnet)))
+				.unwrap_err();
+
+		assert!(matches!(error, DeployError::Project { .. }));
+	}
+
+	#[test]
+	fn local_execution_needs_no_confirmation() {
+		let fixture = Fixture::new();
+		let plan =
+			prepare_deployment(&fixture.request(DeploymentTarget::Cluster(Cluster::Localnet)))
+				.unwrap_or_else(|error| panic!("prepare deployment: {error}"));
+		let mut runner = FakeRunner::default();
+		let mut confirmer = rejecting_confirmer();
+
+		execute_deployment(&plan, false, false, &mut runner, &mut confirmer)
+			.unwrap_or_else(|error| panic!("execute deployment: {error}"));
+
+		assert_eq!(runner.calls.len(), 1);
+		assert!(confirmer.prompts.is_empty());
+	}
+
+	#[test]
+	fn remote_execution_requires_confirmation_unless_yes() {
+		let fixture = Fixture::new();
+		let plan = prepare_deployment(&fixture.request(DeploymentTarget::Cluster(Cluster::Devnet)))
+			.unwrap_or_else(|error| panic!("prepare deployment: {error}"));
+		let mut runner = FakeRunner::default();
+		let mut confirmer = rejecting_confirmer();
+		let error =
+			execute_deployment(&plan, false, false, &mut runner, &mut confirmer).unwrap_err();
+		assert!(matches!(error, DeployError::ConfirmationRequired));
+		assert!(runner.calls.is_empty());
+		assert_eq!(confirmer.prompts.len(), 1);
+
+		execute_deployment(&plan, true, false, &mut runner, &mut confirmer)
+			.unwrap_or_else(|error| panic!("execute with yes: {error}"));
+		assert_eq!(runner.calls.len(), 1);
+	}
+
+	#[test]
+	fn unreadable_confirmation_fails_before_child_execution() {
+		let fixture = Fixture::new();
+		let plan = prepare_deployment(&fixture.request(DeploymentTarget::Cluster(Cluster::Devnet)))
+			.unwrap_or_else(|error| panic!("prepare deployment: {error}"));
+		let mut runner = FakeRunner::default();
+		let mut confirmer = FakeConfirmer {
+			confirmed: Err(io::Error::new(io::ErrorKind::BrokenPipe, "closed")),
+			prompts: Vec::new(),
+		};
+		let error =
+			execute_deployment(&plan, false, false, &mut runner, &mut confirmer).unwrap_err();
+
+		assert!(matches!(error, DeployError::ConfirmationRequired));
+		assert!(runner.calls.is_empty());
+	}
+
+	#[test]
+	fn terminal_confirmation_requires_the_exact_word() {
+		let mut output = Vec::new();
+		assert!(!read_deployment_confirmation(
+			"prompt",
+			false,
+			&mut "deploy\n".as_bytes(),
+			&mut output,
+		)
+		.unwrap_or_else(|error| panic!("non-terminal confirmation: {error}")));
+		assert!(output.is_empty());
+
+		assert!(
+			read_deployment_confirmation("prompt", true, &mut "deploy\n".as_bytes(), &mut output,)
+				.unwrap_or_else(|error| panic!("terminal confirmation: {error}"))
+		);
+		assert_eq!(output, b"prompt");
+
+		output.clear();
+		assert!(
+			!read_deployment_confirmation("prompt", true, &mut "yes\n".as_bytes(), &mut output,)
+				.unwrap_or_else(|error| panic!("rejected confirmation: {error}"))
+		);
+	}
+
+	#[test]
+	fn positive_confirmation_allows_remote_execution() {
+		let fixture = Fixture::new();
+		let plan =
+			prepare_deployment(&fixture.request(DeploymentTarget::Cluster(Cluster::Testnet)))
+				.unwrap_or_else(|error| panic!("prepare deployment: {error}"));
+		let mut runner = FakeRunner::default();
+		let mut confirmer = FakeConfirmer {
+			confirmed: Ok(true),
+			prompts: Vec::new(),
+		};
+
+		execute_deployment(&plan, false, false, &mut runner, &mut confirmer)
+			.unwrap_or_else(|error| panic!("execute deployment: {error}"));
+		assert_eq!(runner.calls.len(), 1);
+	}
+
+	#[test]
+	fn mainnet_needs_separate_acknowledgement() {
+		let fixture = Fixture::new();
+		let plan =
+			prepare_deployment(&fixture.request(DeploymentTarget::Cluster(Cluster::MainnetBeta)))
+				.unwrap_or_else(|error| panic!("prepare deployment: {error}"));
+		let mut runner = FakeRunner::default();
+		let mut confirmer = rejecting_confirmer();
+
+		let error =
+			execute_deployment(&plan, true, false, &mut runner, &mut confirmer).unwrap_err();
+		assert!(matches!(error, DeployError::MainnetNotAllowed));
+		assert!(runner.calls.is_empty());
+
+		execute_deployment(&plan, true, true, &mut runner, &mut confirmer)
+			.unwrap_or_else(|error| panic!("execute acknowledged mainnet: {error}"));
+		assert_eq!(runner.calls.len(), 1);
+
+		let custom = prepare_deployment(&fixture.request(DeploymentTarget::RpcUrl(
+			"https://rpc.example.com".to_owned(),
+		)))
+		.unwrap_or_else(|error| panic!("prepare custom remote: {error}"));
+		let error =
+			execute_deployment(&custom, true, false, &mut runner, &mut confirmer).unwrap_err();
+		assert!(matches!(error, DeployError::MainnetNotAllowed));
+		execute_deployment(&custom, true, true, &mut runner, &mut confirmer)
+			.unwrap_or_else(|error| panic!("execute acknowledged custom remote: {error}"));
+	}
+
+	#[test]
+	fn mainnet_acknowledgement_is_rejected_for_other_targets() {
+		let fixture = Fixture::new();
+		let plan = prepare_deployment(&fixture.request(DeploymentTarget::Cluster(Cluster::Devnet)))
+			.unwrap_or_else(|error| panic!("prepare deployment: {error}"));
+		let mut runner = FakeRunner::default();
+		let mut confirmer = rejecting_confirmer();
+		let error = execute_deployment(&plan, true, true, &mut runner, &mut confirmer).unwrap_err();
+
+		assert!(matches!(
+			error,
+			DeployError::UnexpectedMainnetAcknowledgement
+		));
+		assert!(runner.calls.is_empty());
+	}
+
+	#[test]
+	fn child_start_and_failure_stop_the_plan() {
+		let fixture = Fixture::new();
+		let request = fixture.request(DeploymentTarget::Cluster(Cluster::Localnet));
+		let plan = prepare_deployment(&request)
+			.unwrap_or_else(|error| panic!("prepare deployment: {error}"));
+		let mut confirmer = rejecting_confirmer();
+		let mut start_failure = FakeRunner {
+			calls: Vec::new(),
+			results: VecDeque::from([Err(io::Error::new(io::ErrorKind::NotFound, "missing"))]),
+		};
+		let error = execute_deployment(&plan, false, false, &mut start_failure, &mut confirmer)
+			.unwrap_err();
+		assert!(matches!(error, DeployError::CommandStart { .. }));
+		assert_eq!(start_failure.calls.len(), 1);
+
+		let mut child_failure = FakeRunner {
+			calls: Vec::new(),
+			results: VecDeque::from([Ok(CommandStatus {
+				success: false,
+				code: Some(7),
+			})]),
+		};
+		let error = execute_deployment(&plan, false, false, &mut child_failure, &mut confirmer)
+			.unwrap_err();
+		assert!(matches!(error, DeployError::CommandFailed { .. }));
+		assert_eq!(child_failure.calls.len(), 1);
+
+		let mut signaled_child = FakeRunner {
+			calls: Vec::new(),
+			results: VecDeque::from([Ok(CommandStatus {
+				success: false,
+				code: None,
+			})]),
+		};
+		let error = execute_deployment(&plan, false, false, &mut signaled_child, &mut confirmer)
+			.unwrap_err();
+		assert!(error.to_string().contains("terminated by signal"));
+		assert_eq!(signaled_child.calls.len(), 1);
+	}
+
+	#[test]
+	fn changed_inputs_are_rejected_immediately_before_deploy() {
+		let fixture = Fixture::new();
+		let plan =
+			prepare_deployment(&fixture.request(DeploymentTarget::Cluster(Cluster::Localnet)))
+				.unwrap_or_else(|error| panic!("prepare deployment: {error}"));
+		fs::write(&fixture.program, b"changed SBF")
+			.unwrap_or_else(|error| panic!("change program: {error}"));
+		let mut runner = FakeRunner::default();
+		let mut confirmer = rejecting_confirmer();
+		let error =
+			execute_deployment(&plan, false, false, &mut runner, &mut confirmer).unwrap_err();
+
+		assert!(matches!(error, DeployError::InputsChanged));
+		assert!(runner.calls.is_empty());
+
+		let fixture = Fixture::new();
+		let plan =
+			prepare_deployment(&fixture.request(DeploymentTarget::Cluster(Cluster::Localnet)))
+				.unwrap_or_else(|error| panic!("prepare deployment: {error}"));
+		fs::remove_file(&fixture.authority)
+			.unwrap_or_else(|error| panic!("remove authority: {error}"));
+		let error =
+			execute_deployment(&plan, false, false, &mut runner, &mut confirmer).unwrap_err();
+		assert!(matches!(error, DeployError::InvalidFile { .. }));
+
+		let fixture = Fixture::new();
+		let plan =
+			prepare_deployment(&fixture.request(DeploymentTarget::Cluster(Cluster::Localnet)))
+				.unwrap_or_else(|error| panic!("prepare deployment: {error}"));
+		fs::write(fixture.root.join("src/lib.rs"), "not valid Rust {")
+			.unwrap_or_else(|error| panic!("change source: {error}"));
+		let error =
+			execute_deployment(&plan, false, false, &mut runner, &mut confirmer).unwrap_err();
+		assert!(matches!(error, DeployError::Project { .. }));
+
+		assert!(matches!(
+			file_digest(&fixture.root.join("missing.so"), "program"),
+			Err(DeployError::InvalidFile { .. })
+		));
+	}
+
+	#[test]
+	fn human_plan_lists_every_resolved_input() {
+		let fixture = Fixture::new();
+		let plan =
+			prepare_deployment(&fixture.request(DeploymentTarget::Cluster(Cluster::Localnet)))
+				.unwrap_or_else(|error| panic!("prepare deployment: {error}"));
+		let output = plan.render_text();
+
+		for expected in [
+			plan.project_root(),
+			plan.program(),
+			plan.program_keypair(),
+			plan.upgrade_authority(),
+			plan.payer(),
+			plan.program_id(),
+			plan.rpc_url(),
+		] {
+			assert!(output.contains(&diagnostic_quote(expected)));
+		}
+		assert!(format!("{:?}", DeploymentTarget::Cluster(Cluster::Localnet)).contains("Localnet"));
+		assert!(format!("{plan:?}").contains("DeploymentPlan"));
+	}
+
+	#[test]
+	fn diagnostic_quoting_escapes_control_characters() {
+		assert_eq!(
+			diagnostic_quote("line\nbreak\ttab"),
+			r#""line\nbreak\ttab""#
+		);
+
+		let fixture = Fixture::new();
+		let mut plan =
+			prepare_deployment(&fixture.request(DeploymentTarget::Cluster(Cluster::Devnet)))
+				.unwrap_or_else(|error| panic!("prepare deployment: {error}"));
+		plan.program = "program\nwith-control.so".to_owned();
+		let output = plan.render_text();
+		let mut runner = FakeRunner::default();
+		let mut confirmer = rejecting_confirmer();
+		let error =
+			execute_deployment(&plan, false, false, &mut runner, &mut confirmer).unwrap_err();
+
+		assert!(matches!(error, DeployError::ConfirmationRequired));
+		assert!(!output.contains("program\nwith-control"));
+		assert!(output.contains(r#""program\nwith-control.so""#));
+		assert!(!confirmer.prompts[0].contains("program\nwith-control"));
+		assert!(confirmer.prompts[0].contains(r#""program\nwith-control.so""#));
+	}
+
+	#[test]
+	fn diagnostic_redaction_handles_every_url_shape() {
+		assert_eq!(redact_rpc_for_diagnostic("relative"), "relative");
+		assert_eq!(
+			redact_rpc_for_diagnostic("https://rpc.example.com/#sentinel"),
+			"https://rpc.example.com/#<redacted>"
+		);
+		assert_eq!(
+			redact_rpc_for_diagnostic("https://rpc.example.com/?key=sentinel#sentinel"),
+			"https://rpc.example.com/?<redacted>#<redacted>"
+		);
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn non_utf8_plan_path_fails_closed() {
+		use std::ffi::OsString;
+		use std::os::unix::ffi::OsStringExt;
+
+		let non_utf8 = PathBuf::from(OsString::from_vec(vec![0xff]));
+		assert!(matches!(
+			path_string(&non_utf8, "program"),
+			Err(DeployError::NonUtf8Path { .. })
+		));
+	}
+
+	fn canonical(path: &Path) -> String {
+		fs::canonicalize(path)
+			.unwrap_or_else(|error| panic!("canonicalize {}: {error}", path.display()))
+			.to_string_lossy()
+			.into_owned()
+	}
+
+	fn path(path: &Path) -> String {
+		path.to_string_lossy().into_owned()
+	}
+}

--- a/crates/pina_cli/src/lib.rs
+++ b/crates/pina_cli/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod build;
 pub mod codama;
 pub mod codegen;
+pub mod deploy;
 pub mod error;
 pub mod idl_metadata;
 pub mod init;

--- a/crates/pina_cli/src/main.rs
+++ b/crates/pina_cli/src/main.rs
@@ -63,6 +63,33 @@ fn main() {
 			command,
 			solana_verify,
 		} => run_verify(command, solana_verify),
+		Commands::Deploy {
+			project,
+			program,
+			build,
+			program_keypair,
+			upgrade_authority,
+			payer,
+			cluster,
+			dry_run,
+			json,
+			yes,
+			allow_mainnet,
+		} => {
+			run_deploy(
+				project,
+				program,
+				build,
+				program_keypair,
+				upgrade_authority,
+				payer,
+				&cluster,
+				dry_run,
+				json,
+				yes,
+				allow_mainnet,
+			);
+		}
 		Commands::Codama { command } => {
 			match command {
 				CodamaCommands::Generate {
@@ -372,7 +399,6 @@ fn run_build(
 			std::process::exit(1);
 		}
 	};
-
 	println!("{} Built {}", "✔".green(), output.package_name);
 	println!("  SBF  {}", output.sbf_artifact.display());
 	println!("  IDL  {}", output.idl.display());
@@ -459,6 +485,88 @@ fn run_dev(
 	if let Err(error) = pina_cli::workflow::dev_project(&options) {
 		eprintln!("{} {}", "Error".red().bold(), error);
 		std::process::exit(error.exit_code());
+	}
+}
+
+#[allow(clippy::fn_params_excessive_bools, clippy::too_many_arguments)]
+fn run_deploy(
+	project: PathBuf,
+	program: Option<PathBuf>,
+	build: bool,
+	program_keypair: Option<PathBuf>,
+	upgrade_authority: PathBuf,
+	payer: PathBuf,
+	cluster: &str,
+	dry_run: bool,
+	json: bool,
+	yes: bool,
+	allow_mainnet: bool,
+) {
+	let target = pina_cli::deploy::DeploymentTarget::from_cluster_arg(cluster);
+	let request = pina_cli::deploy::DeploymentRequest {
+		project,
+		program,
+		program_keypair,
+		upgrade_authority,
+		payer,
+		target,
+	};
+	let mut runner = pina_cli::deploy::SystemCommandRunner;
+	if let Err(error) = pina_cli::deploy::validate_deployment_target(&request.target) {
+		eprintln!("{} {}", "Error".red().bold(), error);
+		std::process::exit(1);
+	}
+
+	if build && let Err(error) = pina_cli::deploy::build_deployment_program(&request.project) {
+		eprintln!("{} {}", "Error".red().bold(), error);
+		std::process::exit(1);
+	}
+
+	let plan = match pina_cli::deploy::prepare_deployment(&request) {
+		Ok(plan) => plan,
+		Err(error) => {
+			eprintln!("{} {}", "Error".red().bold(), error);
+			std::process::exit(1);
+		}
+	};
+
+	if json {
+		#[rustfmt::skip]
+		let output = serde_json::to_string_pretty(&plan).unwrap_or_else(|error| panic!("deployment plans contain only JSON-compatible values: {error}"));
+		println!("{output}");
+	} else {
+		print!("{}", plan.render_text());
+	}
+
+	if dry_run {
+		return;
+	}
+
+	let mut confirmer = StdinDeploymentConfirmer;
+
+	if let Err(error) =
+		pina_cli::deploy::execute_deployment(&plan, yes, allow_mainnet, &mut runner, &mut confirmer)
+	{
+		eprintln!("{} {}", "Error".red().bold(), error);
+		std::process::exit(1);
+	}
+
+	println!("{} Deployment complete", "✔".green());
+}
+
+struct StdinDeploymentConfirmer;
+
+impl pina_cli::deploy::DeploymentConfirmer for StdinDeploymentConfirmer {
+	fn confirm(&mut self, prompt: &str) -> std::io::Result<bool> {
+		let stdin = std::io::stdin();
+		let stderr = std::io::stderr();
+		let is_terminal = stdin.is_terminal();
+		pina_cli::deploy::read_deployment_confirmation(
+			prompt,
+			is_terminal,
+			&mut stdin.lock(),
+			&mut stderr.lock(),
+		)
 	}
 }
 

--- a/crates/pina_cli/tests/cli_snapshots.rs
+++ b/crates/pina_cli/tests/cli_snapshots.rs
@@ -268,6 +268,13 @@ fn verify_status_help_snapshot() {
 }
 
 #[test]
+fn deploy_help_snapshot() {
+	let mut command = Command::new(env!("CARGO_BIN_EXE_pina"));
+	command.args(["deploy", "--help"]);
+	assert_cmd_snapshot!("deploy_help", command);
+}
+
+#[test]
 fn codama_help_snapshot() {
 	let mut command = Command::new(env!("CARGO_BIN_EXE_pina"));
 	command.args(["codama", "--help"]);

--- a/crates/pina_cli/tests/deploy_command.rs
+++ b/crates/pina_cli/tests/deploy_command.rs
@@ -1,0 +1,433 @@
+//! End-to-end CLI coverage for deployment planning and safety gates.
+
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+#[cfg(unix)]
+use std::process::Stdio;
+#[cfg(unix)]
+use std::time::Duration;
+#[cfg(unix)]
+use std::time::Instant;
+
+use ed25519_dalek::SigningKey;
+use tempfile::TempDir;
+
+struct ProjectFixture {
+	_temp: TempDir,
+	root: PathBuf,
+	program: PathBuf,
+	program_keypair: PathBuf,
+	authority: PathBuf,
+	payer: PathBuf,
+}
+
+impl ProjectFixture {
+	fn new() -> Self {
+		let temp = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir: {error}"));
+		let root = temp.path().join("project");
+		let deploy = root.join("target/deploy");
+		let program = deploy.join("deploy_fixture.so");
+		let program_keypair = deploy.join("deploy_fixture-keypair.json");
+		let authority = root.join("authority.json");
+		let payer = root.join("payer.json");
+		fs::create_dir_all(root.join("src"))
+			.unwrap_or_else(|error| panic!("create fixture source: {error}"));
+		fs::create_dir_all(&deploy)
+			.unwrap_or_else(|error| panic!("create fixture deploy directory: {error}"));
+		fs::write(
+			root.join("Cargo.toml"),
+			"[package]\nname = \"deploy-fixture\"\nversion = \"0.1.0\"\n",
+		)
+		.unwrap_or_else(|error| panic!("write fixture manifest: {error}"));
+		fs::write(&program, b"synthetic SBF")
+			.unwrap_or_else(|error| panic!("write fixture artifact: {error}"));
+		let program_id = write_keypair(&program_keypair, 3);
+		write_keypair(&authority, 5);
+		write_keypair(&payer, 7);
+		fs::write(
+			root.join("src/lib.rs"),
+			format!("use pina::prelude::*;\ndeclare_id!(\"{program_id}\");\n"),
+		)
+		.unwrap_or_else(|error| panic!("write fixture source: {error}"));
+
+		Self {
+			_temp: temp,
+			root,
+			program,
+			program_keypair,
+			authority,
+			payer,
+		}
+	}
+
+	fn command(&self) -> Command {
+		let mut command = Command::new(env!("CARGO_BIN_EXE_pina"));
+		command
+			.arg("deploy")
+			.arg("--project")
+			.arg(&self.root)
+			.arg("--upgrade-authority")
+			.arg(&self.authority)
+			.arg("--payer")
+			.arg(&self.payer);
+		command
+	}
+}
+
+fn write_keypair(path: &Path, seed: u8) -> String {
+	let signing_key = SigningKey::from_bytes(&[seed; 32]);
+	let public = signing_key.verifying_key().to_bytes();
+	let mut bytes = signing_key.to_bytes().to_vec();
+	bytes.extend_from_slice(&public);
+	fs::write(
+		path,
+		serde_json::to_vec(&bytes)
+			.unwrap_or_else(|error| panic!("serialize fixture keypair: {error}")),
+	)
+	.unwrap_or_else(|error| panic!("write fixture keypair: {error}"));
+	make_keypair_private(path);
+	bs58::encode(public).into_string()
+}
+
+#[cfg(unix)]
+fn make_keypair_private(path: &Path) {
+	use std::os::unix::fs::PermissionsExt as _;
+
+	fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+		.unwrap_or_else(|error| panic!("protect fixture keypair: {error}"));
+}
+
+#[cfg(not(unix))]
+fn make_keypair_private(_: &Path) {}
+
+fn canonical(path: &Path) -> String {
+	fs::canonicalize(path)
+		.unwrap_or_else(|error| panic!("canonicalize {}: {error}", path.display()))
+		.to_string_lossy()
+		.into_owned()
+}
+
+#[test]
+fn dry_run_json_is_machine_readable_and_starts_no_child() {
+	let fixture = ProjectFixture::new();
+	let output = fixture
+		.command()
+		.args([
+			"--cluster",
+			"https://rpc.example.com/solana",
+			"--dry-run",
+			"--json",
+		])
+		.output()
+		.unwrap_or_else(|error| panic!("run dry deployment: {error}"));
+
+	assert!(output.status.success());
+	assert!(output.stderr.is_empty());
+	let text = String::from_utf8_lossy(&output.stdout);
+	let plan = serde_json::from_slice::<serde_json::Value>(&output.stdout)
+		.unwrap_or_else(|error| panic!("parse deployment JSON: {error}"));
+	assert_eq!(plan["cluster"], "custom");
+	assert_eq!(plan["requires_mainnet_acknowledgement"], true);
+	assert_eq!(plan["program"], canonical(&fixture.program));
+	assert_eq!(plan["program_keypair"], canonical(&fixture.program_keypair));
+	assert!(text.contains("https://rpc.example.com/solana"));
+}
+
+#[test]
+fn rpc_query_values_are_rejected_without_leaking_them() {
+	let fixture = ProjectFixture::new();
+	let output = fixture
+		.command()
+		.args([
+			"--cluster",
+			"https://rpc.example.com/?token=sentinel-secret",
+			"--dry-run",
+		])
+		.output()
+		.unwrap_or_else(|error| panic!("run query deployment: {error}"));
+	let stderr = String::from_utf8_lossy(&output.stderr);
+
+	assert!(!output.status.success());
+	assert!(stderr.contains("process arguments"));
+	assert!(!stderr.contains("sentinel-secret"));
+}
+
+#[cfg(unix)]
+#[test]
+fn invalid_rpc_targets_fail_before_the_build_boundary() {
+	use std::os::unix::fs::PermissionsExt as _;
+
+	let fixture = ProjectFixture::new();
+	let bin = fixture.root.join("invalid-target-fake-bin");
+	let cargo = bin.join("cargo");
+	let marker = fixture.root.join("unexpected-build.txt");
+	fs::create_dir_all(&bin).unwrap_or_else(|error| panic!("create fake bin: {error}"));
+	fs::write(
+		&cargo,
+		"#!/bin/sh\nset -eu\nprintf 'invoked\\n' > \"$PINA_DEPLOY_BUILD_MARKER\"\nexit 97\n",
+	)
+	.unwrap_or_else(|error| panic!("write fake cargo: {error}"));
+	let mut permissions = fs::metadata(&cargo)
+		.unwrap_or_else(|error| panic!("stat fake cargo: {error}"))
+		.permissions();
+	permissions.set_mode(0o755);
+	fs::set_permissions(&cargo, permissions)
+		.unwrap_or_else(|error| panic!("make fake cargo executable: {error}"));
+	let existing_path = std::env::var_os("PATH").unwrap_or_default();
+	let paths = std::iter::once(bin)
+		.chain(std::env::split_paths(&existing_path))
+		.collect::<Vec<_>>();
+	let joined_path =
+		std::env::join_paths(paths).unwrap_or_else(|error| panic!("construct test PATH: {error}"));
+
+	for rpc_url in [
+		"https://user:sentinel-secret@rpc.example.com",
+		"https://rpc.example.com/?token=sentinel-secret",
+		"https://rpc.example.com/#sentinel-secret",
+		"https://rpc.example.com/\ncontrol",
+	] {
+		let output = fixture
+			.command()
+			.args(["--cluster", rpc_url, "--build"])
+			.env("PATH", &joined_path)
+			.env("PINA_DEPLOY_BUILD_MARKER", &marker)
+			.output()
+			.unwrap_or_else(|error| panic!("run invalid target deployment: {error}"));
+
+		assert!(!output.status.success());
+		assert!(
+			!marker.exists(),
+			"invalid target crossed the build boundary"
+		);
+		assert!(!String::from_utf8_lossy(&output.stderr).contains("sentinel-secret"));
+	}
+}
+
+#[test]
+fn clap_rejects_missing_target_and_mutating_dry_run_combinations() {
+	let fixture = ProjectFixture::new();
+	let missing_target = fixture
+		.command()
+		.output()
+		.unwrap_or_else(|error| panic!("run missing-target command: {error}"));
+	assert!(!missing_target.status.success());
+	assert!(String::from_utf8_lossy(&missing_target.stderr).contains("--cluster"));
+
+	for args in [
+		["--cluster", "devnet", "--dry-run", "--build"],
+		["--cluster", "devnet", "--dry-run", "--yes"],
+		["--cluster", "devnet", "--json", "--yes"],
+	] {
+		let output = fixture
+			.command()
+			.args(args)
+			.output()
+			.unwrap_or_else(|error| panic!("run invalid deploy command: {error}"));
+		assert!(!output.status.success());
+	}
+}
+
+#[test]
+fn non_tty_remote_deployment_fails_before_child_execution() {
+	let fixture = ProjectFixture::new();
+	let output = fixture
+		.command()
+		.args(["--cluster", "devnet"])
+		.output()
+		.unwrap_or_else(|error| panic!("run remote deployment: {error}"));
+
+	assert!(!output.status.success());
+	assert!(
+		String::from_utf8_lossy(&output.stderr).contains("remote deployment was not confirmed")
+	);
+}
+
+#[test]
+fn every_named_remote_cluster_can_be_planned_without_execution() {
+	let fixture = ProjectFixture::new();
+
+	for cluster in ["testnet", "mainnet-beta"] {
+		let output = fixture
+			.command()
+			.args(["--cluster", cluster, "--dry-run"])
+			.output()
+			.unwrap_or_else(|error| panic!("plan {cluster} deployment: {error}"));
+		assert!(output.status.success());
+		assert!(String::from_utf8_lossy(&output.stdout).contains(cluster));
+	}
+}
+
+#[test]
+fn deployment_resolution_errors_are_reported_without_starting_a_child() {
+	let fixture = ProjectFixture::new();
+	let output = fixture
+		.command()
+		.args([
+			"--cluster",
+			"localnet",
+			"--program",
+			"missing-program.so",
+			"--dry-run",
+		])
+		.output()
+		.unwrap_or_else(|error| panic!("run invalid deployment: {error}"));
+
+	assert!(!output.status.success());
+	assert!(String::from_utf8_lossy(&output.stderr).contains("program is not a readable"));
+}
+
+#[test]
+fn build_failure_stops_before_final_planning() {
+	let fixture = ProjectFixture::new();
+	let output = Command::new(env!("CARGO_BIN_EXE_pina"))
+		.arg("deploy")
+		.arg("--project")
+		.arg(fixture.root.join("missing-project"))
+		.arg("--upgrade-authority")
+		.arg(&fixture.authority)
+		.arg("--payer")
+		.arg(&fixture.payer)
+		.args(["--cluster", "localnet", "--build"])
+		.output()
+		.unwrap_or_else(|error| panic!("run failing build: {error}"));
+
+	assert!(!output.status.success());
+	assert!(String::from_utf8_lossy(&output.stderr).contains("deployment build failed"));
+	assert!(!String::from_utf8_lossy(&output.stdout).contains("Deployment plan"));
+}
+
+#[cfg(unix)]
+#[test]
+fn local_deployment_passes_the_exact_modeled_arguments_to_solana() {
+	use std::os::unix::fs::PermissionsExt;
+
+	let fixture = ProjectFixture::new();
+	let bin = fixture.root.join("fake-bin");
+	let solana = bin.join("solana");
+	let log = fixture.root.join("solana-args.txt");
+	fs::create_dir_all(&bin).unwrap_or_else(|error| panic!("create fake bin: {error}"));
+	fs::write(
+		&solana,
+		"#!/bin/sh\nset -eu\npwd > \"$PINA_DEPLOY_TEST_CWD\"\nprintf '%s\\n' \"$@\" > \
+		 \"$PINA_DEPLOY_TEST_LOG\"\n",
+	)
+	.unwrap_or_else(|error| panic!("write fake solana: {error}"));
+	let mut permissions = fs::metadata(&solana)
+		.unwrap_or_else(|error| panic!("stat fake solana: {error}"))
+		.permissions();
+	permissions.set_mode(0o755);
+	fs::set_permissions(&solana, permissions)
+		.unwrap_or_else(|error| panic!("make fake solana executable: {error}"));
+	let existing_path = std::env::var_os("PATH").unwrap_or_default();
+	let paths = std::iter::once(bin.clone())
+		.chain(std::env::split_paths(&existing_path))
+		.collect::<Vec<_>>();
+	let joined_path =
+		std::env::join_paths(paths).unwrap_or_else(|error| panic!("construct test PATH: {error}"));
+	let output = fixture
+		.command()
+		.args(["--cluster", "localnet"])
+		.env("PATH", joined_path)
+		.env("PINA_DEPLOY_TEST_CWD", fixture.root.join("solana-cwd.txt"))
+		.env("PINA_DEPLOY_TEST_LOG", &log)
+		.output()
+		.unwrap_or_else(|error| panic!("run local deployment: {error}"));
+
+	assert!(
+		output.status.success(),
+		"deployment failed: {}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+	let args = fs::read_to_string(&log)
+		.unwrap_or_else(|error| panic!("read fake Solana arguments: {error}"));
+	let expected = format!(
+		"program\ndeploy\n{}\n--program-id\n{}\n--upgrade-authority\n{}\n--fee-payer\n{}\n--url\nhttp://127.0.0.1:8899\n",
+		canonical(&fixture.program),
+		canonical(&fixture.program_keypair),
+		canonical(&fixture.authority),
+		canonical(&fixture.payer),
+	);
+	assert_eq!(args, expected);
+	let cwd = fs::read_to_string(fixture.root.join("solana-cwd.txt"))
+		.unwrap_or_else(|error| panic!("read fake Solana working directory: {error}"));
+	assert_eq!(cwd.trim(), canonical(&fixture.root));
+}
+
+#[cfg(unix)]
+#[test]
+fn solana_child_receives_eof_while_pina_stdin_remains_open() {
+	use std::os::unix::fs::PermissionsExt as _;
+
+	let fixture = ProjectFixture::new();
+	let bin = fixture.root.join("stdin-fake-bin");
+	let solana = bin.join("solana");
+	let marker = fixture.root.join("solana-stdin-eof.txt");
+	fs::create_dir_all(&bin).unwrap_or_else(|error| panic!("create fake bin: {error}"));
+	fs::write(
+		&solana,
+		"#!/bin/sh\nset -eu\nif IFS= read -r value; then exit 41; fi\nprintf 'eof\\n' > \
+		 \"$PINA_DEPLOY_STDIN_MARKER\"\n",
+	)
+	.unwrap_or_else(|error| panic!("write stdin-probing Solana: {error}"));
+	let mut permissions = fs::metadata(&solana)
+		.unwrap_or_else(|error| panic!("stat fake solana: {error}"))
+		.permissions();
+	permissions.set_mode(0o755);
+	fs::set_permissions(&solana, permissions)
+		.unwrap_or_else(|error| panic!("make fake solana executable: {error}"));
+	let existing_path = std::env::var_os("PATH").unwrap_or_default();
+	let paths = std::iter::once(bin)
+		.chain(std::env::split_paths(&existing_path))
+		.collect::<Vec<_>>();
+	let joined_path =
+		std::env::join_paths(paths).unwrap_or_else(|error| panic!("construct test PATH: {error}"));
+	let mut child = fixture
+		.command()
+		.args(["--cluster", "localnet"])
+		.env("PATH", joined_path)
+		.env("PINA_DEPLOY_STDIN_MARKER", &marker)
+		.stdin(Stdio::piped())
+		.stdout(Stdio::piped())
+		.stderr(Stdio::piped())
+		.spawn()
+		.unwrap_or_else(|error| panic!("spawn deployment with held-open stdin: {error}"));
+	let deadline = Instant::now() + Duration::from_secs(3);
+
+	let timed_out = loop {
+		if child
+			.try_wait()
+			.unwrap_or_else(|error| panic!("poll deployment: {error}"))
+			.is_some()
+		{
+			break false;
+		}
+
+		if Instant::now() >= deadline {
+			drop(child.stdin.take());
+			break true;
+		}
+
+		std::thread::sleep(Duration::from_millis(10));
+	};
+
+	let output = child
+		.wait_with_output()
+		.unwrap_or_else(|error| panic!("collect deployment: {error}"));
+	assert!(
+		!timed_out,
+		"Solana inherited Pina stdin and blocked; stderr: {}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+	assert!(
+		output.status.success(),
+		"deployment failed: {}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+	assert_eq!(
+		fs::read_to_string(&marker)
+			.unwrap_or_else(|error| panic!("read stdin EOF marker: {error}")),
+		"eof\n"
+	);
+}

--- a/crates/pina_cli/tests/snapshots/cli_snapshots__deploy_help.snap
+++ b/crates/pina_cli/tests/snapshots/cli_snapshots__deploy_help.snap
@@ -1,0 +1,77 @@
+---
+source: crates/pina_cli/tests/cli_snapshots.rs
+info:
+  program: pina
+  args:
+    - deploy
+    - "--help"
+---
+success: true
+exit_code: 0
+----- stdout -----
+Deploy a compiled Pina program through the Solana CLI.
+
+Resolves the program artifact from a Cargo program crate or an explicit --program path, validates every keypair, prints the complete plan, and invokes `solana program deploy`. A cluster or RPC URL is always required. Remote writes require confirmation or --yes; mainnet also requires --allow-mainnet. Custom remote URLs require the same acknowledgement because their cluster identity cannot be proven.
+
+Usage: pina deploy [OPTIONS] --upgrade-authority <KEYPAIR> --payer <KEYPAIR> --cluster <CLUSTER|URL>
+
+Options:
+  -p, --project <DIR>
+          Directory used for Pina.toml or Cargo metadata project discovery
+
+      --program <PROGRAM.SO>
+          Existing SBF shared object. Conflicts with --build
+
+      --build
+          Run Pina's project-aware SBF build before final deployment planning
+
+      --program-keypair <KEYPAIR>
+          Keypair whose public key is the deployed program address
+
+      --upgrade-authority <KEYPAIR>
+          Keypair authorized to upgrade the deployed program
+
+      --payer <KEYPAIR>
+          Keypair that pays the deployment transaction fees
+
+      --cluster <CLUSTER|URL>
+          Named cluster or explicit HTTP(S) RPC URL. No target is selected by default
+
+      --dry-run
+          Print the resolved deployment plan without building or deploying
+
+      --json
+          Emit the dry-run plan as JSON. Requires --dry-run
+
+      --yes
+          Skip the remote deployment confirmation prompt
+
+      --allow-mainnet
+          Acknowledge that mainnet-beta or a custom remote endpoint can affect real assets
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+Examples:
+  pina deploy --cluster localnet \
+    --payer ~/.config/solana/id.json \
+    --upgrade-authority ~/.config/solana/id.json
+  pina deploy --build --cluster devnet \
+    --payer ./keys/devnet-payer.json \
+    --upgrade-authority ./keys/devnet-authority.json
+  pina deploy --program ./artifacts/my_program.so \
+    --program-keypair ./keys/my_program.json \
+    --cluster http://127.0.0.1:8899 \
+    --payer ./keys/local-payer.json \
+    --upgrade-authority ./keys/local-authority.json --dry-run --json
+
+Safety:
+  No cluster is selected by default. --cluster accepts a named cluster or explicit RPC URL.
+  Custom URL user information, queries, and fragments are rejected. Accepted hosts and paths
+  remain visible in plans and process listings, so never put a secret anywhere in the URL.
+  Prefer a named cluster when possible.
+  Remote deployment prompts for the word deploy; use --yes only in reviewed automation.
+  Mainnet and custom remote deployment additionally require --allow-mainnet.
+  --dry-run never builds or deploys and --json is available only with --dry-run.
+
+----- stderr -----

--- a/crates/pina_cli/tests/snapshots/cli_snapshots__root_help.snap
+++ b/crates/pina_cli/tests/snapshots/cli_snapshots__root_help.snap
@@ -10,7 +10,7 @@ exit_code: 0
 ----- stdout -----
 Build, test, inspect, and generate artifacts for Pina Solana programs.
 
-Use 'pina init' to start a program, 'pina build' for its SBF binary and IDL, 'pina test' for SBF integration, 'pina test --unit' for the fast native/Mollusk loop, 'pina dev' for a persistent Surfpool network, 'pina generate' for selected client ecosystems, and 'pina verify' for deployed-program verification. Low-level IDL, profiling, terminal documentation, and the legacy repository-wide Codama workflow remain available.
+Use 'pina init' to start a program, 'pina build' for its SBF binary and IDL, 'pina test' for SBF integration, 'pina test --unit' for the fast native/Mollusk loop, 'pina dev' for a persistent Surfpool network, 'pina generate' for selected client ecosystems, 'pina deploy' for explicit cluster deployment, and 'pina verify' for deployed-program verification. Low-level IDL, profiling, terminal documentation, and the legacy repository-wide Codama workflow remain available.
 
 Usage: pina <COMMAND>
 
@@ -33,6 +33,8 @@ Commands:
           Profile compute-unit costs in a compiled SBF program
   verify
           Verify deployed programs and publish source-build records
+  deploy
+          Deploy a compiled Pina program through the Solana CLI
   codama
           Run Codama IDL and client-generation workflows
   help
@@ -54,6 +56,7 @@ Examples:
   pina generate --client rust --client typescript
   pina idl --path ./programs/counter_program --output ./idls/counter_program.json
   pina profile ./target/deploy/counter_program.so --json
+  pina deploy --cluster localnet --payer ~/.config/solana/id.json --upgrade-authority ~/.config/solana/id.json --dry-run
 
 Agent discovery:
   Run 'pina <command> --help' for command-specific inputs, outputs, and examples.

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -14,6 +14,7 @@
   - [Generate an IDL](./cli/idl.md)
   - [Read Terminal Docs](./cli/docs.md)
   - [Profile an SBF Program](./cli/profile.md)
+  - [Deploy a Program](./cli/deploy.md)
   - [Generate Codama Clients](./cli/codama-generate.md)
   - [Automation and Agent Usage](./cli/automation.md)
 - [Agent Skill](./agent-skill.md)

--- a/docs/src/cli/automation.md
+++ b/docs/src/cli/automation.md
@@ -69,6 +69,18 @@ pina profile ./target/deploy/counter_program.so --json > /tmp/profile.json
 jq -e '.functions | type == "array"' /tmp/profile.json
 ```
 
+Inspect a deployment without executing a child process:
+
+```bash
+pina deploy \
+  --project ./programs/counter_program \
+  --cluster devnet \
+  --upgrade-authority ./keys/devnet-authority.json \
+  --payer ./keys/devnet-payer.json \
+  --dry-run --json > /tmp/deploy-plan.json
+jq -e '.program_id and .commands' /tmp/deploy-plan.json
+```
+
 ## Automation rules
 
 - Check the exit status before consuming output.
@@ -87,6 +99,9 @@ jq -e '.functions | type == "array"' /tmp/profile.json
 - Use `pina test --unit` when only native Rust or Mollusk tests are required.
 - Treat a missing `tests/surfpool` package or built `.so` as a failed integration setup, not a skip.
 - `pina dev` is offline unless `--network` or a credential-free HTTP(S) `--rpc-url` is explicitly supplied. The URL is visible in Surfpool's process arguments, so never place a secret anywhere in it.
+- Always inspect `deploy --dry-run --json` before remote automation.
+- Never pass `deploy --yes` until the exact target, program ID, authority, payer, and command plan have been reviewed.
+- Never put a secret anywhere in a custom deploy RPC URL. Pina rejects user information, queries, and fragments, but accepted hosts and paths remain visible in plan output and process listings because Solana receives the endpoint through `--url`. Prefer named clusters.
 
 ## Stable verification
 

--- a/docs/src/cli/deploy.md
+++ b/docs/src/cli/deploy.md
@@ -1,0 +1,62 @@
+# `pina deploy`
+
+`pina deploy` resolves and validates a Pina program deployment, displays the complete operation, and delegates the write to the Solana CLI. It never inherits a cluster from Solana configuration.
+
+```text
+pina deploy [OPTIONS] --upgrade-authority <KEYPAIR> --payer <KEYPAIR> \
+  --cluster <CLUSTER|URL>
+```
+
+Run `pina deploy --help` for the authoritative option list.
+
+## Safe planning
+
+Review a deployment without building, contacting an RPC endpoint, or invoking the Solana CLI:
+
+```bash
+pina deploy \
+  --project ./programs/counter_program \
+  --cluster devnet \
+  --upgrade-authority ./keys/devnet-authority.json \
+  --payer ./keys/devnet-payer.json \
+  --dry-run
+```
+
+Use `--dry-run --json` for agents and CI. The plan includes the canonical project, artifact, program keypair, declared program ID, upgrade authority, fee payer, cluster, complete RPC endpoint, acknowledgement policy, and ordered command argument vector. Custom URL hosts and paths are intentionally preserved, so they must not contain secrets.
+
+Dry runs perform no build or deployment. Consequently, `--dry-run` conflicts with `--build`, `--yes`, and `--allow-mainnet`.
+
+## Input resolution
+
+`--project` accepts a project directory or any directory below it. Pina uses the same project discovery as `pina build`: the nearest ancestor `Pina.toml`, then unambiguous Cargo metadata as a fallback. The library target name and Cargo metadata target directory resolve:
+
+- `<cargo-target>/deploy/<lib-name>.so`
+- `<cargo-target>/deploy/<lib-name>-keypair.json`
+
+Use `--program` or `--program-keypair` to override either conventional path. `--program` conflicts with `--build`. Every resolved file is canonicalized and must be a regular file. Keypair files cannot exceed 4 KiB and must contain a valid 64-byte Solana JSON keypair. On Unix, Pina rejects keypairs with any group or world permission bits; `chmod 600 <keypair>` is the recommended mode. Pina cannot inspect equivalent Windows ACL policy, so Windows operators must restrict keypair access with the operating system's ACL tooling. The program keypair address must match the program's `declare_id!`; deploy never generates or silently replaces an identity.
+
+`--upgrade-authority` and `--payer` are always explicit. Pina does not inherit wallet paths from Solana configuration and does not store deployment credentials in `Pina.toml`.
+
+## Targets and confirmation
+
+One explicit target is required:
+
+- `--cluster localnet`
+- `--cluster devnet`
+- `--cluster testnet`
+- `--cluster mainnet-beta`
+- `--cluster <HTTP(S)-URL>`
+
+Custom endpoints reject URL user information, query parameters, and fragments. The Solana CLI accepts its RPC endpoint through `--url`, so every accepted host and path is visible in the dry-run plan, confirmation, and operating-system process listings. Pina cannot distinguish a provider token embedded in a path from a legitimate endpoint path. Never put a secret anywhere in a custom URL; prefer a named cluster when possible.
+
+Local endpoints execute after displaying the plan. Every remote endpoint prompts the operator to type `deploy`. Non-interactive remote deployment fails before starting a child process unless `--yes` is supplied. Named mainnet and every custom remote endpoint additionally require `--allow-mainnet`, because Pina cannot prove which Solana cluster an arbitrary URL serves. The flag is rejected for localnet, devnet, testnet, and custom loopback endpoints.
+
+## Build and external requirements
+
+Pina validates and redacts the explicit target before project discovery or any build begins. `--build` then invokes the same in-process project build workflow as `pina build` before Pina resolves and displays the final deployment plan. It does not search `PATH` for another Pina executable. A failed build stops immediately. After confirmation, Pina revalidates the declared program ID, every keypair, and streamed SHA-256 fingerprints of the artifact and keypair files immediately before starting Solana. Changes detected by that final validation require the operator to review a new plan. As with any path-based external CLI handoff, a privileged local process could still replace a file between Pina's final validation and Solana opening it; keep deployment directories and keypairs writable only by the deploying user.
+
+Deployment requires the external `solana` executable from Agave on `PATH`. Pina runs every modeled command from the resolved project root, passes an argument vector directly—never a shell command string—and closes the child's standard input after Pina handles confirmation. The npm-distributed Pina binary supports platforms on which Agave may not be available, so verify the local Agave installation before depending on deployment automation.
+
+## Output contract
+
+Without `--json`, stdout contains the plan and completion status. Diagnostics, confirmation, and child failures use stderr. `--dry-run --json` emits one JSON object to stdout and no progress text. The full accepted RPC host and path appear in both formats and in the Solana argument plan. Missing files, malformed keypairs, program-ID mismatches, ambiguous projects, invalid RPC URLs, rejected confirmations, missing executables, signaled children, and non-zero child exits all fail closed.

--- a/docs/src/cli/index.md
+++ b/docs/src/cli/index.md
@@ -1,6 +1,6 @@
 # Pina CLI
 
-The `pina` command scaffolds programs, extracts Codama IDLs, renders clients, reads bundled reference material, and profiles compiled SBF binaries. It is designed for both interactive use and scripted or agent-driven discovery.
+The `pina` command scaffolds programs, extracts Codama IDLs, renders clients, reads bundled reference material, profiles compiled SBF binaries, and plans explicit deployments. It is designed for both interactive use and scripted or agent-driven discovery.
 
 ## Install
 
@@ -40,6 +40,7 @@ The shortcut runs `cargo run -p pina_cli -- ...` against the checked-out source.
 | [`pina idl`](./idl.md)                         | Extract a Codama root-node IDL                               | JSON                                      |
 | [`pina docs`](./docs.md)                       | List or render bundled terminal docs                         | Terminal text                             |
 | [`pina profile`](./profile.md)                 | Estimate per-function SBF compute cost                       | Text or JSON                              |
+| [`pina deploy`](./deploy.md)                   | Plan and execute an explicit cluster deployment              | Plan or JSON                              |
 | [`pina codama generate`](./codama-generate.md) | Generate IDLs and Rust, JavaScript, and Dart clients         | Generated directories                     |
 
 ## Discover the interface
@@ -59,6 +60,7 @@ pina idl --help
 pina docs --help
 pina init --help
 pina profile --help
+pina deploy --help
 pina codama --help
 pina codama generate --help
 ```
@@ -79,6 +81,7 @@ Long help includes the input contract, output behavior, defaults, and copyable e
 | `test`            | Child test-runner output          | Build output and errors             |
 | `dev`             | Surfpool UI and logs              | Build output and errors             |
 | `profile`         | Report when `--output` is omitted | Errors                              |
+| `deploy`          | Inspectable plan and completion   | Confirmation, progress, errors      |
 | `codama generate` | Completion summary                | Errors and renderer failures        |
 
 Successful commands exit with code `0`. Operational failures exit with code `1`. Verification hash mismatches exit with code `2`. Invalid command-line syntax is rejected by Clap with a non-zero usage error before an operation begins.

--- a/docs/src/crates-and-features.md
+++ b/docs/src/crates-and-features.md
@@ -86,6 +86,7 @@ Commands:
 - `pina idl --path <dir>` — generate a Codama IDL JSON from a Pina program
 - `pina docs [topic]` — list or render bundled terminal documentation
 - `pina profile <path.so>` — profile a compiled SBF binary statically
+- `pina deploy` — plan and execute an explicit cluster deployment
 - `pina codama generate` — run the legacy repository-wide client workflow
 
 <!-- {/pinaCliCommands} -->

--- a/packages/pina__skill/references/cli-and-codegen.md
+++ b/packages/pina__skill/references/cli-and-codegen.md
@@ -18,6 +18,7 @@ pina init --help
 pina test --help
 pina dev --help
 pina profile --help
+pina deploy --help
 pina codama generate --help
 ```
 
@@ -156,3 +157,18 @@ pina verify record \
 Use `pina verify record --export [AUTHORITY] --output verification.tx` when another signer or multisig must submit the transaction. Export performs Pina's deployed-hash preflight but never submits or rebuilds the repository, does not require `--yes` or `--acknowledge-mainnet`, and writes only the validated base58 or base64 transaction payload. Remote verification begins only after the exported transaction is submitted.
 
 `pina verify submit --program-id <ADDRESS> --uploader <ADDRESS>` submits an existing record to the official mainnet remote verifier. `pina verify status --program-id <ADDRESS>` is the corresponding read-only mainnet status query. Never place credentials in an RPC URL; the URL is necessarily visible in child-process arguments.
+
+## Safe deployment
+
+Plan deployments before permitting a write:
+
+```sh
+pina deploy --cluster devnet \
+  --upgrade-authority ./keys/devnet-authority.json \
+  --payer ./keys/devnet-payer.json \
+  --dry-run --json
+```
+
+The cluster is always explicit. Pina never inherits a Solana CLI target or wallet, and deploy never creates a program identity. Conventional artifacts are `<cargo-target>/deploy/<library-name>.so` and `<cargo-target>/deploy/<library-name>-keypair.json`; override either path only when the plan requires it. Review the program ID and complete argument vector in the plan. Keep keypairs below 4 KiB and owner-private; on Unix use mode `0600`, while Windows ACLs must be restricted with operating-system tooling.
+
+Remote execution requires an interactive `deploy` confirmation or `--yes`. Named mainnet and custom remote endpoints also require `--allow-mainnet`. Custom URL user information, queries, and fragments are rejected, but accepted hosts and paths remain visible in plan output and process listings. Never put a secret anywhere in the URL; prefer a named cluster. Use `--build` when the canonical artifact must be refreshed before the final plan. Deployment requires the external Agave `solana` executable on `PATH`.

--- a/templates/pina-overview.t.md
+++ b/templates/pina-overview.t.md
@@ -172,6 +172,7 @@ cargo nextest run  # Faster parallel test execution
 - `pina idl --path <dir>` — generate a Codama IDL JSON from a Pina program
 - `pina docs [topic]` — list or render bundled terminal documentation
 - `pina profile <path.so>` — profile a compiled SBF binary statically
+- `pina deploy` — plan and execute an explicit cluster deployment
 - `pina codama generate` — run the legacy repository-wide client workflow
 
 <!-- {/pinaCliCommands} -->


### PR DESCRIPTION
## Summary

- add project-aware `pina deploy` with canonical artifact and program-keypair discovery
- support explicit local, named remote, and custom RPC targets with dry-run plans
- integrate optional in-process `pina build` before final deployment-plan resolution
- document cluster policy, authority/payer behavior, keypair requirements, dry runs, confirmations, and automation

## Safety

- requires explicit cluster selection and deliberate acknowledgement for mainnet-risk endpoints
- refuses non-interactive remote deployment without `--yes`
- cryptographically validates bounded private keypair files and the program `declare_id!`
- redacts RPC data, uses structured argv without a shell, and streams artifact hashing
- revalidates artifact and keypair fingerprints immediately before invoking Solana
- tests use a fake Solana executable; no real deployment was performed

## Verification

- full `pina_cli` tests and docs
- focused deploy units 32/32 and CLI integrations 8/8
- `lint:all`, strict Clippy, `cargo deny`, Monochange validation, and affected-package policy
- exact patch coverage: **1,374/1,374 executable Rust lines (100%)**
- independent architecture/security review cleared commit `22bc272de3a8631f2778ada2609a7206251db72f`

Created on behalf of Ifiok Jr. (`@ifiokjr`) using Codex (GPT-5, high reasoning).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `pina deploy` for planning and executing program deployments to explicit clusters or custom RPC endpoints.
  * Added text and machine-readable JSON dry-run plans.
  * Added optional project-aware builds and deployment confirmation safeguards.
  * Added validation for artifacts, program IDs, keypairs, and RPC URLs.

* **Documentation**
  * Added CLI help, deployment guides, automation guidance, and deployment references.

* **Tests**
  * Added coverage for dry runs, validation, confirmations, local and remote deployments, and command execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->