### PR TITLE
feat(cli): add deployed program verification workflows

### DIFF
--- a/.changeset/verifiable-program-records.md
+++ b/.changeset/verifiable-program-records.md
@@ -1,0 +1,8 @@
+---
+pina_cli: feat
+pina_skill: feat
+---
+
+# Verify deployed programs and record reproducible source
+
+Add read-only deployed executable comparisons, content-addressed build-record publication, multisig transaction export, and mainnet remote-verifier submission and status workflows through the pinned official `solana-verify` 0.5.1 interface. The CLI validates provenance, executable hashes, keypairs, clusters, confirmations, upstream mismatch output, and exported transaction encoding before reporting success.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1415,6 +1415,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1441,6 +1452,27 @@ dependencies = [
  "rfc6979",
  "signature",
  "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "sha2 0.10.9",
+ "subtle",
 ]
 
 [[package]]
@@ -1671,6 +1703,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "fs2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1831,10 +1872,114 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
+
+[[package]]
+name = "icu_properties"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
+
+[[package]]
+name = "icu_provider"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -2078,6 +2223,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "litrs"
@@ -2433,6 +2584,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "percentage"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2493,10 +2650,13 @@ name = "pina_cli"
 version = "0.9.0"
 dependencies = [
  "atomic-write-file",
+ "base64",
+ "bs58",
  "cargo_metadata",
  "clap",
  "codama-nodes",
  "comfy-table",
+ "ed25519-dalek",
  "fs2",
  "heck",
  "insta",
@@ -2511,11 +2671,13 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "solana-address",
  "syn 3.0.3",
  "tempfile",
  "termimad",
  "thiserror 2.0.20",
  "toml 1.1.4+spec-1.1.0",
+ "url",
  "walkdir",
 ]
 
@@ -2664,6 +2826,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -4412,6 +4583,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "staking-rewards-program-client"
 version = "0.0.0"
 dependencies = [
@@ -4487,6 +4664,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4586,6 +4774,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -4834,6 +5032,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5009,12 +5225,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "writeable"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
 ]
 
 [[package]]
@@ -5035,6 +5280,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
 ]
 
 [[package]]
@@ -5077,6 +5343,39 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,10 +90,13 @@ rust-version = "1.89.0"
 
 [workspace.dependencies]
 atomic-write-file = { default-features = false, version = "^0.3" }
+base64 = "0.22.1"
+bs58 = "0.5.1"
 cargo_metadata = { default-features = false, version = "^0.23" }
 clap = { default-features = false, version = "^4", features = ["derive", "std"] }
 codama-nodes = { default-features = false, version = "0.11.0" }
 darling = { default-features = false, version = "0.24.0" }
+ed25519-dalek = { version = "2.2.0", default-features = false }
 fs2 = { default-features = false, version = "^0.4" }
 heck = { default-features = false, version = "^0.5" }
 insta = { default-features = false, version = "^1" }
@@ -131,6 +134,7 @@ thiserror = { default-features = false, version = "^2" }
 tokio = { default-features = false, version = "^1" }
 toml = { default-features = false, version = "^1", features = ["parse", "serde"] }
 trybuild = { default-features = false, version = "^1" }
+url = "2.5.4"
 walkdir = { default-features = false, version = "^2" }
 zeropod = { default-features = false, version = "0.3.5", features = ["solana-address", "solana-program-error"] }
 

--- a/crates/pina_cli/Cargo.toml
+++ b/crates/pina_cli/Cargo.toml
@@ -17,10 +17,13 @@ doc = false
 
 [dependencies]
 atomic-write-file = { workspace = true }
+base64 = { workspace = true }
+bs58 = { workspace = true }
 cargo_metadata = { workspace = true, default-features = true }
 clap = { workspace = true, default-features = true }
 codama-nodes = { workspace = true, default-features = true }
 comfy-table = "8.0.0"
+ed25519-dalek = { workspace = true }
 fs2 = { workspace = true, default-features = true }
 heck = { workspace = true, default-features = true }
 owo-colors = "4.0"
@@ -32,11 +35,13 @@ rayon = "1.10"
 serde = { workspace = true, features = ["derive"], default-features = true }
 serde_json = { workspace = true, default-features = true }
 sha2 = { version = "0.10.9", default-features = true }
+solana-address = { workspace = true, default-features = true }
 syn = { workspace = true, default-features = true, features = ["full", "extra-traits", "visit", "printing"] }
 tempfile = { workspace = true, default-features = true }
 termimad = "0.35.1"
 thiserror = { workspace = true, default-features = true }
 toml = { workspace = true, default-features = true }
+url = { workspace = true }
 walkdir = { workspace = true, default-features = true }
 
 [dev-dependencies]

--- a/crates/pina_cli/readme.md
+++ b/crates/pina_cli/readme.md
@@ -61,6 +61,22 @@ pina generate --client rust --client typescript
 
 Rust-only generation does not require Node.js.
 
+### `pina verify`
+
+Build deterministically, compare the artifact with a deployed program, and publish a source record:
+
+```bash
+pina build --verify
+pina verify check --program-id <ADDRESS> --cluster devnet
+pina verify record \
+  --program-id <ADDRESS> \
+  --cluster devnet \
+  --build-record ./target/pina/verifiable/my_program-<HASH>.json \
+  --authority ./upgrade-authority.json
+```
+
+See the [verification command reference](https://pina-rs.github.io/pina/cli/verify.html) for exit codes, mainnet acknowledgement, multisig export, remote submission, and keypair/RPC safety rules.
+
 ### `pina idl`
 
 <br>

--- a/crates/pina_cli/src/cli.rs
+++ b/crates/pina_cli/src/cli.rs
@@ -16,8 +16,10 @@ use clap::ValueEnum;
 	about = "Build, inspect, and generate artifacts for Pina Solana programs",
 	long_about = "Build, inspect, and generate artifacts for Pina Solana programs.\n\nUse 'pina \
 	              init' to start a program, 'pina build' for its SBF binary and IDL, and 'pina \
-	              generate' for selected client ecosystems. Low-level IDL, profiling, terminal \
-	              documentation, and the legacy repository-wide Codama workflow remain available.",
+	              generate' for selected client ecosystems. Use 'pina build --verify' and 'pina \
+	              verify' for reproducible deployed-program verification. Low-level IDL, \
+	              profiling, terminal documentation, and the legacy repository-wide Codama \
+	              workflow remain available.",
 	next_line_help = true,
 	arg_required_else_help = true,
 	after_help = "Examples:\n  pina init counter_program\n  cd counter_program && pina build\n  \
@@ -25,7 +27,9 @@ use clap::ValueEnum;
 	              ./programs/counter_program --output ./idls/counter_program.json\n  pina profile \
 	              ./target/deploy/counter_program.so --json\n\nAgent discovery:\n  Run 'pina \
 	              <command> --help' for command-specific inputs, outputs, and examples.\n  Run \
-	              'pina docs' to list the bundled architecture and IDL reference topics."
+	              'pina docs' to list the bundled architecture and IDL reference topics.\n  For \
+	              deployment verification, run 'pina verify --help' and then inspect the selected \
+	              leaf command."
 )]
 pub(crate) struct Cli {
 	#[command(subcommand)]
@@ -226,6 +230,32 @@ pub(crate) enum Commands {
 		output: Option<PathBuf>,
 	},
 
+	/// Verify deployed programs and publish source-build records.
+	///
+	/// Uses the official solana-verify 0.5.1 executable. `check` is read-only;
+	/// `record` is the only subcommand that writes on-chain state. Remote
+	/// submission and status use the mainnet verifier service.
+	#[command(after_help = r#"Examples:
+  pina verify check --program-id <ADDRESS> --cluster devnet
+  pina verify record --program-id <ADDRESS> --cluster devnet \
+    --build-record ./target/pina/verifiable/my_program-<HASH>.json \
+    --authority ./authority.json --yes
+  pina verify submit --program-id <ADDRESS> --uploader <ADDRESS>
+  pina verify status --program-id <ADDRESS>"#)]
+	Verify {
+		#[command(subcommand)]
+		command: VerifyCommands,
+
+		/// solana-verify 0.5.1 executable. Pina never installs it.
+		#[arg(
+			long,
+			default_value = "solana-verify",
+			hide_default_value = true,
+			value_name = "COMMAND"
+		)]
+		solana_verify: OsString,
+	},
+
 	/// Run Codama IDL and client-generation workflows.
 	///
 	/// Use the generate subcommand to extract every selected program IDL and
@@ -242,6 +272,161 @@ pub(crate) enum ClientArg {
 	Rust,
 	Typescript,
 	Dart,
+}
+
+/// Deployed-program verification operations.
+#[derive(Subcommand, Debug)]
+pub(crate) enum VerifyCommands {
+	/// Compare a local SBF executable with a deployed program.
+	///
+	/// Uses solana-verify's trailing-zero-aware executable and deployed-program
+	/// hashes. Exits 0 on a match, 2 on a mismatch, and 1 on an operational error.
+	#[command(after_help = r#"Examples:
+  pina verify check --program-id <ADDRESS> --cluster devnet
+  pina verify check --program-id <ADDRESS> --cluster mainnet-beta \
+    --program ./target/deploy/my_program.so
+  pina verify check --program-id <ADDRESS> --cluster https://rpc.example.com \
+    --project ./programs/my_program
+
+Output and status:
+  Exit 0 means the executables match. Exit 2 means the comparison completed but
+  hashes differ. Exit 1 means validation, RPC, or tool failure. Custom RPC URLs
+  must be credential-free origins because RPC URLs are visible in process argv."#)]
+	Check {
+		/// Deployed program address.
+		#[arg(long, value_name = "ADDRESS")]
+		program_id: String,
+
+		/// Solana cluster alias or HTTP(S) RPC URL. Always explicit.
+		#[arg(long, value_name = "CLUSTER")]
+		cluster: String,
+
+		/// Local SBF executable. Conflicts with --project discovery.
+		#[arg(long, value_name = "PROGRAM.SO", conflicts_with = "project")]
+		program: Option<PathBuf>,
+
+		/// Directory used to discover the executable. Defaults to the current directory.
+		#[arg(
+			short,
+			long,
+			default_value = ".",
+			hide_default_value = true,
+			value_name = "DIR"
+		)]
+		project: PathBuf,
+	},
+
+	/// Build from an immutable repository revision and record verification metadata.
+	///
+	/// This writes on-chain state after the official repository build matches the
+	/// deployed executable. The authority signs and pays transaction fees because
+	/// solana-verify 0.5.1 does not support a separate payer.
+	#[command(after_help = r#"Examples:
+  pina verify record --program-id <ADDRESS> --cluster devnet \
+    --build-record ./target/pina/verifiable/my_program-<HASH>.json \
+    --authority ./upgrade-authority.json --yes
+
+  pina verify record --program-id <ADDRESS> --cluster mainnet-beta \
+    --build-record ./target/pina/verifiable/my_program-<HASH>.json \
+    --authority ./upgrade-authority.json --yes --acknowledge-mainnet
+
+  pina verify record --program-id <ADDRESS> --cluster mainnet-beta \
+    --build-record ./target/pina/verifiable/my_program-<HASH>.json \
+    --export <MULTISIG_ADDRESS> --output ./verification.tx \
+    --export-encoding base64
+
+Safety:
+  The build record binds the validated artifact hash to its public repository,
+  full revision, build paths, library, and Cargo features. Interactive recording
+  requires typing `record`; automation requires --yes. Submissions to mainnet and
+  unknown remote RPC origins additionally require --acknowledge-mainnet. Export
+  never submits or rebuilds the repository; remote verification begins only after
+  the exported transaction is submitted. Export does not require that acknowledgement."#)]
+	Record {
+		/// Deployed program address.
+		#[arg(long, value_name = "ADDRESS")]
+		program_id: String,
+
+		/// Solana cluster alias or HTTP(S) RPC URL. Always explicit.
+		#[arg(long, value_name = "CLUSTER")]
+		cluster: String,
+
+		/// Content-addressed record produced by `pina build --verify`.
+		#[arg(long, value_name = "FILE")]
+		build_record: PathBuf,
+
+		/// Upgrade-authority keypair. It also pays fees with solana-verify 0.5.1.
+		#[arg(long, value_name = "KEYPAIR", required_unless_present = "export")]
+		authority: Option<PathBuf>,
+
+		/// Export without submitting. Optionally provide a public authority address.
+		#[arg(
+			long,
+			num_args = 0..=1,
+			default_missing_value = "",
+			requires = "output",
+			value_name = "AUTHORITY"
+		)]
+		export: Option<String>,
+
+		/// Write only the validated encoded transaction payload to FILE.
+		#[arg(long, value_name = "FILE", requires = "export")]
+		output: Option<PathBuf>,
+
+		/// Encoding for the exported transaction: base64 or base58.
+		#[arg(
+			long,
+			value_enum,
+			value_name = "ENCODING",
+			requires = "export",
+			hide_possible_values = true
+		)]
+		export_encoding: Option<ExportEncodingArg>,
+
+		/// Confirm recording without an interactive prompt. Has no effect on export.
+		#[arg(long, conflicts_with = "export")]
+		yes: bool,
+
+		/// Acknowledge submission to mainnet or an unknown remote endpoint.
+		#[arg(long)]
+		acknowledge_mainnet: bool,
+	},
+
+	/// Submit an existing on-chain verification record to the mainnet remote verifier.
+	#[command(
+		after_help = "Example:\n  pina verify submit --program-id <ADDRESS> --uploader \
+		              <ADDRESS>\n\n\\
+		              This command always targets the official mainnet remote verifier. UPLOADER is the \
+		              \\
+		              public address that created the on-chain verification record; it is not a keypair."
+	)]
+	Submit {
+		/// Program address whose recorded build should be verified.
+		#[arg(long, value_name = "ADDRESS")]
+		program_id: String,
+
+		/// Public address that uploaded the verification record.
+		#[arg(long, value_name = "ADDRESS")]
+		uploader: String,
+	},
+
+	/// Read the mainnet remote-verifier status for a program.
+	#[command(
+		after_help = "Example:\n  pina verify status --program-id <ADDRESS>\n\nThis command is \\
+		              read-only and always queries the official mainnet remote verifier."
+	)]
+	Status {
+		/// Program address to inspect.
+		#[arg(long, value_name = "ADDRESS")]
+		program_id: String,
+	},
+}
+
+/// Transaction encoding supported by solana-verify exports.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub(crate) enum ExportEncodingArg {
+	Base64,
+	Base58,
 }
 
 /// Codama-related generation workflows.

--- a/crates/pina_cli/src/lib.rs
+++ b/crates/pina_cli/src/lib.rs
@@ -6,6 +6,7 @@ pub mod init;
 pub mod ir;
 pub mod parse;
 pub mod project;
+pub mod verification;
 
 mod dart_client;
 mod js_client;

--- a/crates/pina_cli/src/main.rs
+++ b/crates/pina_cli/src/main.rs
@@ -1,6 +1,8 @@
 mod cli;
 
 use std::fs;
+use std::io::IsTerminal;
+use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -12,6 +14,8 @@ use crate::cli::Cli;
 use crate::cli::ClientArg;
 use crate::cli::CodamaCommands;
 use crate::cli::Commands;
+use crate::cli::ExportEncodingArg;
+use crate::cli::VerifyCommands;
 
 fn main() {
 	let cli = Cli::parse();
@@ -48,6 +52,10 @@ fn main() {
 		Commands::Docs { topic } => run_docs(topic.as_deref()),
 		Commands::Init { name, path, force } => run_init(name.as_str(), path.as_deref(), force),
 		Commands::Profile { path, json, output } => run_profile(&path, json, output.as_deref()),
+		Commands::Verify {
+			command,
+			solana_verify,
+		} => run_verify(command, solana_verify),
 		Commands::Codama { command } => {
 			match command {
 				CodamaCommands::Generate {
@@ -72,6 +80,254 @@ fn main() {
 			}
 		}
 	}
+}
+
+fn run_verify(command: VerifyCommands, solana_verify: std::ffi::OsString) {
+	let executor = pina_cli::verification::SystemVerifyExecutor::new(solana_verify);
+
+	match command {
+		VerifyCommands::Check {
+			program_id,
+			cluster,
+			program,
+			project,
+		} => run_verify_check(&executor, program_id, &cluster, program, project),
+		VerifyCommands::Record {
+			program_id,
+			cluster,
+			build_record,
+			authority,
+			export,
+			output,
+			export_encoding,
+			yes,
+			acknowledge_mainnet,
+		} => {
+			run_verify_record(
+				&executor,
+				program_id,
+				&cluster,
+				build_record,
+				authority,
+				export,
+				output,
+				export_encoding,
+				yes,
+				acknowledge_mainnet,
+			);
+		}
+		VerifyCommands::Submit {
+			program_id,
+			uploader,
+		} => {
+			let output = pina_cli::verification::submit_program(&executor, &program_id, &uploader)
+				.unwrap_or_else(|error| exit_verify_error(error));
+			write_process_output(&output, true);
+		}
+		VerifyCommands::Status { program_id } => {
+			let output = pina_cli::verification::status_program(&executor, &program_id)
+				.unwrap_or_else(|error| exit_verify_error(error));
+			write_process_output(&output, true);
+		}
+	}
+}
+
+fn run_verify_check(
+	executor: &pina_cli::verification::SystemVerifyExecutor,
+	program_id: String,
+	cluster: &str,
+	program: Option<PathBuf>,
+	project: PathBuf,
+) {
+	let cluster = cluster
+		.parse::<pina_cli::verification::Cluster>()
+		.unwrap_or_else(|error| exit_verify_error(error));
+	let result = pina_cli::verification::check_program(
+		executor,
+		&pina_cli::verification::CheckOptions {
+			program_id,
+			cluster,
+			program,
+			project_dir: project,
+		},
+	)
+	.unwrap_or_else(|error| exit_verify_error(error));
+
+	match result {
+		pina_cli::verification::CheckResult::Match { hash } => {
+			println!("{} Program executable matches", "✔".green());
+			println!("  Hash {hash}");
+		}
+		pina_cli::verification::CheckResult::Mismatch { local, deployed } => {
+			eprintln!("{} Program executables differ", "Error".red().bold());
+			eprintln!("  Local    {local}");
+			eprintln!("  Deployed {deployed}");
+			std::process::exit(2);
+		}
+	}
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_verify_record(
+	executor: &pina_cli::verification::SystemVerifyExecutor,
+	program_id: String,
+	cluster: &str,
+	build_record: PathBuf,
+	authority: Option<PathBuf>,
+	export: Option<String>,
+	output: Option<PathBuf>,
+	export_encoding: Option<ExportEncodingArg>,
+	yes: bool,
+	acknowledge_mainnet: bool,
+) {
+	let cluster = cluster
+		.parse::<pina_cli::verification::Cluster>()
+		.unwrap_or_else(|error| exit_verify_error(error));
+	let is_export = export.is_some();
+	let export_encoding = match export_encoding.unwrap_or(ExportEncodingArg::Base58) {
+		ExportEncodingArg::Base64 => pina_cli::verification::ExportEncoding::Base64,
+		ExportEncodingArg::Base58 => pina_cli::verification::ExportEncoding::Base58,
+	};
+	let options = pina_cli::verification::RecordOptions {
+		program_id,
+		cluster,
+		build_record,
+		authority,
+		export_authority: export,
+		export_output: output.clone(),
+		export_encoding,
+		confirmed: is_export || yes,
+		mainnet_acknowledged: acknowledge_mainnet,
+	};
+
+	let mut input = std::io::stdin().lock();
+	let mut diagnostics = std::io::stderr().lock();
+	let plan = prepare_and_confirm_record(
+		&options,
+		std::io::stdin().is_terminal(),
+		&mut input,
+		&mut diagnostics,
+	)
+	.unwrap_or_else(|error| exit_verify_error(error));
+	drop(input);
+	drop(diagnostics);
+
+	let result = pina_cli::verification::execute_record(executor, &plan)
+		.unwrap_or_else(|error| exit_verify_error(error));
+
+	if is_export {
+		let _ = std::io::stderr().lock().write_all(&result.stdout);
+		write_process_output(&result, false);
+		if let Some(path) = output {
+			println!(
+				"{} Exported verification transaction to {}",
+				"✔".green(),
+				escaped_path(&path)
+			);
+		}
+	} else {
+		write_process_output(&result, true);
+	}
+}
+
+fn prepare_and_confirm_record(
+	options: &pina_cli::verification::RecordOptions,
+	is_terminal: bool,
+	input: &mut impl std::io::BufRead,
+	diagnostics: &mut impl Write,
+) -> Result<pina_cli::verification::RecordPlan, pina_cli::verification::VerifyError> {
+	if !options.confirmed && !is_terminal {
+		return Err(pina_cli::verification::VerifyError::ConfirmationRequired);
+	}
+
+	let mut plan = pina_cli::verification::prepare_record(options)?;
+
+	if !options.confirmed {
+		let review = plan.review();
+		let _ = writeln!(diagnostics, "Verification record plan:");
+		let _ = writeln!(
+			diagnostics,
+			"  Build record {}",
+			escaped_path(&review.build_record)
+		);
+		let _ = writeln!(diagnostics, "  Program      {}", review.program_id);
+		let _ = writeln!(diagnostics, "  Cluster      {}", review.cluster);
+		let _ = writeln!(diagnostics, "  Repository   {}", review.repository);
+		let _ = writeln!(diagnostics, "  Revision     {}", review.revision);
+		let _ = writeln!(
+			diagnostics,
+			"  Mount        {}",
+			escaped_text(&review.mount_path)
+		);
+		let _ = writeln!(
+			diagnostics,
+			"  Workspace    {}",
+			escaped_text(&review.workspace_path)
+		);
+		let _ = writeln!(diagnostics, "  Library      {}", review.library_name);
+		let features = display_features(&review.features);
+		let _ = writeln!(diagnostics, "  Features     {features}");
+		let _ = writeln!(
+			diagnostics,
+			"  Defaults     {}",
+			if review.default_features {
+				"enabled"
+			} else {
+				"disabled"
+			}
+		);
+		let _ = writeln!(diagnostics, "  Hash         {}", review.executable_hash);
+		let _ = writeln!(diagnostics, "  Authority    {}", review.authority);
+		let _ = writeln!(
+			diagnostics,
+			"  Keypair      {}",
+			escaped_path(&review.authority_path)
+		);
+		let _ = write!(diagnostics, "Type `record` to submit this transaction: ");
+		let _ = diagnostics.flush();
+		let mut answer = String::new();
+
+		if !input
+			.read_line(&mut answer)
+			.is_ok_and(|_| answer.trim() == "record")
+		{
+			return Err(pina_cli::verification::VerifyError::ConfirmationRequired);
+		}
+		plan.confirm();
+	}
+
+	Ok(plan)
+}
+
+#[allow(clippy::unnecessary_debug_formatting)]
+fn escaped_path(path: &Path) -> String {
+	format!("{path:?}")
+}
+
+fn escaped_text(value: &str) -> String {
+	value.chars().flat_map(char::escape_default).collect()
+}
+
+fn display_features(features: &[String]) -> String {
+	if features.is_empty() {
+		"(none)".to_owned()
+	} else {
+		features.join(",")
+	}
+}
+
+fn write_process_output(output: &pina_cli::verification::ProcessOutput, include_stdout: bool) {
+	if include_stdout {
+		let _ = std::io::stdout().lock().write_all(&output.stdout);
+	}
+
+	let _ = std::io::stderr().lock().write_all(&output.stderr);
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn exit_verify_error(error: pina_cli::verification::VerifyError) -> ! {
+	eprintln!("{} {}", "Error".red().bold(), error);
+	std::process::exit(error.exit_code());
 }
 
 fn run_build(
@@ -406,4 +662,191 @@ fn run_codama_generate(
 		generated_examples.len(),
 		generated_examples.join(", "),
 	);
+}
+
+#[cfg(test)]
+mod tests {
+	use std::fs;
+	use std::io::Cursor;
+
+	use ed25519_dalek::SigningKey;
+	use sha2::Digest;
+	use sha2::Sha256;
+	use tempfile::TempDir;
+
+	use super::display_features;
+	use super::escaped_path;
+	use super::escaped_text;
+	use super::prepare_and_confirm_record;
+
+	#[test]
+	fn escapes_control_characters_in_confirmation_paths() {
+		let rendered = escaped_path(std::path::Path::new("record\n\u{1b}[31m.json"));
+
+		assert_eq!(rendered, "\"record\\n\\u{1b}[31m.json\"");
+		assert!(!rendered.contains('\n'));
+		assert!(!rendered.contains('\u{1b}'));
+		assert_eq!(display_features(&[]), "(none)");
+		assert_eq!(
+			escaped_text("path with spaces\n\u{1b}"),
+			"path with spaces\\n\\u{1b}"
+		);
+		assert_eq!(
+			display_features(&["logs".to_owned(), "trace".to_owned()]),
+			"logs,trace"
+		);
+	}
+
+	fn record_options(temp: &TempDir, confirmed: bool) -> pina_cli::verification::RecordOptions {
+		let artifact_bytes = vec![7_u8; 128];
+		let hash = format!("{:x}", Sha256::digest(&artifact_bytes));
+		let record_dir = temp.path().join("record with spaces");
+		fs::create_dir_all(&record_dir).unwrap();
+		let record = record_dir.join(format!("fixture-{hash}.json"));
+		let artifact = record.with_extension("so");
+		let json = serde_json::json!({
+			"schemaVersion": 1,
+			"packageName": "fixture",
+			"libraryName": "fixture",
+			"executableHash": hash,
+			"solanaVerifyVersion": "0.5.1",
+			"build": {
+				"mountPath": "mount with spaces\n\u{1b}[33m",
+				"workspacePath": "workspace\n\u{1b}[34m",
+				"programPath": "programs/fixture",
+				"libraryName": "fixture",
+				"features": ["bpf-entrypoint"],
+				"defaultFeatures": true,
+				"cargoLockSha256": "a".repeat(64),
+			},
+			"source": {
+				"repository": "https://github.com/pina-rs/pina",
+				"revision": "0123456789abcdef0123456789abcdef01234567",
+				"dirty": false,
+			},
+			"diagnostics": [],
+		});
+		fs::write(&artifact, artifact_bytes).unwrap();
+		fs::write(&record, serde_json::to_vec(&json).unwrap()).unwrap();
+
+		let authority = temp.path().join("keypair with spaces.json");
+		let signing_key = SigningKey::from_bytes(&[3_u8; 32]);
+		let public = signing_key.verifying_key().to_bytes();
+		let bytes = [signing_key.to_bytes().as_slice(), public.as_slice()].concat();
+		fs::write(&authority, serde_json::to_vec(&bytes).unwrap()).unwrap();
+		#[cfg(unix)]
+		{
+			use std::os::unix::fs::PermissionsExt;
+
+			fs::set_permissions(&authority, fs::Permissions::from_mode(0o600)).unwrap();
+		}
+
+		pina_cli::verification::RecordOptions {
+			program_id: "11111111111111111111111111111111".to_owned(),
+			cluster: "devnet".parse().unwrap(),
+			build_record: record,
+			authority: Some(authority),
+			export_authority: None,
+			export_output: None,
+			export_encoding: pina_cli::verification::ExportEncoding::Base58,
+			confirmed,
+			mainnet_acknowledged: false,
+		}
+	}
+
+	#[cfg(any(target_os = "linux", target_os = "macos"))]
+	#[test]
+	fn confirmation_prepares_exactly_the_plan_that_is_reviewed() {
+		let temp = TempDir::new().unwrap();
+		let options = record_options(&temp, false);
+		let mut diagnostics = Vec::new();
+		let error = prepare_and_confirm_record(
+			&options,
+			false,
+			&mut Cursor::new(b"record\n"),
+			&mut diagnostics,
+		)
+		.err()
+		.unwrap();
+		assert!(matches!(
+			error,
+			pina_cli::verification::VerifyError::ConfirmationRequired
+		));
+		assert!(diagnostics.is_empty());
+
+		let error =
+			prepare_and_confirm_record(&options, true, &mut Cursor::new(b"no\n"), &mut diagnostics)
+				.err()
+				.unwrap();
+		assert!(matches!(
+			error,
+			pina_cli::verification::VerifyError::ConfirmationRequired
+		));
+
+		diagnostics.clear();
+		let plan = prepare_and_confirm_record(
+			&options,
+			true,
+			&mut Cursor::new(b"record\n"),
+			&mut diagnostics,
+		)
+		.unwrap();
+		let rendered = String::from_utf8_lossy(&diagnostics);
+		assert!(rendered.contains("record with spaces"));
+		assert!(rendered.contains("fixture-"));
+		assert!(rendered.contains("keypair with spaces.json"));
+		assert!(rendered.contains("Mount        mount with spaces\\n\\u{1b}[33m"));
+		assert!(rendered.contains("Workspace    workspace\\n\\u{1b}[34m"));
+		assert!(rendered.contains("Features     bpf-entrypoint"));
+		assert!(rendered.contains("Defaults     enabled"));
+		assert_eq!(plan.review().program_id, options.program_id);
+		drop(plan);
+
+		let mut json: serde_json::Value =
+			serde_json::from_slice(&fs::read(&options.build_record).unwrap()).unwrap();
+		json["build"]["defaultFeatures"] = serde_json::Value::Bool(false);
+		fs::write(&options.build_record, serde_json::to_vec(&json).unwrap()).unwrap();
+		diagnostics.clear();
+		prepare_and_confirm_record(
+			&options,
+			true,
+			&mut Cursor::new(b"record\n"),
+			&mut diagnostics,
+		)
+		.unwrap();
+		assert!(
+			String::from_utf8(diagnostics)
+				.unwrap()
+				.contains("Defaults     disabled")
+		);
+
+		let confirmed = record_options(&temp, true);
+		prepare_and_confirm_record(
+			&confirmed,
+			false,
+			&mut Cursor::new(Vec::<u8>::new()),
+			&mut Vec::new(),
+		)
+		.unwrap();
+	}
+
+	#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+	#[test]
+	fn confirmation_fails_closed_on_unsupported_hosts() {
+		let temp = TempDir::new().unwrap();
+		let options = record_options(&temp, false);
+		let error = prepare_and_confirm_record(
+			&options,
+			true,
+			&mut Cursor::new(b"record\n"),
+			&mut Vec::new(),
+		)
+		.err()
+		.unwrap();
+
+		assert!(matches!(
+			error,
+			pina_cli::verification::VerifyError::UnsupportedRecordHost { .. }
+		));
+	}
 }

--- a/crates/pina_cli/src/verification.rs
+++ b/crates/pina_cli/src/verification.rs
@@ -1,0 +1,2446 @@
+//! Deployed-program verification through the official `solana-verify` CLI.
+
+use std::ffi::OsString;
+use std::fmt;
+use std::fs;
+use std::fs::OpenOptions;
+use std::io::Read;
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+use std::process::ExitStatus;
+use std::process::Stdio;
+use std::str::FromStr;
+
+use atomic_write_file::AtomicWriteFile;
+use base64::Engine;
+use ed25519_dalek::SigningKey;
+use solana_address::Address;
+use url::Host;
+use url::Url;
+
+use crate::project::Project;
+use crate::project::ProjectError;
+use crate::verifiable::VerifyBuildError;
+
+/// The supported upstream verification tool release.
+pub const SOLANA_VERIFY_VERSION: &str = "0.5.1";
+
+const MAINNET_RPC: &str = "https://api.mainnet-beta.solana.com";
+const DEVNET_RPC: &str = "https://api.devnet.solana.com";
+const TESTNET_RPC: &str = "https://api.testnet.solana.com";
+const LOCALNET_RPC: &str = "http://localhost:8899";
+const MAX_CAPTURED_OUTPUT: usize = 1_048_576;
+const MAX_KEYPAIR_BYTES: usize = 4_096;
+
+/// A validated Solana cluster alias or RPC URL.
+#[derive(Clone, PartialEq, Eq)]
+pub struct Cluster {
+	rpc: String,
+	name: String,
+	mainnet_risk: bool,
+}
+
+impl Cluster {
+	/// Return the RPC value passed to `solana-verify`.
+	#[must_use]
+	pub fn rpc(&self) -> &str {
+		&self.rpc
+	}
+
+	/// Return a safe display name that excludes URL credentials and queries.
+	#[must_use]
+	pub fn display_name(&self) -> &str {
+		&self.name
+	}
+
+	/// Whether this is the canonical mainnet endpoint.
+	#[must_use]
+	pub const fn requires_mainnet_acknowledgement(&self) -> bool {
+		self.mainnet_risk
+	}
+}
+
+impl fmt::Debug for Cluster {
+	fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+		formatter
+			.debug_struct("Cluster")
+			.field("endpoint", &self.name)
+			.field("mainnet_risk", &self.mainnet_risk)
+			.finish_non_exhaustive()
+	}
+}
+
+impl FromStr for Cluster {
+	type Err = VerifyError;
+
+	fn from_str(value: &str) -> Result<Self, Self::Err> {
+		let (rpc, name, mainnet_risk) = match value {
+			"mainnet" | "mainnet-beta" => (MAINNET_RPC, "mainnet-beta", true),
+			"devnet" => (DEVNET_RPC, "devnet", false),
+			"testnet" => (TESTNET_RPC, "testnet", false),
+			"localnet" | "localhost" => (LOCALNET_RPC, "localnet", false),
+			_ => return parse_custom_rpc(value),
+		};
+
+		Ok(Self {
+			rpc: rpc.to_owned(),
+			name: name.to_owned(),
+			mainnet_risk,
+		})
+	}
+}
+
+fn parse_custom_rpc(value: &str) -> Result<Cluster, VerifyError> {
+	let url = Url::parse(value).map_err(|_| VerifyError::InvalidCluster)?;
+	let loopback = matches!(url.host(), Some(Host::Domain("localhost")))
+		|| matches!(url.host(), Some(Host::Ipv4(address)) if address.is_loopback())
+		|| matches!(url.host(), Some(Host::Ipv6(address)) if address.is_loopback());
+
+	if !matches!(url.scheme(), "http" | "https")
+		|| (url.scheme() != "https" && !loopback)
+		|| url.host().is_none()
+		|| !url.username().is_empty()
+		|| url.password().is_some()
+		|| url.query().is_some()
+		|| url.fragment().is_some()
+		|| !matches!(url.path(), "" | "/")
+	{
+		return Err(VerifyError::InvalidCluster);
+	}
+
+	let host = url.host_str().ok_or(VerifyError::InvalidCluster)?;
+	let name = match url.port() {
+		Some(port) => format!("{}://{host}:{port}", url.scheme()),
+		None => format!("{}://{host}", url.scheme()),
+	};
+	Ok(Cluster {
+		rpc: value.to_owned(),
+		name,
+		mainnet_risk: !loopback,
+	})
+}
+
+/// A validated public HTTPS Git repository URL.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepositoryUrl(String);
+
+impl RepositoryUrl {
+	/// Return the URL passed to the verifier.
+	#[must_use]
+	pub fn as_str(&self) -> &str {
+		&self.0
+	}
+}
+
+impl FromStr for RepositoryUrl {
+	type Err = VerifyError;
+
+	fn from_str(value: &str) -> Result<Self, Self::Err> {
+		let url = Url::parse(value).map_err(|_| VerifyError::InvalidRepository)?;
+
+		if url.scheme() != "https"
+			|| !url.username().is_empty()
+			|| url.password().is_some()
+			|| url.query().is_some()
+			|| url.fragment().is_some()
+			|| !is_public_host(url.host())
+		{
+			return Err(VerifyError::InvalidRepository);
+		}
+
+		Ok(Self(value.to_owned()))
+	}
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn is_public_host(host: Option<Host<&str>>) -> bool {
+	match host {
+		Some(Host::Domain(domain)) => is_public_domain(domain),
+		Some(Host::Ipv4(address)) => {
+			!(address.is_private()
+				|| address.is_loopback()
+				|| address.is_link_local()
+				|| address.is_broadcast()
+				|| address.is_documentation()
+				|| address.is_multicast()
+				|| address.is_unspecified())
+		}
+		Some(Host::Ipv6(address)) => {
+			if let Some(mapped) = address.to_ipv4_mapped() {
+				return is_public_host(Some(Host::Ipv4(mapped)));
+			}
+			let segments = address.segments();
+			let documentation = segments[0] == 0x2001 && segments[1] == 0x0db8;
+
+			!(address.is_loopback()
+				|| address.is_unspecified()
+				|| address.is_unique_local()
+				|| address.is_unicast_link_local()
+				|| address.is_multicast()
+				|| documentation)
+		}
+		None => false,
+	}
+}
+
+fn is_public_domain(value: &str) -> bool {
+	let domain = value.trim_end_matches('.').to_ascii_lowercase();
+	let reserved = [
+		"localhost",
+		"local",
+		"internal",
+		"test",
+		"invalid",
+		"example",
+	];
+	let labels_valid = domain.len() <= 253
+		&& domain.split('.').all(|label| {
+			let bytes = label.as_bytes();
+			!bytes.is_empty()
+				&& bytes.len() <= 63
+				&& bytes.first().is_some_and(u8::is_ascii_alphanumeric)
+				&& bytes.last().is_some_and(u8::is_ascii_alphanumeric)
+				&& bytes
+					.iter()
+					.all(|byte| byte.is_ascii_alphanumeric() || *byte == b'-')
+		});
+
+	labels_valid
+		&& domain.contains('.')
+		&& !reserved
+			.iter()
+			.any(|suffix| domain == *suffix || domain.ends_with(&format!(".{suffix}")))
+}
+
+/// A full SHA-1 Git revision.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Revision(String);
+
+impl Revision {
+	/// Return the validated revision.
+	#[must_use]
+	pub fn as_str(&self) -> &str {
+		&self.0
+	}
+}
+
+impl FromStr for Revision {
+	type Err = VerifyError;
+
+	fn from_str(value: &str) -> Result<Self, Self::Err> {
+		if value.len() != 40 || !value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+			return Err(VerifyError::InvalidRevision);
+		}
+
+		Ok(Self(value.to_ascii_lowercase()))
+	}
+}
+
+/// Encoding used for an exported verification transaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExportEncoding {
+	Base64,
+	Base58,
+}
+
+impl ExportEncoding {
+	fn as_str(self) -> &'static str {
+		match self {
+			Self::Base64 => "base64",
+			Self::Base58 => "base58",
+		}
+	}
+}
+
+/// Result of comparing a local executable with a deployed program.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CheckResult {
+	Match { hash: String },
+	Mismatch { local: String, deployed: String },
+}
+
+/// Inputs for a read-only executable comparison.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckOptions {
+	pub program_id: String,
+	pub cluster: Cluster,
+	pub program: Option<PathBuf>,
+	pub project_dir: PathBuf,
+}
+
+/// Inputs shared by recording and exporting verification metadata.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecordOptions {
+	pub program_id: String,
+	pub cluster: Cluster,
+	pub build_record: PathBuf,
+	pub authority: Option<PathBuf>,
+	pub export_authority: Option<String>,
+	pub export_output: Option<PathBuf>,
+	pub export_encoding: ExportEncoding,
+	pub confirmed: bool,
+	pub mainnet_acknowledged: bool,
+}
+
+/// Fully validated values shown before an interactive record submission.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecordReview {
+	pub build_record: PathBuf,
+	pub program_id: String,
+	pub cluster: String,
+	pub repository: String,
+	pub revision: String,
+	pub mount_path: String,
+	pub workspace_path: String,
+	pub library_name: String,
+	pub features: Vec<String>,
+	pub default_features: bool,
+	pub executable_hash: String,
+	pub authority_path: PathBuf,
+	pub authority: String,
+}
+
+/// An immutable, validated recording plan.
+///
+/// For direct submissions this owns a private temporary copy of the authority keypair, so the
+/// file reviewed by the user cannot be replaced between confirmation and process execution.
+pub struct RecordPlan {
+	options: RecordOptions,
+	program_id: Address,
+	context: ProjectContext,
+	record_hash: String,
+	authority: Address,
+	staged_authority: Option<StagedAuthority>,
+}
+
+impl RecordPlan {
+	/// Return the non-secret values that must be reviewed before submission.
+	#[must_use]
+	pub fn review(&self) -> RecordReview {
+		RecordReview {
+			build_record: self.options.build_record.clone(),
+			program_id: self.program_id.to_string(),
+			cluster: self.options.cluster.display_name().to_owned(),
+			repository: self.context.repository.as_str().to_owned(),
+			revision: self.context.revision.as_str().to_owned(),
+			mount_path: self.context.mount_path.clone(),
+			workspace_path: self.context.workspace_path.clone(),
+			library_name: self.context.library_name.clone(),
+			features: self.context.features.clone(),
+			default_features: self.context.default_features,
+			executable_hash: self.record_hash.clone(),
+			authority_path: self.options.authority.clone().unwrap_or_default(),
+			authority: self.authority.to_string(),
+		}
+	}
+
+	/// Mark this exact prepared plan as interactively confirmed.
+	pub const fn confirm(&mut self) {
+		self.options.confirmed = true;
+	}
+}
+
+struct StagedAuthority {
+	_directory: tempfile::TempDir,
+	path: PathBuf,
+}
+
+/// Process result returned by a verification executor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProcessOutput {
+	pub status: ProcessStatus,
+	pub stdout: Vec<u8>,
+	pub stderr: Vec<u8>,
+}
+
+/// Portable child-process termination information.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessStatus {
+	Code(i32),
+	Signal,
+}
+
+impl ProcessStatus {
+	fn success(self) -> bool {
+		matches!(self, Self::Code(0))
+	}
+}
+
+impl fmt::Display for ProcessStatus {
+	fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+		match self {
+			Self::Code(code) => write!(formatter, "exit code {code}"),
+			Self::Signal => formatter.write_str("signal"),
+		}
+	}
+}
+
+/// Executes the official verification tool.
+pub trait VerifyExecutor {
+	/// Run `solana-verify` with structured arguments.
+	fn run(&self, arguments: &[OsString]) -> Result<ProcessOutput, std::io::Error>;
+
+	/// Run a potentially long command while streaming its output.
+	fn run_streaming(&self, arguments: &[OsString]) -> Result<ProcessOutput, std::io::Error> {
+		self.run(arguments)
+	}
+}
+
+/// Production process executor.
+#[derive(Debug, Clone)]
+pub struct SystemVerifyExecutor {
+	executable: OsString,
+}
+
+impl Default for SystemVerifyExecutor {
+	fn default() -> Self {
+		Self {
+			executable: OsString::from("solana-verify"),
+		}
+	}
+}
+
+impl SystemVerifyExecutor {
+	/// Select an explicit `solana-verify` executable.
+	#[must_use]
+	pub fn new(executable: OsString) -> Self {
+		Self { executable }
+	}
+}
+
+impl VerifyExecutor for SystemVerifyExecutor {
+	fn run(&self, arguments: &[OsString]) -> Result<ProcessOutput, std::io::Error> {
+		let mut child = Command::new(&self.executable)
+			.args(arguments)
+			.stdin(Stdio::null())
+			.stdout(Stdio::piped())
+			.stderr(Stdio::piped())
+			.spawn()?;
+		let stdout = child
+			.stdout
+			.take()
+			.expect("piped solana-verify stdout must be available");
+		let stderr = child
+			.stderr
+			.take()
+			.expect("piped solana-verify stderr must be available");
+		let stdout_thread = std::thread::spawn(move || read_bounded(stdout));
+		let stderr_thread = std::thread::spawn(move || read_bounded(stderr));
+		let status = child.wait()?;
+		let stdout = join_reader(stdout_thread)?;
+		let stderr = join_reader(stderr_thread)?;
+
+		Ok(ProcessOutput {
+			status: process_status(status),
+			stdout,
+			stderr,
+		})
+	}
+
+	fn run_streaming(&self, arguments: &[OsString]) -> Result<ProcessOutput, std::io::Error> {
+		let mut child = Command::new(&self.executable)
+			.args(arguments)
+			.stdin(Stdio::null())
+			.stdout(Stdio::piped())
+			.stderr(Stdio::piped())
+			.spawn()?;
+		let stdout = child
+			.stdout
+			.take()
+			.expect("piped solana-verify stdout must be available");
+		let stderr = child
+			.stderr
+			.take()
+			.expect("piped solana-verify stderr must be available");
+		let stdout_thread = std::thread::spawn(move || read_streaming(stdout, false));
+		let stderr_thread = std::thread::spawn(move || read_streaming(stderr, true));
+		let status = child.wait()?;
+		let stdout = join_reader(stdout_thread)?;
+		let stderr = join_reader(stderr_thread)?;
+
+		Ok(ProcessOutput {
+			status: process_status(status),
+			stdout,
+			stderr,
+		})
+	}
+}
+
+fn read_bounded(mut reader: impl Read) -> Result<Vec<u8>, std::io::Error> {
+	let mut captured = Vec::new();
+	let mut chunk = [0_u8; 8_192];
+
+	loop {
+		let read = reader.read(&mut chunk)?;
+
+		if read == 0 {
+			break;
+		}
+
+		let remaining = MAX_CAPTURED_OUTPUT.saturating_sub(captured.len());
+		captured.extend_from_slice(&chunk[..read.min(remaining)]);
+	}
+
+	Ok(captured)
+}
+
+fn read_streaming(mut reader: impl Read, stderr: bool) -> Result<Vec<u8>, std::io::Error> {
+	if stderr {
+		return read_streaming_to(&mut reader, std::io::stderr().lock());
+	}
+
+	read_streaming_to(&mut reader, std::io::stdout().lock())
+}
+
+fn read_streaming_to(
+	mut reader: impl Read,
+	mut writer: impl Write,
+) -> Result<Vec<u8>, std::io::Error> {
+	let mut captured = Vec::new();
+	let mut chunk = [0_u8; 8_192];
+	let mut write_error = None;
+
+	loop {
+		let read = reader.read(&mut chunk)?;
+
+		if read == 0 {
+			break;
+		}
+
+		if write_error.is_none()
+			&& let Err(error) = writer.write_all(&chunk[..read])
+		{
+			write_error = Some(error);
+		}
+
+		append_tail(&mut captured, &chunk[..read]);
+	}
+
+	write_error.map_or(Ok(captured), Err)
+}
+
+fn append_tail(captured: &mut Vec<u8>, chunk: &[u8]) {
+	if chunk.len() >= MAX_CAPTURED_OUTPUT {
+		captured.clear();
+		captured.extend_from_slice(&chunk[chunk.len() - MAX_CAPTURED_OUTPUT..]);
+		return;
+	}
+
+	let overflow = captured
+		.len()
+		.saturating_add(chunk.len())
+		.saturating_sub(MAX_CAPTURED_OUTPUT);
+
+	if overflow > 0 {
+		captured.drain(..overflow);
+	}
+
+	captured.extend_from_slice(chunk);
+}
+
+fn join_reader(
+	thread: std::thread::JoinHandle<Result<Vec<u8>, std::io::Error>>,
+) -> Result<Vec<u8>, std::io::Error> {
+	flatten_reader(thread.join())
+}
+
+fn flatten_reader(
+	result: std::thread::Result<Result<Vec<u8>, std::io::Error>>,
+) -> Result<Vec<u8>, std::io::Error> {
+	result.map_err(|_| std::io::Error::other("solana-verify output reader failed"))?
+}
+
+fn process_status(status: ExitStatus) -> ProcessStatus {
+	status
+		.code()
+		.map_or(ProcessStatus::Signal, ProcessStatus::Code)
+}
+
+/// Errors produced by deployed-program verification workflows.
+#[derive(Debug, thiserror::Error)]
+pub enum VerifyError {
+	#[error("invalid Solana program address")]
+	InvalidAddress,
+
+	#[error(
+		"cluster must be a known alias or an HTTP(S) origin without credentials, path, query, or \
+		 fragment"
+	)]
+	InvalidCluster,
+
+	#[error("repository must be a public HTTPS URL without credentials, query, or fragment")]
+	InvalidRepository,
+
+	#[error("revision must be a full 40-character hexadecimal Git SHA")]
+	InvalidRevision,
+
+	#[error("could not run `solana-verify`: {0}")]
+	MissingTool(std::io::Error),
+
+	#[error("unsupported solana-verify version; expected {SOLANA_VERIFY_VERSION}, found {found}")]
+	WrongVersion { found: String },
+
+	#[error("`solana-verify {command}` failed with {status}: {details}")]
+	CommandFailed {
+		command: &'static str,
+		status: ProcessStatus,
+		details: String,
+	},
+
+	#[error("`solana-verify {command}` returned an invalid executable hash")]
+	InvalidHash { command: &'static str },
+
+	#[error(transparent)]
+	Project(#[from] ProjectError),
+
+	#[error(transparent)]
+	VerifyBuild(#[from] VerifyBuildError),
+
+	#[error("program executable does not exist: {0}")]
+	MissingProgram(PathBuf),
+
+	#[error("could not read keypair {path}: {source}")]
+	ReadKeypair {
+		path: PathBuf,
+		source: std::io::Error,
+	},
+
+	#[error("could not create a private authority copy for solana-verify: {0}")]
+	StageKeypair(std::io::Error),
+
+	#[error("keypair at {0} is not a valid 64-byte Solana keypair")]
+	InvalidKeypair(PathBuf),
+
+	#[error("--authority is required unless --export provides an authority address")]
+	MissingAuthority,
+
+	#[error("--authority cannot be combined with an authority address supplied to --export")]
+	ConflictingAuthority,
+
+	#[error("recording verification metadata requires confirmation; pass --yes in automation")]
+	ConfirmationRequired,
+
+	#[error("mainnet recording requires --acknowledge-mainnet")]
+	MainnetAcknowledgementRequired,
+
+	#[error("--output is required with --export")]
+	MissingExportOutput,
+
+	#[error("could not write exported transaction to {path}: {source}")]
+	WriteExport {
+		path: PathBuf,
+		source: std::io::Error,
+	},
+
+	#[error("keypair path must be a private regular file and may not be a symbolic link: {0}")]
+	UnsafeKeypair(PathBuf),
+
+	#[error("export output did not end with a valid {encoding} transaction payload")]
+	InvalidExport { encoding: &'static str },
+
+	#[error("verified build record does not contain a public repository and full revision")]
+	MissingBuildProvenance,
+
+	#[error("verified build record contains an unsafe source path")]
+	UnsafeBuildPath,
+
+	#[error("verified build hash {local} does not match deployed program hash {deployed}")]
+	RecordMismatch { local: String, deployed: String },
+
+	#[error(
+		"solana-verify {SOLANA_VERIFY_VERSION} repository recording is unsupported on {host}; use \
+		 Linux or macOS"
+	)]
+	UnsupportedRecordHost { host: String },
+}
+
+impl VerifyError {
+	/// Return the documented process exit code for this failure.
+	#[must_use]
+	pub const fn exit_code(&self) -> i32 {
+		if matches!(self, Self::RecordMismatch { .. }) {
+			2
+		} else {
+			1
+		}
+	}
+}
+
+/// Compare an SBF executable with the deployed program through the official hash commands.
+///
+/// `solana-verify` removes trailing zero bytes before hashing both executables. Delegating both
+/// hashes preserves that official behavior rather than reproducing it independently.
+///
+/// # Errors
+///
+/// Returns an error for invalid input, project discovery failure, missing tools, unsupported tool
+/// versions, malformed hashes, or unsuccessful child processes.
+pub fn check_program(
+	executor: &impl VerifyExecutor,
+	options: &CheckOptions,
+) -> Result<CheckResult, VerifyError> {
+	let program_id = parse_address(&options.program_id)?;
+	let executable = resolve_executable(options)?;
+
+	check_tool_version(executor)?;
+	let local = run_hash(
+		executor,
+		"get-executable-hash",
+		[
+			OsString::from("get-executable-hash"),
+			executable.into_os_string(),
+		],
+	)?;
+	let deployed = run_hash(
+		executor,
+		"get-program-hash",
+		[
+			OsString::from("-u"),
+			OsString::from(options.cluster.rpc()),
+			OsString::from("get-program-hash"),
+			OsString::from(program_id.to_string()),
+		],
+	)?;
+
+	if local == deployed {
+		return Ok(CheckResult::Match { hash: local });
+	}
+
+	Ok(CheckResult::Mismatch { local, deployed })
+}
+
+/// Record or export repository verification metadata through `solana-verify`.
+///
+/// # Errors
+///
+/// Returns an error when inputs or keypairs are invalid, safety acknowledgement is absent, project
+/// paths are ambiguous, export cannot be written, or `solana-verify` fails.
+pub fn record_program(
+	executor: &impl VerifyExecutor,
+	options: &RecordOptions,
+) -> Result<ProcessOutput, VerifyError> {
+	record_program_for_host(executor, options, std::env::consts::OS)
+}
+
+fn record_program_for_host(
+	executor: &impl VerifyExecutor,
+	options: &RecordOptions,
+	host: &str,
+) -> Result<ProcessOutput, VerifyError> {
+	let exporting = options.export_authority.is_some() || options.export_output.is_some();
+
+	if !exporting && !options.confirmed {
+		return Err(VerifyError::ConfirmationRequired);
+	}
+
+	let plan = prepare_record_for_host(options, host)?;
+	execute_record(executor, &plan)
+}
+
+/// Validate all local inputs and freeze them into one confirmation and execution plan.
+///
+/// This performs no network calls and does not invoke `solana-verify`.
+///
+/// # Errors
+///
+/// Returns an error when the host, address, build record, provenance, paths, export output, or
+/// authority keypair is invalid.
+pub fn prepare_record(options: &RecordOptions) -> Result<RecordPlan, VerifyError> {
+	prepare_record_for_host(options, std::env::consts::OS)
+}
+
+fn prepare_record_for_host(options: &RecordOptions, host: &str) -> Result<RecordPlan, VerifyError> {
+	ensure_record_host(host)?;
+	let program_id = parse_address(&options.program_id)?;
+	let exporting = options.export_authority.is_some() || options.export_output.is_some();
+
+	let record = crate::build::read_verified_build_record(&options.build_record)?;
+	let context = project_context(&record)?;
+	let (authority, staged_authority) = if exporting {
+		let authority = export_authority(options)?;
+		(authority, None)
+	} else {
+		let authority_path = options
+			.authority
+			.as_deref()
+			.ok_or(VerifyError::MissingAuthority)?;
+		let keypair = read_keypair(authority_path)?;
+		let authority = keypair.address;
+		let staged = stage_keypair(&keypair.contents)?;
+		(authority, Some(staged))
+	};
+
+	Ok(RecordPlan {
+		options: options.clone(),
+		program_id,
+		context,
+		record_hash: record.executable_hash().to_owned(),
+		authority,
+		staged_authority,
+	})
+}
+
+/// Execute one previously prepared and, when mutating, confirmed record plan.
+///
+/// # Errors
+///
+/// Returns an error when confirmation or network safety is absent, hashes differ, the official
+/// tool fails, or an exported transaction cannot be validated and written.
+pub fn execute_record(
+	executor: &impl VerifyExecutor,
+	plan: &RecordPlan,
+) -> Result<ProcessOutput, VerifyError> {
+	let exporting = plan.options.export_authority.is_some() || plan.options.export_output.is_some();
+
+	if exporting {
+		return export_record(executor, plan);
+	}
+
+	if !plan.options.confirmed {
+		return Err(VerifyError::ConfirmationRequired);
+	}
+
+	if plan.options.cluster.requires_mainnet_acknowledgement() && !plan.options.mainnet_acknowledged
+	{
+		return Err(VerifyError::MainnetAcknowledgementRequired);
+	}
+
+	let authority_path = &plan
+		.staged_authority
+		.as_ref()
+		.ok_or(VerifyError::MissingAuthority)?
+		.path;
+
+	check_tool_version(executor)?;
+	let deployed = run_hash(
+		executor,
+		"get-program-hash",
+		[
+			OsString::from("-u"),
+			OsString::from(plan.options.cluster.rpc()),
+			OsString::from("get-program-hash"),
+			OsString::from(plan.program_id.to_string()),
+		],
+	)?;
+
+	if deployed != plan.record_hash {
+		return Err(VerifyError::RecordMismatch {
+			local: plan.record_hash.clone(),
+			deployed,
+		});
+	}
+
+	let arguments = record_arguments(
+		&plan.options,
+		&plan.context,
+		authority_path,
+		&plan.program_id,
+	);
+	let output = run_streaming_checked(executor, "verify-from-repo", &arguments)?;
+	guard_record_transcript(&output.stdout)?;
+
+	Ok(ProcessOutput {
+		stdout: Vec::new(),
+		stderr: Vec::new(),
+		..output
+	})
+}
+
+/// Validate and resolve every value shown by the interactive recording prompt.
+///
+/// This performs no network calls and does not invoke `solana-verify`.
+///
+/// # Errors
+///
+/// Returns an error when the host, program address, build record, provenance, paths, or authority
+/// keypair is invalid.
+pub fn review_record(options: &RecordOptions) -> Result<RecordReview, VerifyError> {
+	Ok(prepare_record(options)?.review())
+}
+
+fn ensure_record_host(host: &str) -> Result<(), VerifyError> {
+	if matches!(host, "linux" | "macos") {
+		return Ok(());
+	}
+
+	Err(VerifyError::UnsupportedRecordHost {
+		host: host.to_owned(),
+	})
+}
+
+/// Submit a mainnet remote-verifier job.
+///
+/// # Errors
+///
+/// Returns an error for invalid addresses, unavailable tools, unsupported versions, or a failed
+/// remote submission.
+pub fn submit_program(
+	executor: &impl VerifyExecutor,
+	program_id: &str,
+	uploader: &str,
+) -> Result<ProcessOutput, VerifyError> {
+	let program_id = parse_address(program_id)?;
+	let uploader = parse_address(uploader)?;
+
+	check_tool_version(executor)?;
+	run_checked(
+		executor,
+		"remote submit-job",
+		&[
+			OsString::from("-u"),
+			OsString::from(MAINNET_RPC),
+			OsString::from("remote"),
+			OsString::from("submit-job"),
+			OsString::from("--program-id"),
+			OsString::from(program_id.to_string()),
+			OsString::from("--uploader"),
+			OsString::from(uploader.to_string()),
+		],
+	)
+}
+
+/// Fetch remote verification status for a program.
+///
+/// # Errors
+///
+/// Returns an error for invalid addresses, unavailable tools, unsupported versions, or a failed
+/// status command.
+pub fn status_program(
+	executor: &impl VerifyExecutor,
+	program_id: &str,
+) -> Result<ProcessOutput, VerifyError> {
+	let program_id = parse_address(program_id)?;
+
+	check_tool_version(executor)?;
+	run_checked(
+		executor,
+		"remote get-status",
+		&[
+			OsString::from("-u"),
+			OsString::from(MAINNET_RPC),
+			OsString::from("remote"),
+			OsString::from("get-status"),
+			OsString::from("--program-id"),
+			OsString::from(program_id.to_string()),
+		],
+	)
+}
+
+fn parse_address(value: &str) -> Result<Address, VerifyError> {
+	Address::from_str(value).map_err(|_| VerifyError::InvalidAddress)
+}
+
+fn resolve_executable(options: &CheckOptions) -> Result<PathBuf, VerifyError> {
+	let path = if let Some(path) = &options.program {
+		path.clone()
+	} else {
+		let project = Project::discover(&options.project_dir)?;
+		project
+			.target_dir
+			.join("deploy")
+			.join(format!("{}.so", project.library_name))
+	};
+
+	if !path.is_file() {
+		return Err(VerifyError::MissingProgram(path));
+	}
+
+	Ok(path)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ProjectContext {
+	repository: RepositoryUrl,
+	revision: Revision,
+	mount_path: String,
+	workspace_path: String,
+	library_name: String,
+	features: Vec<String>,
+	default_features: bool,
+}
+
+fn project_context(
+	record: &crate::build::VerifiedBuildRecord,
+) -> Result<ProjectContext, VerifyError> {
+	let repository = record
+		.repository()
+		.ok_or(VerifyError::MissingBuildProvenance)?
+		.parse()?;
+	let revision = record
+		.revision()
+		.ok_or(VerifyError::MissingBuildProvenance)?
+		.parse()?;
+	let mount_path = verified_relative_path(record.mount_path())?;
+	let workspace_path = verified_relative_path(record.workspace_path())?;
+
+	Ok(ProjectContext {
+		repository,
+		revision,
+		mount_path,
+		workspace_path,
+		library_name: record.library_name().to_owned(),
+		features: record.features().to_vec(),
+		default_features: record.default_features(),
+	})
+}
+
+fn verified_relative_path(value: &str) -> Result<String, VerifyError> {
+	let path = Path::new(value);
+
+	if path.is_absolute()
+		|| path
+			.components()
+			.any(|component| matches!(component, std::path::Component::ParentDir))
+	{
+		return Err(VerifyError::UnsafeBuildPath);
+	}
+
+	Ok(value.replace('\\', "/"))
+}
+
+struct ValidatedKeypair {
+	address: Address,
+	contents: Vec<u8>,
+}
+
+fn read_keypair(path: &Path) -> Result<ValidatedKeypair, VerifyError> {
+	let initial_metadata = map_keypair_io(path, fs::symlink_metadata(path))?;
+
+	if !initial_metadata.file_type().is_file() {
+		return Err(VerifyError::UnsafeKeypair(path.to_path_buf()));
+	}
+
+	#[cfg(windows)]
+	{
+		use std::os::windows::fs::MetadataExt;
+
+		const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+
+		if initial_metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+			return Err(VerifyError::UnsafeKeypair(path.to_path_buf()));
+		}
+	}
+
+	let mut file = map_keypair_io(path, fs::File::open(path))?;
+	let opened_metadata = map_keypair_io(path, file.metadata())?;
+	validate_keypair_metadata(path, &initial_metadata, &opened_metadata)?;
+	let contents = read_keypair_contents(path, &mut file)?;
+	let bytes = serde_json::from_slice::<Vec<u8>>(&contents)
+		.map_err(|_| VerifyError::InvalidKeypair(path.to_path_buf()))?;
+	let keypair: [u8; 64] = bytes
+		.try_into()
+		.map_err(|_| VerifyError::InvalidKeypair(path.to_path_buf()))?;
+	let secret: [u8; 32] = keypair[..32]
+		.try_into()
+		.map_err(|_| VerifyError::InvalidKeypair(path.to_path_buf()))?;
+	let signing_key = SigningKey::from_bytes(&secret);
+	let expected_public = signing_key.verifying_key().to_bytes();
+
+	if keypair[32..] != expected_public {
+		return Err(VerifyError::InvalidKeypair(path.to_path_buf()));
+	}
+
+	Ok(ValidatedKeypair {
+		address: Address::new_from_array(expected_public),
+		contents,
+	})
+}
+
+fn validate_keypair_metadata(
+	path: &Path,
+	initial: &fs::Metadata,
+	opened: &fs::Metadata,
+) -> Result<(), VerifyError> {
+	if !opened.file_type().is_file() {
+		return Err(VerifyError::UnsafeKeypair(path.to_path_buf()));
+	}
+
+	#[cfg(unix)]
+	{
+		use std::os::unix::fs::MetadataExt;
+		use std::os::unix::fs::PermissionsExt;
+
+		if initial.dev() != opened.dev()
+			|| initial.ino() != opened.ino()
+			|| opened.permissions().mode() & 0o077 != 0
+		{
+			return Err(VerifyError::UnsafeKeypair(path.to_path_buf()));
+		}
+	}
+	#[cfg(not(unix))]
+	let _ = initial;
+
+	if opened.len() > MAX_KEYPAIR_BYTES as u64 {
+		return Err(VerifyError::UnsafeKeypair(path.to_path_buf()));
+	}
+
+	Ok(())
+}
+
+fn read_keypair_contents(path: &Path, reader: &mut impl Read) -> Result<Vec<u8>, VerifyError> {
+	let mut contents = Vec::new();
+	let read = reader
+		.take((MAX_KEYPAIR_BYTES + 1) as u64)
+		.read_to_end(&mut contents);
+	map_keypair_io(path, read)?;
+
+	if contents.len() > MAX_KEYPAIR_BYTES {
+		return Err(VerifyError::UnsafeKeypair(path.to_path_buf()));
+	}
+
+	Ok(contents)
+}
+
+fn map_keypair_io<T>(path: &Path, result: Result<T, std::io::Error>) -> Result<T, VerifyError> {
+	result.map_err(|source| {
+		VerifyError::ReadKeypair {
+			path: path.to_path_buf(),
+			source,
+		}
+	})
+}
+
+fn stage_keypair(contents: &[u8]) -> Result<StagedAuthority, VerifyError> {
+	let directory = tempfile::Builder::new()
+		.prefix("pina-verify-authority-")
+		.tempdir()
+		.map_err(VerifyError::StageKeypair)?;
+	let path = directory.path().join("authority.json");
+	let mut options = OpenOptions::new();
+	options.write(true).create_new(true);
+	#[cfg(unix)]
+	{
+		use std::os::unix::fs::OpenOptionsExt;
+
+		options.mode(0o600);
+	}
+	let mut file = options.open(&path).map_err(VerifyError::StageKeypair)?;
+	file.write_all(contents)
+		.and_then(|()| file.sync_all())
+		.map_err(VerifyError::StageKeypair)?;
+
+	Ok(StagedAuthority {
+		_directory: directory,
+		path,
+	})
+}
+
+fn export_authority(options: &RecordOptions) -> Result<Address, VerifyError> {
+	if options.export_output.is_none() {
+		return Err(VerifyError::MissingExportOutput);
+	}
+
+	match options.export_authority.as_deref() {
+		Some(value) if !value.is_empty() => {
+			if options.authority.is_some() {
+				return Err(VerifyError::ConflictingAuthority);
+			}
+
+			parse_address(value)
+		}
+		_ => {
+			let authority_path = options
+				.authority
+				.as_deref()
+				.ok_or(VerifyError::MissingAuthority)?;
+			Ok(read_keypair(authority_path)?.address)
+		}
+	}
+}
+
+fn check_tool_version(executor: &impl VerifyExecutor) -> Result<(), VerifyError> {
+	let output = executor
+		.run(&[OsString::from("--version")])
+		.map_err(VerifyError::MissingTool)?;
+
+	if !output.status.success() {
+		return Err(command_failed("--version", &output));
+	}
+
+	let found = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+	let accepted = format!("solana-verify {SOLANA_VERIFY_VERSION}");
+
+	if found != accepted {
+		return Err(VerifyError::WrongVersion { found });
+	}
+
+	Ok(())
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn run_hash<const N: usize>(
+	executor: &impl VerifyExecutor,
+	command: &'static str,
+	arguments: [OsString; N],
+) -> Result<String, VerifyError> {
+	let output = run_checked(executor, command, &arguments)?;
+	let hash = String::from_utf8_lossy(&output.stdout)
+		.trim()
+		.to_ascii_lowercase();
+
+	if hash.len() != 64 || !hash.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+		return Err(VerifyError::InvalidHash { command });
+	}
+
+	Ok(hash)
+}
+
+fn run_checked(
+	executor: &impl VerifyExecutor,
+	command: &'static str,
+	arguments: &[OsString],
+) -> Result<ProcessOutput, VerifyError> {
+	let output = executor.run(arguments).map_err(VerifyError::MissingTool)?;
+
+	if !output.status.success() {
+		return Err(command_failed(command, &output));
+	}
+
+	Ok(output)
+}
+
+fn run_streaming_checked(
+	executor: &impl VerifyExecutor,
+	command: &'static str,
+	arguments: &[OsString],
+) -> Result<ProcessOutput, VerifyError> {
+	let output = executor
+		.run_streaming(arguments)
+		.map_err(VerifyError::MissingTool)?;
+
+	if !output.status.success() {
+		return Err(command_failed(command, &output));
+	}
+
+	Ok(output)
+}
+
+fn command_failed(command: &'static str, output: &ProcessOutput) -> VerifyError {
+	let details = sanitize_diagnostics(&String::from_utf8_lossy(&output.stderr));
+	let details = details.trim().to_owned();
+	let details = if details.is_empty() {
+		"no diagnostic output".to_owned()
+	} else {
+		details
+	};
+
+	VerifyError::CommandFailed {
+		command,
+		status: output.status,
+		details,
+	}
+}
+
+fn sanitize_diagnostics(value: &str) -> String {
+	let redacted: String = value
+		.split_inclusive(char::is_whitespace)
+		.map(|token| {
+			let bare = token.trim_end_matches(char::is_whitespace);
+			let whitespace = &token[bare.len()..];
+			let suffix_index = bare
+				.trim_end_matches(['.', ',', ':', ';', ')', ']', '}'])
+				.len();
+			let (candidate, suffix) = bare.split_at(suffix_index);
+			let redacted = Url::parse(candidate).ok().and_then(|url| {
+				let host = url.host_str()?;
+				Some(match url.port() {
+					Some(port) => format!("{}://{host}:{port}", url.scheme()),
+					None => format!("{}://{host}", url.scheme()),
+				})
+			});
+
+			match redacted {
+				Some(redacted) => format!("{redacted}{suffix}{whitespace}"),
+				None => format!("{bare}{whitespace}"),
+			}
+		})
+		.collect();
+	let mut escaped = String::with_capacity(redacted.len());
+
+	for character in redacted.chars() {
+		if character.is_control() && !matches!(character, '\n' | '\t') {
+			escaped.extend(character.escape_default());
+		} else {
+			escaped.push(character);
+		}
+	}
+
+	escaped
+}
+
+fn record_arguments(
+	options: &RecordOptions,
+	context: &ProjectContext,
+	authority: &Path,
+	program_id: &Address,
+) -> Vec<OsString> {
+	let mut arguments = vec![
+		OsString::from("-u"),
+		OsString::from(options.cluster.rpc()),
+		OsString::from("verify-from-repo"),
+		OsString::from(context.repository.as_str()),
+		OsString::from("--commit-hash"),
+		OsString::from(context.revision.as_str()),
+		OsString::from("--program-id"),
+		OsString::from(program_id.to_string()),
+		OsString::from("--mount-path"),
+		OsString::from(&context.mount_path),
+		OsString::from("--workspace-path"),
+		OsString::from(&context.workspace_path),
+		OsString::from("--library-name"),
+		OsString::from(&context.library_name),
+		OsString::from("--skip-prompt"),
+		OsString::from("--keypair"),
+		authority.as_os_str().to_owned(),
+	];
+	append_cargo_arguments(&mut arguments, context);
+	arguments
+}
+
+fn append_cargo_arguments(arguments: &mut Vec<OsString>, context: &ProjectContext) {
+	if context.features.is_empty() && context.default_features {
+		return;
+	}
+
+	arguments.push(OsString::from("--"));
+
+	if !context.features.is_empty() {
+		arguments.push(OsString::from("--features"));
+		arguments.push(OsString::from(context.features.join(",")));
+	}
+
+	if !context.default_features {
+		arguments.push(OsString::from("--no-default-features"));
+	}
+}
+
+fn guard_record_transcript(stdout: &[u8]) -> Result<(), VerifyError> {
+	let transcript = String::from_utf8_lossy(stdout);
+
+	if !transcript.contains("Program hashes do not match") {
+		return Ok(());
+	}
+
+	let local = transcript_hash(&transcript, "Executable Program Hash from repo:")
+		.unwrap_or_else(|| "unknown".to_owned());
+	let deployed = transcript_hash(&transcript, "On-chain Program Hash:")
+		.unwrap_or_else(|| "unknown".to_owned());
+
+	Err(VerifyError::RecordMismatch { local, deployed })
+}
+
+fn transcript_hash(transcript: &str, prefix: &str) -> Option<String> {
+	transcript.lines().rev().find_map(|line| {
+		let value = line.strip_prefix(prefix)?.trim();
+
+		(value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit()))
+			.then(|| value.to_ascii_lowercase())
+	})
+}
+
+fn export_record(
+	executor: &impl VerifyExecutor,
+	plan: &RecordPlan,
+) -> Result<ProcessOutput, VerifyError> {
+	let output_path = plan
+		.options
+		.export_output
+		.as_deref()
+		.ok_or(VerifyError::MissingExportOutput)?;
+
+	check_tool_version(executor)?;
+	let deployed = run_hash(
+		executor,
+		"get-program-hash",
+		[
+			OsString::from("-u"),
+			OsString::from(plan.options.cluster.rpc()),
+			OsString::from("get-program-hash"),
+			OsString::from(plan.program_id.to_string()),
+		],
+	)?;
+
+	if deployed != plan.record_hash {
+		return Err(VerifyError::RecordMismatch {
+			local: plan.record_hash.clone(),
+			deployed,
+		});
+	}
+
+	let mut arguments = vec![
+		OsString::from("-u"),
+		OsString::from(plan.options.cluster.rpc()),
+		OsString::from("export-pda-tx"),
+		OsString::from("--uploader"),
+		OsString::from(plan.authority.to_string()),
+		OsString::from("--encoding"),
+		OsString::from(plan.options.export_encoding.as_str()),
+		OsString::from("--mount-path"),
+		OsString::from(&plan.context.mount_path),
+		OsString::from("--workspace-path"),
+		OsString::from(&plan.context.workspace_path),
+		OsString::from("--library-name"),
+		OsString::from(&plan.context.library_name),
+		OsString::from(plan.context.repository.as_str()),
+		OsString::from("--commit-hash"),
+		OsString::from(plan.context.revision.as_str()),
+		OsString::from("--program-id"),
+		OsString::from(plan.program_id.to_string()),
+	];
+	append_cargo_arguments(&mut arguments, &plan.context);
+	let output = run_checked(executor, "export-pda-tx", &arguments)?;
+	let (diagnostics, payload) = split_export_output(&output.stdout, plan.options.export_encoding)?;
+
+	write_export(output_path, payload.as_bytes())?;
+	Ok(ProcessOutput {
+		stdout: diagnostics,
+		..output
+	})
+}
+
+fn split_export_output(
+	stdout: &[u8],
+	encoding: ExportEncoding,
+) -> Result<(Vec<u8>, String), VerifyError> {
+	let text = std::str::from_utf8(stdout).map_err(|_| {
+		VerifyError::InvalidExport {
+			encoding: encoding.as_str(),
+		}
+	})?;
+	let trimmed = text.trim_end_matches(['\r', '\n']);
+	let split = trimmed.rfind('\n');
+	let (diagnostics, payload) = split.map_or(("", trimmed), |index| {
+		(&trimmed[..=index], &trimmed[index + 1..])
+	});
+	let decoded = match encoding {
+		ExportEncoding::Base64 => {
+			base64::engine::general_purpose::STANDARD
+				.decode(payload)
+				.map_err(|_| ())
+		}
+		ExportEncoding::Base58 => bs58::decode(payload).into_vec().map_err(|_| ()),
+	}
+	.map_err(|()| {
+		VerifyError::InvalidExport {
+			encoding: encoding.as_str(),
+		}
+	})?;
+
+	if decoded.len() < 64 {
+		return Err(VerifyError::InvalidExport {
+			encoding: encoding.as_str(),
+		});
+	}
+
+	Ok((diagnostics.as_bytes().to_vec(), payload.to_owned()))
+}
+
+fn write_export(path: &Path, contents: &[u8]) -> Result<(), VerifyError> {
+	let mut file = AtomicWriteFile::open(path).map_err(|source| {
+		VerifyError::WriteExport {
+			path: path.to_path_buf(),
+			source,
+		}
+	})?;
+	let result = file.write_all(contents).and_then(|()| file.commit());
+	map_export_write_result(path, result)
+}
+
+fn map_export_write_result(
+	path: &Path,
+	result: Result<(), std::io::Error>,
+) -> Result<(), VerifyError> {
+	result.map_err(|source| {
+		VerifyError::WriteExport {
+			path: path.to_path_buf(),
+			source,
+		}
+	})
+}
+
+#[cfg(test)]
+mod tests {
+	use std::cell::RefCell;
+	use std::collections::VecDeque;
+
+	use sha2::Digest;
+	use sha2::Sha256;
+	use tempfile::TempDir;
+
+	use super::*;
+
+	const PROGRAM_ID: &str = "11111111111111111111111111111111";
+	const UPLOADER: &str = "SysvarRent111111111111111111111111111111111";
+	const REVISION: &str = "0123456789abcdef0123456789abcdef01234567";
+
+	#[derive(Default)]
+	struct FakeExecutor {
+		outputs: RefCell<VecDeque<Result<ProcessOutput, std::io::Error>>>,
+		calls: RefCell<Vec<Vec<OsString>>>,
+	}
+
+	impl FakeExecutor {
+		fn with(outputs: impl IntoIterator<Item = ProcessOutput>) -> Self {
+			Self {
+				outputs: RefCell::new(outputs.into_iter().map(Ok).collect()),
+				calls: RefCell::default(),
+			}
+		}
+	}
+
+	impl VerifyExecutor for FakeExecutor {
+		fn run(&self, arguments: &[OsString]) -> Result<ProcessOutput, std::io::Error> {
+			self.calls.borrow_mut().push(arguments.to_vec());
+			self.outputs
+				.borrow_mut()
+				.pop_front()
+				.unwrap_or_else(|| Err(std::io::Error::other("missing fake output")))
+		}
+	}
+
+	fn output(code: i32, stdout: impl AsRef<[u8]>, stderr: impl AsRef<[u8]>) -> ProcessOutput {
+		ProcessOutput {
+			status: ProcessStatus::Code(code),
+			stdout: stdout.as_ref().to_vec(),
+			stderr: stderr.as_ref().to_vec(),
+		}
+	}
+
+	fn version() -> ProcessOutput {
+		output(0, "solana-verify 0.5.1\n", "")
+	}
+
+	fn record_hash() -> String {
+		format!("{:x}", Sha256::digest([7_u8; 128]))
+	}
+
+	fn record_program_for_test(
+		executor: &impl VerifyExecutor,
+		options: &RecordOptions,
+	) -> Result<ProcessOutput, VerifyError> {
+		record_program_for_host(executor, options, "linux")
+	}
+
+	fn prepare_record_for_test(options: &RecordOptions) -> Result<RecordPlan, VerifyError> {
+		prepare_record_for_host(options, "linux")
+	}
+
+	fn review_record_for_test(options: &RecordOptions) -> Result<RecordReview, VerifyError> {
+		Ok(prepare_record_for_test(options)?.review())
+	}
+
+	#[test]
+	fn validates_cluster_aliases_and_redacts_custom_rpc() {
+		assert!(
+			Cluster::from_str("mainnet-beta")
+				.unwrap()
+				.requires_mainnet_acknowledgement()
+		);
+		assert_eq!(Cluster::from_str("devnet").unwrap().rpc(), DEVNET_RPC);
+		assert_eq!(Cluster::from_str("testnet").unwrap().rpc(), TESTNET_RPC);
+		assert_eq!(Cluster::from_str("localhost").unwrap().rpc(), LOCALNET_RPC);
+		let custom = Cluster::from_str("https://rpc.example.com").unwrap();
+		assert_eq!(custom.display_name(), "https://rpc.example.com");
+		assert!(custom.requires_mainnet_acknowledgement());
+		assert!(!format!("{custom:?}").contains("token"));
+		assert!(Cluster::from_str("https://user:pass@example.com/rpc?token=secret").is_err());
+		assert!(Cluster::from_str("http://rpc.example.com").is_err());
+		assert!(Cluster::from_str("file:///tmp/rpc").is_err());
+		assert_eq!(
+			Cluster::from_str("http://[::1]:8899")
+				.unwrap()
+				.display_name(),
+			"http://[::1]:8899"
+		);
+	}
+
+	#[test]
+	fn validates_public_repository_and_full_revision() {
+		assert!(RepositoryUrl::from_str("https://github.com/pina-rs/pina").is_ok());
+		for value in [
+			"http://github.com/pina-rs/pina",
+			"https://user@github.com/pina-rs/pina",
+			"https://localhost/repo",
+			"https://127.0.0.1/repo",
+			"https://example.com/repo?token=x",
+			"https://repo.local/project",
+			"https://repo.internal/project",
+			"https://repo.test/project",
+			"https://[fc00::1]/project",
+			"https://[fe80::1]/project",
+			"https://[2001:db8::1]/project",
+			"https://[::ffff:127.0.0.1]/project",
+			"https://[::ffff:10.0.0.1]/project",
+		] {
+			assert!(RepositoryUrl::from_str(value).is_err(), "accepted {value}");
+		}
+		for domain in [
+			"bad..example.com",
+			"-bad.example.com",
+			"bad-.example.com",
+			"bad_label.example.com",
+			"localhost",
+		] {
+			assert!(!is_public_domain(domain));
+		}
+		assert!(is_public_domain("github.com."));
+		assert_eq!(
+			Revision::from_str(&REVISION.to_uppercase())
+				.unwrap()
+				.as_str(),
+			REVISION
+		);
+		assert!(Revision::from_str("abc123").is_err());
+		assert!(is_public_host(Some(Host::Ipv4("8.8.8.8".parse().unwrap()))));
+		for address in [
+			"10.0.0.1",
+			"127.0.0.1",
+			"169.254.1.1",
+			"255.255.255.255",
+			"192.0.2.1",
+			"224.0.0.1",
+			"0.0.0.0",
+		] {
+			assert!(!is_public_host(Some(Host::Ipv4(address.parse().unwrap()))));
+		}
+		assert!(is_public_host(Some(Host::Ipv6(
+			"2001:4860:4860::8888".parse().unwrap()
+		))));
+		assert!(!is_public_host(Some(Host::Ipv6("::".parse().unwrap()))));
+		for address in [
+			"fc00::1",
+			"fe80::1",
+			"ff02::1",
+			"2001:db8::1",
+			"::ffff:10.0.0.1",
+		] {
+			assert!(!is_public_host(Some(Host::Ipv6(address.parse().unwrap()))));
+		}
+		assert!(!is_public_host(None));
+	}
+
+	#[test]
+	fn covers_small_helpers_and_bounded_reader_errors() {
+		assert_eq!(ExportEncoding::Base58.as_str(), "base58");
+		assert_eq!(ProcessStatus::Code(3).to_string(), "exit code 3");
+		assert!(format!("{:?}", SystemVerifyExecutor::default()).contains("solana-verify"));
+
+		let mut tail = vec![1_u8; 12];
+		append_tail(&mut tail, &vec![2_u8; MAX_CAPTURED_OUTPUT + 1]);
+		assert_eq!(tail.len(), MAX_CAPTURED_OUTPUT);
+		assert!(tail.iter().all(|byte| *byte == 2));
+
+		struct ErrorReader;
+		impl Read for ErrorReader {
+			fn read(&mut self, _buffer: &mut [u8]) -> Result<usize, std::io::Error> {
+				Err(std::io::Error::other("read failed"))
+			}
+		}
+		assert!(read_bounded(ErrorReader).is_err());
+		let panic_result: std::thread::Result<Result<Vec<u8>, std::io::Error>> =
+			Err(Box::new("fixture panic"));
+		assert!(flatten_reader(panic_result).is_err());
+
+		let mut arguments = Vec::new();
+		append_cargo_arguments(
+			&mut arguments,
+			&ProjectContext {
+				repository: RepositoryUrl::from_str("https://github.com/pina-rs/pina").unwrap(),
+				revision: Revision::from_str(REVISION).unwrap(),
+				mount_path: ".".to_owned(),
+				workspace_path: ".".to_owned(),
+				library_name: "fixture".to_owned(),
+				features: Vec::new(),
+				default_features: true,
+			},
+		);
+		assert!(arguments.is_empty());
+	}
+
+	#[test]
+	fn compares_official_hashes_and_preserves_paths_with_spaces() {
+		let temp = TempDir::new().unwrap();
+		let program = temp.path().join("program with spaces.so");
+		fs::write(&program, b"binary\0\0").unwrap();
+		let hash = "a".repeat(64);
+		let executor = FakeExecutor::with([
+			version(),
+			output(0, format!("{hash}\n"), ""),
+			output(0, format!("{hash}\n"), ""),
+		]);
+		let result = check_program(
+			&executor,
+			&CheckOptions {
+				program_id: PROGRAM_ID.to_owned(),
+				cluster: Cluster::from_str("devnet").unwrap(),
+				program: Some(program.clone()),
+				project_dir: PathBuf::from("unused"),
+			},
+		)
+		.unwrap();
+
+		assert_eq!(result, CheckResult::Match { hash });
+		assert_eq!(executor.calls.borrow()[1][1], program.as_os_str());
+	}
+
+	#[test]
+	fn check_discovers_the_project_executable() {
+		let temp = TempDir::new().unwrap();
+		fs::create_dir_all(temp.path().join("src")).unwrap();
+		fs::create_dir_all(temp.path().join("target/deploy")).unwrap();
+		fs::write(
+			temp.path().join("Cargo.toml"),
+			"[package]\nname = \"fixture-program\"\nversion = \"0.1.0\"\nedition = \
+			 \"2024\"\n\n[lib]\ncrate-type = [\"cdylib\"]\n",
+		)
+		.unwrap();
+		fs::write(temp.path().join("src/lib.rs"), "").unwrap();
+		fs::write(temp.path().join("target/deploy/fixture_program.so"), b"sbf").unwrap();
+		let hash = "a".repeat(64);
+		let executor = FakeExecutor::with([
+			version(),
+			output(0, format!("{hash}\n"), ""),
+			output(0, format!("{hash}\n"), ""),
+		]);
+		let result = check_program(
+			&executor,
+			&CheckOptions {
+				program_id: PROGRAM_ID.to_owned(),
+				cluster: Cluster::from_str("devnet").unwrap(),
+				program: None,
+				project_dir: temp.path().to_path_buf(),
+			},
+		)
+		.unwrap();
+		assert!(matches!(result, CheckResult::Match { .. }));
+	}
+
+	#[test]
+	fn reports_hash_mismatch_without_error() {
+		let temp = TempDir::new().unwrap();
+		let program = temp.path().join("program.so");
+		fs::write(&program, b"binary").unwrap();
+		let executor = FakeExecutor::with([
+			version(),
+			output(0, format!("{}\n", "a".repeat(64)), ""),
+			output(0, format!("{}\n", "b".repeat(64)), ""),
+		]);
+		let result = check_program(
+			&executor,
+			&CheckOptions {
+				program_id: PROGRAM_ID.to_owned(),
+				cluster: Cluster::from_str("devnet").unwrap(),
+				program: Some(program),
+				project_dir: PathBuf::new(),
+			},
+		)
+		.unwrap();
+
+		assert!(matches!(result, CheckResult::Mismatch { .. }));
+	}
+
+	#[test]
+	fn reports_missing_tool_version_hash_status_and_signal() {
+		let missing = FakeExecutor::default();
+		let error = check_tool_version(&missing).unwrap_err();
+		assert!(matches!(error, VerifyError::MissingTool(_)));
+
+		let wrong = FakeExecutor::with([output(0, "solana-verify 0.6.0", "")]);
+		assert!(matches!(
+			check_tool_version(&wrong),
+			Err(VerifyError::WrongVersion { .. })
+		));
+
+		let failed = FakeExecutor::with([output(7, "", "network failed")]);
+		assert!(matches!(
+			check_tool_version(&failed),
+			Err(VerifyError::CommandFailed {
+				status: ProcessStatus::Code(7),
+				..
+			})
+		));
+
+		let signaled = command_failed(
+			"remote get-status",
+			&ProcessOutput {
+				status: ProcessStatus::Signal,
+				stdout: Vec::new(),
+				stderr: Vec::new(),
+			},
+		);
+		assert!(signaled.to_string().contains("signal"));
+		assert!(signaled.to_string().contains("no diagnostic output"));
+
+		let malformed = FakeExecutor::with([version(), output(0, "not-a-hash", "")]);
+		let temp = TempDir::new().unwrap();
+		let program = temp.path().join("program.so");
+		fs::write(&program, b"binary").unwrap();
+		let result = check_program(
+			&malformed,
+			&CheckOptions {
+				program_id: PROGRAM_ID.to_owned(),
+				cluster: Cluster::from_str("devnet").unwrap(),
+				program: Some(program),
+				project_dir: PathBuf::new(),
+			},
+		);
+		assert!(matches!(result, Err(VerifyError::InvalidHash { .. })));
+	}
+
+	#[test]
+	fn rejects_invalid_addresses_and_missing_programs_before_execution() {
+		let executor = FakeExecutor::default();
+		let invalid = check_program(
+			&executor,
+			&CheckOptions {
+				program_id: "invalid".to_owned(),
+				cluster: Cluster::from_str("devnet").unwrap(),
+				program: Some(PathBuf::from("missing.so")),
+				project_dir: PathBuf::new(),
+			},
+		);
+		assert!(matches!(invalid, Err(VerifyError::InvalidAddress)));
+
+		let missing = check_program(
+			&executor,
+			&CheckOptions {
+				program_id: PROGRAM_ID.to_owned(),
+				cluster: Cluster::from_str("devnet").unwrap(),
+				program: Some(PathBuf::from("missing.so")),
+				project_dir: PathBuf::new(),
+			},
+		);
+		assert!(matches!(missing, Err(VerifyError::MissingProgram(_))));
+	}
+
+	#[test]
+	fn submit_and_status_use_mainnet_and_validate_uploader() {
+		let executor = FakeExecutor::with([version(), output(0, "job", "")]);
+		let submitted = submit_program(&executor, PROGRAM_ID, UPLOADER).unwrap();
+		assert_eq!(submitted.stdout, b"job");
+		assert!(executor.calls.borrow()[1].contains(&OsString::from(MAINNET_RPC)));
+
+		let executor = FakeExecutor::with([version(), output(0, "verified\n", "diagnostic\n")]);
+		let status = status_program(&executor, PROGRAM_ID).unwrap();
+		assert_eq!(status.stdout, b"verified\n");
+		assert_eq!(status.stderr, b"diagnostic\n");
+		assert!(submit_program(&FakeExecutor::default(), PROGRAM_ID, "invalid").is_err());
+	}
+
+	#[test]
+	fn export_writes_only_validated_payload_and_preserves_diagnostics() {
+		let temp = TempDir::new().unwrap();
+		let build_record = create_build_record(&temp);
+		let output_path = temp.path().join("transaction with spaces.txt");
+		let payload = base64::engine::general_purpose::STANDARD.encode([7_u8; 128]);
+		let upstream_output = format!("Cloning repository\nBuilding program\n{payload}\n");
+		let executor = FakeExecutor::with([
+			version(),
+			output(0, format!("{}\n", record_hash()), ""),
+			output(0, &upstream_output, "diagnostic\n"),
+		]);
+		let result = record_program_for_test(
+			&executor,
+			&RecordOptions {
+				program_id: PROGRAM_ID.to_owned(),
+				cluster: Cluster::from_str("devnet").unwrap(),
+				build_record,
+				authority: None,
+				export_authority: Some(UPLOADER.to_owned()),
+				export_output: Some(output_path.clone()),
+				export_encoding: ExportEncoding::Base64,
+				confirmed: false,
+				mainnet_acknowledged: false,
+			},
+		)
+		.unwrap();
+
+		assert_eq!(result.stdout, b"Cloning repository\nBuilding program\n");
+		assert_eq!(fs::read(output_path).unwrap(), payload.as_bytes());
+		let arguments = &executor.calls.borrow()[2];
+		assert!(arguments.contains(&OsString::from("base64")));
+	}
+
+	fn create_build_record(temp: &TempDir) -> PathBuf {
+		create_build_record_with(temp, ".", "workspace", &["bpf-entrypoint"], true)
+	}
+
+	fn create_build_record_with(
+		temp: &TempDir,
+		mount_path: &str,
+		workspace_path: &str,
+		features: &[&str],
+		default_features: bool,
+	) -> PathBuf {
+		let bytes = vec![7_u8; 128];
+		let hash = format!("{:x}", Sha256::digest(&bytes));
+		let record = temp.path().join(format!("verify_fixture-{hash}.json"));
+		let artifact = record.with_extension("so");
+		let json = serde_json::json!({
+			"schemaVersion": 1,
+			"packageName": "verify_fixture",
+			"libraryName": "verify_fixture",
+			"executableHash": hash,
+			"solanaVerifyVersion": "0.5.1",
+			"build": {
+				"mountPath": mount_path,
+				"workspacePath": workspace_path,
+				"programPath": "workspace/programs/verify fixture",
+				"libraryName": "verify_fixture",
+				"features": features,
+				"defaultFeatures": default_features,
+				"cargoLockSha256": "a".repeat(64),
+			},
+			"source": {
+				"repository": "https://github.com/pina-rs/pina",
+				"revision": REVISION,
+				"dirty": false,
+			},
+			"diagnostics": [],
+		});
+		fs::write(&artifact, bytes).unwrap();
+		fs::write(&record, serde_json::to_vec_pretty(&json).unwrap()).unwrap();
+		record
+	}
+
+	fn create_keypair(temp: &TempDir, name: &str) -> (PathBuf, Address) {
+		let path = temp.path().join(name);
+		let signing_key = SigningKey::from_bytes(&[3_u8; 32]);
+		let public = signing_key.verifying_key().to_bytes();
+		let bytes = [signing_key.to_bytes().as_slice(), public.as_slice()].concat();
+		fs::write(&path, serde_json::to_vec(&bytes).unwrap()).unwrap();
+		#[cfg(unix)]
+		{
+			use std::os::unix::fs::PermissionsExt;
+
+			fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+		}
+		(path, Address::new_from_array(public))
+	}
+
+	#[test]
+	fn record_requires_safety_acknowledgements_and_valid_keypairs() {
+		let temp = TempDir::new().unwrap();
+		let build_record = create_build_record(&temp);
+		let base = RecordOptions {
+			program_id: PROGRAM_ID.to_owned(),
+			cluster: Cluster::from_str("mainnet-beta").unwrap(),
+			build_record,
+			authority: None,
+			export_authority: None,
+			export_output: None,
+			export_encoding: ExportEncoding::Base58,
+			confirmed: false,
+			mainnet_acknowledged: false,
+		};
+		let executor = FakeExecutor::with([version()]);
+		assert!(matches!(
+			record_program_for_test(&executor, &base),
+			Err(VerifyError::ConfirmationRequired)
+		));
+
+		let mut mainnet = base.clone();
+		mainnet.confirmed = true;
+		let (authority, _) = create_keypair(&temp, "authority.json");
+		mainnet.authority = Some(authority);
+		let executor = FakeExecutor::with([version()]);
+		assert!(matches!(
+			record_program_for_test(&executor, &mainnet),
+			Err(VerifyError::MainnetAcknowledgementRequired)
+		));
+
+		let invalid_keypair = temp.path().join("invalid.json");
+		fs::write(&invalid_keypair, "[1, 2, 3]").unwrap();
+		#[cfg(unix)]
+		{
+			use std::os::unix::fs::PermissionsExt;
+
+			fs::set_permissions(&invalid_keypair, fs::Permissions::from_mode(0o600)).unwrap();
+		}
+		mainnet.authority = Some(invalid_keypair);
+		mainnet.mainnet_acknowledged = true;
+		let executor = FakeExecutor::with([version()]);
+		assert!(matches!(
+			record_program_for_test(&executor, &mainnet),
+			Err(VerifyError::InvalidKeypair(_))
+		));
+	}
+
+	#[test]
+	fn export_requires_output_and_authority() {
+		let temp = TempDir::new().unwrap();
+		let build_record = create_build_record(&temp);
+		let mut options = RecordOptions {
+			program_id: PROGRAM_ID.to_owned(),
+			cluster: Cluster::from_str("devnet").unwrap(),
+			build_record,
+			authority: None,
+			export_authority: Some(String::new()),
+			export_output: None,
+			export_encoding: ExportEncoding::Base58,
+			confirmed: false,
+			mainnet_acknowledged: false,
+		};
+		let executor = FakeExecutor::with([version()]);
+		assert!(matches!(
+			record_program_for_test(&executor, &options),
+			Err(VerifyError::MissingExportOutput)
+		));
+
+		options.export_output = Some(temp.path().join("tx.txt"));
+		let executor = FakeExecutor::with([version()]);
+		assert!(matches!(
+			record_program_for_test(&executor, &options),
+			Err(VerifyError::MissingAuthority)
+		));
+
+		let (authority, _) = create_keypair(&temp, "conflicting.json");
+		options.authority = Some(authority);
+		options.export_authority = Some(UPLOADER.to_owned());
+		assert!(matches!(
+			prepare_record_for_test(&options),
+			Err(VerifyError::ConflictingAuthority)
+		));
+
+		options.export_authority = Some(String::new());
+		let payload = bs58::encode([8_u8; 128]).into_string();
+		let executor = FakeExecutor::with([
+			version(),
+			output(0, format!("{}\n", record_hash()), ""),
+			output(0, format!("{payload}\n"), ""),
+		]);
+		record_program_for_test(&executor, &options).unwrap();
+	}
+
+	#[test]
+	fn record_uses_exact_build_record_provenance_and_features() {
+		let temp = TempDir::new().unwrap();
+		let build_record = create_build_record_with(
+			&temp,
+			".",
+			"crates/workspace with spaces",
+			&["bpf-entrypoint", "logs"],
+			false,
+		);
+		let (authority, _) = create_keypair(&temp, "authority with spaces.json");
+		let hash = record_hash();
+		let executor = FakeExecutor::with([
+			version(),
+			output(0, format!("{hash}\n"), ""),
+			output(
+				0,
+				format!(
+					"Program hash matches ✅\nExecutable Program Hash from repo: {hash}\nOn-chain \
+					 Program Hash: {hash}\nProgram uploaded successfully.\n"
+				),
+				"",
+			),
+		]);
+		let result = record_program_for_test(
+			&executor,
+			&RecordOptions {
+				program_id: PROGRAM_ID.to_owned(),
+				cluster: Cluster::from_str("devnet").unwrap(),
+				build_record,
+				authority: Some(authority.clone()),
+				export_authority: None,
+				export_output: None,
+				export_encoding: ExportEncoding::Base58,
+				confirmed: true,
+				mainnet_acknowledged: false,
+			},
+		)
+		.unwrap();
+
+		assert!(result.stdout.is_empty());
+		let arguments = &executor.calls.borrow()[2];
+		assert!(arguments.contains(&OsString::from("https://github.com/pina-rs/pina")));
+		assert!(arguments.contains(&OsString::from(REVISION)));
+		assert!(arguments.contains(&OsString::from("crates/workspace with spaces")));
+		assert!(arguments.contains(&OsString::from("bpf-entrypoint,logs")));
+		assert!(arguments.contains(&OsString::from("--no-default-features")));
+		let keypair_index = arguments
+			.iter()
+			.position(|argument| argument == "--keypair")
+			.unwrap();
+		assert_ne!(arguments[keypair_index + 1], authority.into_os_string());
+		assert!(
+			arguments[keypair_index + 1]
+				.to_string_lossy()
+				.contains("pina-verify-authority-")
+		);
+	}
+
+	#[test]
+	fn prepared_record_uses_immutable_authority_and_provenance() {
+		let temp = TempDir::new().unwrap();
+		let build_record = create_build_record(&temp);
+		let (authority, expected_address) = create_keypair(&temp, "authority.json");
+		let options = RecordOptions {
+			program_id: PROGRAM_ID.to_owned(),
+			cluster: Cluster::from_str("devnet").unwrap(),
+			build_record: build_record.clone(),
+			authority: Some(authority.clone()),
+			export_authority: None,
+			export_output: None,
+			export_encoding: ExportEncoding::Base58,
+			confirmed: false,
+			mainnet_acknowledged: false,
+		};
+		let mut plan = prepare_record_for_test(&options).unwrap();
+		let review = plan.review();
+		assert_eq!(review.authority, expected_address.to_string());
+		assert_eq!(review.build_record, build_record);
+		assert_eq!(review.features, ["bpf-entrypoint"]);
+		assert!(review.default_features);
+		assert_eq!(
+			review_record_for_test(&options).unwrap().authority,
+			expected_address.to_string()
+		);
+
+		fs::write(&authority, "[]").unwrap();
+		fs::write(&build_record, "{}").unwrap();
+		plan.confirm();
+		let hash = record_hash();
+		let executor = FakeExecutor::with([
+			version(),
+			output(0, format!("{hash}\n"), ""),
+			output(0, "Program uploaded successfully.\n", ""),
+		]);
+		execute_record(&executor, &plan).unwrap();
+
+		let arguments = &executor.calls.borrow()[2];
+		assert!(arguments.contains(&OsString::from(REVISION)));
+		let keypair_index = arguments
+			.iter()
+			.position(|argument| argument == "--keypair")
+			.unwrap();
+		assert_ne!(arguments[keypair_index + 1], authority.into_os_string());
+	}
+
+	#[test]
+	fn prepared_record_still_requires_confirmation() {
+		let temp = TempDir::new().unwrap();
+		let (authority, _) = create_keypair(&temp, "authority.json");
+		let plan = prepare_record_for_test(&RecordOptions {
+			program_id: PROGRAM_ID.to_owned(),
+			cluster: Cluster::from_str("devnet").unwrap(),
+			build_record: create_build_record(&temp),
+			authority: Some(authority),
+			export_authority: None,
+			export_output: None,
+			export_encoding: ExportEncoding::Base58,
+			confirmed: false,
+			mainnet_acknowledged: false,
+		})
+		.unwrap();
+		assert!(matches!(
+			execute_record(&FakeExecutor::default(), &plan),
+			Err(VerifyError::ConfirmationRequired)
+		));
+	}
+
+	#[test]
+	fn keypair_and_build_paths_fail_closed() {
+		let temp = TempDir::new().unwrap();
+		assert!(matches!(
+			read_keypair(&temp.path().join("missing")),
+			Err(VerifyError::ReadKeypair { .. })
+		));
+
+		struct ErrorReader;
+
+		impl Read for ErrorReader {
+			fn read(&mut self, _buffer: &mut [u8]) -> Result<usize, std::io::Error> {
+				Err(std::io::Error::other("fixture read failure"))
+			}
+		}
+
+		let fixture_path = temp.path().join("fixture.json");
+		assert!(matches!(
+			read_keypair_contents(&fixture_path, &mut ErrorReader),
+			Err(VerifyError::ReadKeypair { .. })
+		));
+		assert!(matches!(
+			read_keypair_contents(
+				&fixture_path,
+				&mut std::io::Cursor::new(vec![0_u8; MAX_KEYPAIR_BYTES + 1])
+			),
+			Err(VerifyError::UnsafeKeypair(_))
+		));
+		assert!(matches!(
+			read_keypair(temp.path()),
+			Err(VerifyError::UnsafeKeypair(_))
+		));
+
+		let too_large = temp.path().join("large.json");
+		fs::write(&too_large, vec![0_u8; 4_097]).unwrap();
+		#[cfg(unix)]
+		fs::set_permissions(&too_large, {
+			use std::os::unix::fs::PermissionsExt;
+			fs::Permissions::from_mode(0o600)
+		})
+		.unwrap();
+		assert!(matches!(
+			read_keypair(&too_large),
+			Err(VerifyError::UnsafeKeypair(_))
+		));
+
+		#[cfg(unix)]
+		{
+			use std::os::unix::fs::PermissionsExt;
+
+			let public = temp.path().join("public.json");
+			fs::write(&public, "[]").unwrap();
+			fs::set_permissions(&public, fs::Permissions::from_mode(0o644)).unwrap();
+			assert!(matches!(
+				read_keypair(&public),
+				Err(VerifyError::UnsafeKeypair(_))
+			));
+
+			let replacement = temp.path().join("replacement.json");
+			fs::write(&replacement, "[]").unwrap();
+			fs::set_permissions(&replacement, fs::Permissions::from_mode(0o600)).unwrap();
+			assert!(matches!(
+				validate_keypair_metadata(
+					&public,
+					&fs::metadata(&public).unwrap(),
+					&fs::metadata(&replacement).unwrap(),
+				),
+				Err(VerifyError::UnsafeKeypair(_))
+			));
+			assert!(matches!(
+				validate_keypair_metadata(
+					&public,
+					&fs::metadata(&public).unwrap(),
+					&fs::metadata(temp.path()).unwrap(),
+				),
+				Err(VerifyError::UnsafeKeypair(_))
+			));
+		}
+
+		let bad_public = temp.path().join("bad-public.json");
+		fs::write(&bad_public, serde_json::to_vec(&vec![1_u8; 64]).unwrap()).unwrap();
+		#[cfg(unix)]
+		fs::set_permissions(&bad_public, {
+			use std::os::unix::fs::PermissionsExt;
+			fs::Permissions::from_mode(0o600)
+		})
+		.unwrap();
+		assert!(matches!(
+			read_keypair(&bad_public),
+			Err(VerifyError::InvalidKeypair(_))
+		));
+
+		assert!(verified_relative_path("../program").is_err());
+		assert_eq!(
+			verified_relative_path("programs\\fixture").unwrap(),
+			"programs/fixture"
+		);
+	}
+
+	#[test]
+	fn export_payload_validation_covers_both_encodings_and_write_errors() {
+		let base58 = bs58::encode([5_u8; 64]).into_string();
+		assert_eq!(
+			split_export_output(base58.as_bytes(), ExportEncoding::Base58)
+				.unwrap()
+				.1,
+			base58
+		);
+		for (bytes, encoding) in [
+			(vec![0xff], ExportEncoding::Base64),
+			(b"not-base64".to_vec(), ExportEncoding::Base64),
+			(
+				bs58::encode([1_u8; 2]).into_string().into_bytes(),
+				ExportEncoding::Base58,
+			),
+		] {
+			assert!(split_export_output(&bytes, encoding).is_err());
+		}
+		let temp = TempDir::new().unwrap();
+		assert!(write_export(&temp.path().join("missing/tx"), b"payload").is_err());
+		assert!(
+			map_export_write_result(
+				&temp.path().join("tx"),
+				Err(std::io::Error::other("commit failed"))
+			)
+			.is_err()
+		);
+	}
+
+	#[test]
+	fn checked_process_helpers_reject_nonzero_and_streaming_failures() {
+		let failed = FakeExecutor::with([output(4, "", "failed")]);
+		assert!(matches!(
+			run_checked(&failed, "status", &[]),
+			Err(VerifyError::CommandFailed { .. })
+		));
+		let failed = FakeExecutor::with([output(5, "", "failed")]);
+		assert!(matches!(
+			run_streaming_checked(&failed, "record", &[]),
+			Err(VerifyError::CommandFailed { .. })
+		));
+	}
+
+	#[test]
+	fn record_rejects_preflight_and_upstream_mismatches_with_exit_two() {
+		let temp = TempDir::new().unwrap();
+		let build_record = create_build_record(&temp);
+		let (authority, _) = create_keypair(&temp, "authority.json");
+		let options = RecordOptions {
+			program_id: PROGRAM_ID.to_owned(),
+			cluster: Cluster::from_str("devnet").unwrap(),
+			build_record,
+			authority: Some(authority),
+			export_authority: None,
+			export_output: None,
+			export_encoding: ExportEncoding::Base58,
+			confirmed: true,
+			mainnet_acknowledged: false,
+		};
+		let executor =
+			FakeExecutor::with([version(), output(0, format!("{}\n", "b".repeat(64)), "")]);
+		let error = record_program_for_test(&executor, &options).unwrap_err();
+		assert_eq!(error.exit_code(), 2);
+		assert!(matches!(error, VerifyError::RecordMismatch { .. }));
+		assert_eq!(executor.calls.borrow().len(), 2);
+
+		let hash = record_hash();
+		let executor = FakeExecutor::with([
+			version(),
+			output(0, format!("{hash}\n"), ""),
+			output(
+				0,
+				format!(
+					"Program hashes do not match ❌\nExecutable Program Hash from repo: \
+					 {}\nOn-chain Program Hash: {}\n",
+					"c".repeat(64),
+					"d".repeat(64)
+				),
+				"",
+			),
+		]);
+		let error = record_program_for_test(&executor, &options).unwrap_err();
+		assert!(matches!(error, VerifyError::RecordMismatch { .. }));
+
+		let invalid_hash = FakeExecutor::with([version(), output(0, "invalid", "")]);
+		assert!(matches!(
+			record_program_for_test(&invalid_hash, &options),
+			Err(VerifyError::InvalidHash { .. })
+		));
+	}
+
+	#[test]
+	fn export_preflight_rejects_mismatch_and_never_exports() {
+		let temp = TempDir::new().unwrap();
+		let executor =
+			FakeExecutor::with([version(), output(0, format!("{}\n", "b".repeat(64)), "")]);
+		let error = record_program_for_test(
+			&executor,
+			&RecordOptions {
+				program_id: PROGRAM_ID.to_owned(),
+				cluster: Cluster::from_str("mainnet-beta").unwrap(),
+				build_record: create_build_record(&temp),
+				authority: None,
+				export_authority: Some(UPLOADER.to_owned()),
+				export_output: Some(temp.path().join("tx.txt")),
+				export_encoding: ExportEncoding::Base58,
+				confirmed: false,
+				mainnet_acknowledged: false,
+			},
+		)
+		.unwrap_err();
+
+		assert!(matches!(error, VerifyError::RecordMismatch { .. }));
+		assert_eq!(executor.calls.borrow().len(), 2);
+
+		let invalid_hash = FakeExecutor::with([version(), output(0, "invalid", "")]);
+		let invalid = record_program_for_test(
+			&invalid_hash,
+			&RecordOptions {
+				program_id: PROGRAM_ID.to_owned(),
+				cluster: Cluster::from_str("devnet").unwrap(),
+				build_record: create_build_record(&temp),
+				authority: None,
+				export_authority: Some(UPLOADER.to_owned()),
+				export_output: Some(temp.path().join("invalid.tx")),
+				export_encoding: ExportEncoding::Base58,
+				confirmed: false,
+				mainnet_acknowledged: false,
+			},
+		);
+		assert!(matches!(invalid, Err(VerifyError::InvalidHash { .. })));
+	}
+
+	#[test]
+	fn record_host_and_diagnostic_safety_are_explicit() {
+		assert!(ensure_record_host("linux").is_ok());
+		assert!(ensure_record_host("macos").is_ok());
+		assert!(matches!(
+			ensure_record_host("windows"),
+			Err(VerifyError::UnsupportedRecordHost { .. })
+		));
+		assert_eq!(
+			sanitize_diagnostics("RPC https://user:secret@example.com/path?token=x, failed\n"),
+			"RPC https://example.com, failed\n"
+		);
+		assert_eq!(
+			sanitize_diagnostics("RPC https://user:secret@example.com:8899/path failed"),
+			"RPC https://example.com:8899 failed"
+		);
+		assert_eq!(
+			sanitize_diagnostics("failure\u{1b}[31m\r\nnext\titem"),
+			"failure\\u{1b}[31m\\r\nnext\titem"
+		);
+
+		let temp = TempDir::new().unwrap();
+		let options = RecordOptions {
+			program_id: PROGRAM_ID.to_owned(),
+			cluster: Cluster::from_str("devnet").unwrap(),
+			build_record: temp.path().join("missing.json"),
+			authority: None,
+			export_authority: None,
+			export_output: None,
+			export_encoding: ExportEncoding::Base64,
+			confirmed: true,
+			mainnet_acknowledged: false,
+		};
+		assert!(record_program(&FakeExecutor::default(), &options).is_err());
+		assert!(prepare_record(&options).is_err());
+		assert!(review_record(&options).is_err());
+		assert_eq!(VerifyError::InvalidAddress.exit_code(), 1);
+	}
+
+	#[test]
+	fn streaming_capture_keeps_tail_and_drains_after_writer_failure() {
+		struct BrokenWriter;
+
+		impl Write for BrokenWriter {
+			fn write(&mut self, _buffer: &[u8]) -> Result<usize, std::io::Error> {
+				Err(std::io::Error::new(
+					std::io::ErrorKind::BrokenPipe,
+					"closed",
+				))
+			}
+
+			fn flush(&mut self) -> Result<(), std::io::Error> {
+				Ok(())
+			}
+		}
+		BrokenWriter.flush().unwrap();
+
+		let mut input = vec![b'x'; MAX_CAPTURED_OUTPUT + 128];
+		input.extend_from_slice(b"Program hashes do not match\n");
+		let mut mirrored = Vec::new();
+		let captured = read_streaming_to(input.as_slice(), &mut mirrored).unwrap();
+		assert_eq!(mirrored.len(), input.len());
+		assert!(captured.ends_with(b"Program hashes do not match\n"));
+		assert_eq!(captured.len(), MAX_CAPTURED_OUTPUT);
+
+		let error = read_streaming_to(input.as_slice(), BrokenWriter).unwrap_err();
+		assert_eq!(error.kind(), std::io::ErrorKind::BrokenPipe);
+	}
+}

--- a/crates/pina_cli/tests/cli_snapshots.rs
+++ b/crates/pina_cli/tests/cli_snapshots.rs
@@ -136,6 +136,41 @@ fn profile_help_snapshot() {
 }
 
 #[test]
+fn verify_help_snapshot() {
+	let mut command = Command::new(env!("CARGO_BIN_EXE_pina"));
+	command.args(["verify", "--help"]);
+	assert_cmd_snapshot!("verify_help", command);
+}
+
+#[test]
+fn verify_check_help_snapshot() {
+	let mut command = Command::new(env!("CARGO_BIN_EXE_pina"));
+	command.args(["verify", "check", "--help"]);
+	assert_cmd_snapshot!("verify_check_help", command);
+}
+
+#[test]
+fn verify_record_help_snapshot() {
+	let mut command = Command::new(env!("CARGO_BIN_EXE_pina"));
+	command.args(["verify", "record", "--help"]);
+	assert_cmd_snapshot!("verify_record_help", command);
+}
+
+#[test]
+fn verify_submit_help_snapshot() {
+	let mut command = Command::new(env!("CARGO_BIN_EXE_pina"));
+	command.args(["verify", "submit", "--help"]);
+	assert_cmd_snapshot!("verify_submit_help", command);
+}
+
+#[test]
+fn verify_status_help_snapshot() {
+	let mut command = Command::new(env!("CARGO_BIN_EXE_pina"));
+	command.args(["verify", "status", "--help"]);
+	assert_cmd_snapshot!("verify_status_help", command);
+}
+
+#[test]
 fn codama_help_snapshot() {
 	let mut command = Command::new(env!("CARGO_BIN_EXE_pina"));
 	command.args(["codama", "--help"]);

--- a/crates/pina_cli/tests/snapshots/cli_snapshots__root_help.snap
+++ b/crates/pina_cli/tests/snapshots/cli_snapshots__root_help.snap
@@ -10,7 +10,7 @@ exit_code: 0
 ----- stdout -----
 Build, inspect, and generate artifacts for Pina Solana programs.
 
-Use 'pina init' to start a program, 'pina build' for its SBF binary and IDL, and 'pina generate' for selected client ecosystems. Low-level IDL, profiling, terminal documentation, and the legacy repository-wide Codama workflow remain available.
+Use 'pina init' to start a program, 'pina build' for its SBF binary and IDL, and 'pina generate' for selected client ecosystems. Use 'pina build --verify' and 'pina verify' for reproducible deployed-program verification. Low-level IDL, profiling, terminal documentation, and the legacy repository-wide Codama workflow remain available.
 
 Usage: pina <COMMAND>
 
@@ -27,6 +27,8 @@ Commands:
           Initialize a new Pina program project
   profile
           Profile compute-unit costs in a compiled SBF program
+  verify
+          Verify deployed programs and publish source-build records
   codama
           Run Codama IDL and client-generation workflows
   help
@@ -49,5 +51,6 @@ Examples:
 Agent discovery:
   Run 'pina <command> --help' for command-specific inputs, outputs, and examples.
   Run 'pina docs' to list the bundled architecture and IDL reference topics.
+  For deployment verification, run 'pina verify --help' and then inspect the selected leaf command.
 
 ----- stderr -----

--- a/crates/pina_cli/tests/snapshots/cli_snapshots__verify_check_help.snap
+++ b/crates/pina_cli/tests/snapshots/cli_snapshots__verify_check_help.snap
@@ -1,0 +1,47 @@
+---
+source: crates/pina_cli/tests/cli_snapshots.rs
+info:
+  program: pina
+  args:
+    - verify
+    - check
+    - "--help"
+---
+success: true
+exit_code: 0
+----- stdout -----
+Compare a local SBF executable with a deployed program.
+
+Uses solana-verify's trailing-zero-aware executable and deployed-program hashes. Exits 0 on a match, 2 on a mismatch, and 1 on an operational error.
+
+Usage: pina verify check [OPTIONS] --program-id <ADDRESS> --cluster <CLUSTER>
+
+Options:
+      --program-id <ADDRESS>
+          Deployed program address
+
+      --cluster <CLUSTER>
+          Solana cluster alias or HTTP(S) RPC URL. Always explicit
+
+      --program <PROGRAM.SO>
+          Local SBF executable. Conflicts with --project discovery
+
+  -p, --project <DIR>
+          Directory used to discover the executable. Defaults to the current directory
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+Examples:
+  pina verify check --program-id <ADDRESS> --cluster devnet
+  pina verify check --program-id <ADDRESS> --cluster mainnet-beta \
+    --program ./target/deploy/my_program.so
+  pina verify check --program-id <ADDRESS> --cluster https://rpc.example.com \
+    --project ./programs/my_program
+
+Output and status:
+  Exit 0 means the executables match. Exit 2 means the comparison completed but
+  hashes differ. Exit 1 means validation, RPC, or tool failure. Custom RPC URLs
+  must be credential-free origins because RPC URLs are visible in process argv.
+
+----- stderr -----

--- a/crates/pina_cli/tests/snapshots/cli_snapshots__verify_help.snap
+++ b/crates/pina_cli/tests/snapshots/cli_snapshots__verify_help.snap
@@ -1,0 +1,45 @@
+---
+source: crates/pina_cli/tests/cli_snapshots.rs
+info:
+  program: pina
+  args:
+    - verify
+    - "--help"
+---
+success: true
+exit_code: 0
+----- stdout -----
+Verify deployed programs and publish source-build records.
+
+Uses the official solana-verify 0.5.1 executable. `check` is read-only; `record` is the only subcommand that writes on-chain state. Remote submission and status use the mainnet verifier service.
+
+Usage: pina verify [OPTIONS] <COMMAND>
+
+Commands:
+  check
+          Compare a local SBF executable with a deployed program
+  record
+          Build from an immutable repository revision and record verification metadata
+  submit
+          Submit an existing on-chain verification record to the mainnet remote verifier
+  status
+          Read the mainnet remote-verifier status for a program
+  help
+          Print this message or the help of the given subcommand(s)
+
+Options:
+      --solana-verify <COMMAND>
+          solana-verify 0.5.1 executable. Pina never installs it
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+Examples:
+  pina verify check --program-id <ADDRESS> --cluster devnet
+  pina verify record --program-id <ADDRESS> --cluster devnet \
+    --build-record ./target/pina/verifiable/my_program-<HASH>.json \
+    --authority ./authority.json --yes
+  pina verify submit --program-id <ADDRESS> --uploader <ADDRESS>
+  pina verify status --program-id <ADDRESS>
+
+----- stderr -----

--- a/crates/pina_cli/tests/snapshots/cli_snapshots__verify_record_help.snap
+++ b/crates/pina_cli/tests/snapshots/cli_snapshots__verify_record_help.snap
@@ -1,0 +1,72 @@
+---
+source: crates/pina_cli/tests/cli_snapshots.rs
+info:
+  program: pina
+  args:
+    - verify
+    - record
+    - "--help"
+---
+success: true
+exit_code: 0
+----- stdout -----
+Build from an immutable repository revision and record verification metadata.
+
+This writes on-chain state after the official repository build matches the deployed executable. The authority signs and pays transaction fees because solana-verify 0.5.1 does not support a separate payer.
+
+Usage: pina verify record [OPTIONS] --program-id <ADDRESS> --cluster <CLUSTER> --build-record <FILE>
+
+Options:
+      --program-id <ADDRESS>
+          Deployed program address
+
+      --cluster <CLUSTER>
+          Solana cluster alias or HTTP(S) RPC URL. Always explicit
+
+      --build-record <FILE>
+          Content-addressed record produced by `pina build --verify`
+
+      --authority <KEYPAIR>
+          Upgrade-authority keypair. It also pays fees with solana-verify 0.5.1
+
+      --export [<AUTHORITY>]
+          Export without submitting. Optionally provide a public authority address
+
+      --output <FILE>
+          Write only the validated encoded transaction payload to FILE
+
+      --export-encoding <ENCODING>
+          Encoding for the exported transaction: base64 or base58
+
+      --yes
+          Confirm recording without an interactive prompt. Has no effect on export
+
+      --acknowledge-mainnet
+          Acknowledge submission to mainnet or an unknown remote endpoint
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+Examples:
+  pina verify record --program-id <ADDRESS> --cluster devnet \
+    --build-record ./target/pina/verifiable/my_program-<HASH>.json \
+    --authority ./upgrade-authority.json --yes
+
+  pina verify record --program-id <ADDRESS> --cluster mainnet-beta \
+    --build-record ./target/pina/verifiable/my_program-<HASH>.json \
+    --authority ./upgrade-authority.json --yes --acknowledge-mainnet
+
+  pina verify record --program-id <ADDRESS> --cluster mainnet-beta \
+    --build-record ./target/pina/verifiable/my_program-<HASH>.json \
+    --export <MULTISIG_ADDRESS> --output ./verification.tx \
+    --export-encoding base64
+
+Safety:
+  The build record binds the validated artifact hash to its public repository,
+  full revision, build paths, library, and Cargo features. Interactive recording
+  requires typing `record`; automation requires --yes. Submissions to mainnet and
+  unknown remote RPC origins additionally require --acknowledge-mainnet. Export
+  never submits or rebuilds the repository; remote verification begins only after
+  the exported transaction is submitted. Export does not require that acknowledgement.
+
+----- stderr -----

--- a/crates/pina_cli/tests/snapshots/cli_snapshots__verify_status_help.snap
+++ b/crates/pina_cli/tests/snapshots/cli_snapshots__verify_status_help.snap
@@ -1,0 +1,29 @@
+---
+source: crates/pina_cli/tests/cli_snapshots.rs
+info:
+  program: pina
+  args:
+    - verify
+    - status
+    - "--help"
+---
+success: true
+exit_code: 0
+----- stdout -----
+Read the mainnet remote-verifier status for a program
+
+Usage: pina verify status --program-id <ADDRESS>
+
+Options:
+      --program-id <ADDRESS>
+          Program address to inspect
+  -h, --help
+          Print help
+
+Example:
+  pina verify status --program-id <ADDRESS>
+
+This command is \
+		              read-only and always queries the official mainnet remote verifier.
+
+----- stderr -----

--- a/crates/pina_cli/tests/snapshots/cli_snapshots__verify_submit_help.snap
+++ b/crates/pina_cli/tests/snapshots/cli_snapshots__verify_submit_help.snap
@@ -1,0 +1,32 @@
+---
+source: crates/pina_cli/tests/cli_snapshots.rs
+info:
+  program: pina
+  args:
+    - verify
+    - submit
+    - "--help"
+---
+success: true
+exit_code: 0
+----- stdout -----
+Submit an existing on-chain verification record to the mainnet remote verifier
+
+Usage: pina verify submit --program-id <ADDRESS> --uploader <ADDRESS>
+
+Options:
+      --program-id <ADDRESS>
+          Program address whose recorded build should be verified
+      --uploader <ADDRESS>
+          Public address that uploaded the verification record
+  -h, --help
+          Print help
+
+Example:
+  pina verify submit --program-id <ADDRESS> --uploader <ADDRESS>
+
+\
+		              This command always targets the official mainnet remote verifier. UPLOADER is the \
+		              public address that created the on-chain verification record; it is not a keypair.
+
+----- stderr -----

--- a/crates/pina_cli/tests/verification_command.rs
+++ b/crates/pina_cli/tests/verification_command.rs
@@ -1,0 +1,318 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::Command;
+use std::process::Stdio;
+
+use base64::Engine;
+use ed25519_dalek::SigningKey;
+use sha2::Digest;
+use sha2::Sha256;
+use tempfile::TempDir;
+
+const PROGRAM_ID: &str = "11111111111111111111111111111111";
+const MATCHING_HASH: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+fn fake_verifier(temp: &TempDir) -> std::path::PathBuf {
+	let path = temp.path().join("solana verify with spaces");
+	let script = r#"#!/bin/sh
+set -eu
+if [ "${1:-}" = "--version" ]; then
+  if IFS= read -r unexpected; then
+    printf '%s\n' 'verifier consumed inherited stdin' >&2
+    exit 91
+  fi
+  printf '%s\n' 'solana-verify 0.5.1'
+  exit 0
+fi
+case " $* " in
+  *" get-executable-hash "*)
+    printf '%s\n' 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    ;;
+  *" get-program-hash "*)
+    printf '%s\n' "${PINA_FAKE_DEPLOYED_HASH:-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}"
+    ;;
+  *" verify-from-repo "*)
+    printf '%s\n' 'Program uploaded successfully.'
+    ;;
+  *" export-pda-tx "*)
+    printf '%s\n' 'Building repository'
+    printf '%s\n' "$PINA_FAKE_EXPORT_PAYLOAD"
+    ;;
+  *" remote submit-job "*)
+    printf '%s\n' 'job submitted'
+    ;;
+  *" remote get-status "*)
+    if [ "${PINA_FAKE_SIGNAL:-0}" = 1 ]; then
+      kill -TERM $$
+    fi
+    printf '%s\n' 'verified'
+    ;;
+  *)
+    printf '%s\n' 'unexpected fake invocation' >&2
+    exit 9
+    ;;
+esac
+"#;
+	fs::write(&path, script).unwrap();
+	fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+	path
+}
+
+fn create_record_and_keypair(temp: &TempDir) -> (std::path::PathBuf, std::path::PathBuf, String) {
+	let bytes = vec![7_u8; 128];
+	let hash = format!("{:x}", Sha256::digest(&bytes));
+	let record = temp.path().join(format!("fixture-{hash}.json"));
+	let artifact = record.with_extension("so");
+	let json = serde_json::json!({
+		"schemaVersion": 1,
+		"packageName": "fixture",
+		"libraryName": "fixture",
+		"executableHash": hash,
+		"solanaVerifyVersion": "0.5.1",
+		"build": {
+			"mountPath": ".",
+			"workspacePath": ".",
+			"programPath": "programs/fixture",
+			"libraryName": "fixture",
+			"features": ["bpf-entrypoint"],
+			"defaultFeatures": true,
+			"cargoLockSha256": "a".repeat(64),
+		},
+		"source": {
+			"repository": "https://github.com/pina-rs/pina",
+			"revision": "0123456789abcdef0123456789abcdef01234567",
+			"dirty": false,
+		},
+		"diagnostics": [],
+	});
+	fs::write(&artifact, bytes).unwrap();
+	fs::write(&record, serde_json::to_vec_pretty(&json).unwrap()).unwrap();
+
+	let keypair = temp.path().join("authority keypair.json");
+	let signing_key = SigningKey::from_bytes(&[3_u8; 32]);
+	let public = signing_key.verifying_key().to_bytes();
+	let keypair_bytes = [signing_key.to_bytes().as_slice(), public.as_slice()].concat();
+	fs::write(&keypair, serde_json::to_vec(&keypair_bytes).unwrap()).unwrap();
+	fs::set_permissions(&keypair, fs::Permissions::from_mode(0o600)).unwrap();
+
+	(record, keypair, hash)
+}
+
+fn run_check(verifier: &Path, program: &Path, deployed_hash: &str) -> std::process::Output {
+	Command::new(env!("CARGO_BIN_EXE_pina"))
+		.args([
+			"verify",
+			"--solana-verify",
+			verifier.to_str().unwrap(),
+			"check",
+			"--program-id",
+			PROGRAM_ID,
+			"--cluster",
+			"devnet",
+			"--program",
+			program.to_str().unwrap(),
+		])
+		.env("PINA_FAKE_DEPLOYED_HASH", deployed_hash)
+		.output()
+		.unwrap()
+}
+
+#[test]
+fn check_uses_documented_zero_two_one_exit_codes() {
+	let temp = TempDir::new().unwrap();
+	let verifier = fake_verifier(&temp);
+	let program = temp.path().join("program with spaces.so");
+	fs::write(&program, b"program").unwrap();
+
+	let matching = run_check(&verifier, &program, MATCHING_HASH);
+	assert_eq!(matching.status.code(), Some(0));
+	assert!(String::from_utf8_lossy(&matching.stdout).contains("matches"));
+
+	let mismatch = run_check(&verifier, &program, &"b".repeat(64));
+	assert_eq!(mismatch.status.code(), Some(2));
+	assert!(String::from_utf8_lossy(&mismatch.stderr).contains("differ"));
+
+	let malformed = run_check(&verifier, &program, "not-a-hash");
+	assert_eq!(malformed.status.code(), Some(1));
+	assert!(String::from_utf8_lossy(&malformed.stderr).contains("invalid executable hash"));
+}
+
+#[test]
+fn verifier_children_never_inherit_operator_input() {
+	let temp = TempDir::new().unwrap();
+	let verifier = fake_verifier(&temp);
+	let program = temp.path().join("program.so");
+	fs::write(&program, b"program").unwrap();
+	let mut child = Command::new(env!("CARGO_BIN_EXE_pina"))
+		.args([
+			"verify",
+			"--solana-verify",
+			verifier.to_str().unwrap(),
+			"check",
+			"--program-id",
+			PROGRAM_ID,
+			"--cluster",
+			"devnet",
+			"--program",
+			program.to_str().unwrap(),
+		])
+		.stdin(Stdio::piped())
+		.stdout(Stdio::piped())
+		.stderr(Stdio::piped())
+		.spawn()
+		.unwrap();
+	child
+		.stdin
+		.take()
+		.unwrap()
+		.write_all(b"operator input must stay with Pina\n")
+		.unwrap();
+	let output = child.wait_with_output().unwrap();
+
+	assert_eq!(output.status.code(), Some(0));
+	assert!(!String::from_utf8_lossy(&output.stderr).contains("consumed inherited stdin"));
+}
+
+#[test]
+fn non_interactive_record_refuses_before_spawning_verifier() {
+	let temp = TempDir::new().unwrap();
+	let verifier = temp.path().join("must not run");
+	fs::write(
+		&verifier,
+		"#!/bin/sh\ntouch \"$PINA_SPAWN_MARKER\"\nexit 99\n",
+	)
+	.unwrap();
+	fs::set_permissions(&verifier, fs::Permissions::from_mode(0o755)).unwrap();
+	let marker = temp.path().join("spawned");
+	let output = Command::new(env!("CARGO_BIN_EXE_pina"))
+		.args([
+			"verify",
+			"--solana-verify",
+			verifier.to_str().unwrap(),
+			"record",
+			"--program-id",
+			PROGRAM_ID,
+			"--cluster",
+			"devnet",
+			"--build-record",
+			"missing.json",
+			"--authority",
+			"missing-keypair.json",
+		])
+		.env("PINA_SPAWN_MARKER", &marker)
+		.stdin(Stdio::null())
+		.output()
+		.unwrap();
+
+	assert_eq!(output.status.code(), Some(1));
+	assert!(!marker.exists());
+	assert!(String::from_utf8_lossy(&output.stderr).contains("requires confirmation"));
+}
+
+#[test]
+fn record_export_submit_and_status_use_the_real_process_adapter() {
+	let temp = TempDir::new().unwrap();
+	let verifier = fake_verifier(&temp);
+	let (record, keypair, hash) = create_record_and_keypair(&temp);
+	let common = ["verify", "--solana-verify", verifier.to_str().unwrap()];
+	let recorded = Command::new(env!("CARGO_BIN_EXE_pina"))
+		.args(common)
+		.args([
+			"record",
+			"--program-id",
+			PROGRAM_ID,
+			"--cluster",
+			"devnet",
+			"--build-record",
+			record.to_str().unwrap(),
+			"--authority",
+			keypair.to_str().unwrap(),
+			"--yes",
+		])
+		.env("PINA_FAKE_DEPLOYED_HASH", &hash)
+		.output()
+		.unwrap();
+	assert_eq!(recorded.status.code(), Some(0));
+	assert!(String::from_utf8_lossy(&recorded.stdout).contains("uploaded successfully"));
+
+	let exported_path = temp.path().join("export\n\u{1b}[31m.tx");
+	let payload = base64::engine::general_purpose::STANDARD.encode([9_u8; 128]);
+	let exported = Command::new(env!("CARGO_BIN_EXE_pina"))
+		.args(common)
+		.args([
+			"record",
+			"--program-id",
+			PROGRAM_ID,
+			"--cluster",
+			"mainnet-beta",
+			"--build-record",
+			record.to_str().unwrap(),
+			"--export",
+			"SysvarRent111111111111111111111111111111111",
+			"--output",
+			exported_path.to_str().unwrap(),
+			"--export-encoding",
+			"base64",
+		])
+		.env("PINA_FAKE_DEPLOYED_HASH", &hash)
+		.env("PINA_FAKE_EXPORT_PAYLOAD", &payload)
+		.output()
+		.unwrap();
+	assert_eq!(exported.status.code(), Some(0));
+	assert_eq!(fs::read_to_string(&exported_path).unwrap(), payload);
+	let summary = String::from_utf8_lossy(&exported.stdout);
+	assert!(summary.contains("export\\n\\u{1b}[31m.tx"));
+	assert!(!summary.contains("export\n\u{1b}[31m.tx"));
+
+	for (command, expected) in [("submit", "job submitted"), ("status", "verified")] {
+		let mut process = Command::new(env!("CARGO_BIN_EXE_pina"));
+		process
+			.args(common)
+			.arg(command)
+			.args(["--program-id", PROGRAM_ID]);
+		if command == "submit" {
+			process.args(["--uploader", "SysvarRent111111111111111111111111111111111"]);
+		}
+		let output = process.output().unwrap();
+		assert_eq!(output.status.code(), Some(0));
+		assert!(String::from_utf8_lossy(&output.stdout).contains(expected));
+	}
+}
+
+#[test]
+fn missing_and_signaled_verifier_processes_are_errors() {
+	let temp = TempDir::new().unwrap();
+	let missing = Command::new(env!("CARGO_BIN_EXE_pina"))
+		.args([
+			"verify",
+			"--solana-verify",
+			temp.path().join("missing").to_str().unwrap(),
+			"status",
+			"--program-id",
+			PROGRAM_ID,
+		])
+		.output()
+		.unwrap();
+	assert_eq!(missing.status.code(), Some(1));
+	assert!(String::from_utf8_lossy(&missing.stderr).contains("could not run"));
+
+	let verifier = fake_verifier(&temp);
+	let signaled = Command::new(env!("CARGO_BIN_EXE_pina"))
+		.args([
+			"verify",
+			"--solana-verify",
+			verifier.to_str().unwrap(),
+			"status",
+			"--program-id",
+			PROGRAM_ID,
+		])
+		.env("PINA_FAKE_SIGNAL", "1")
+		.output()
+		.unwrap();
+	assert_eq!(signaled.status.code(), Some(1));
+	assert!(String::from_utf8_lossy(&signaled.stderr).contains("signal"));
+}

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -6,6 +6,7 @@
 - [Pina CLI](./cli/index.md)
   - [Initialize a Program](./cli/init.md)
   - [Build a Program](./cli/build.md)
+  - [Verify a Deployed Program](./cli/verify.md)
   - [Generate Clients](./cli/generate.md)
   - [Project Configuration](./cli/configuration.md)
   - [Generate an IDL](./cli/idl.md)

--- a/docs/src/cli/automation.md
+++ b/docs/src/cli/automation.md
@@ -19,6 +19,14 @@ pina codama --help
 pina codama generate --help
 ```
 
+For deployment verification, inspect the group and selected leaf:
+
+```bash
+pina verify --help
+pina verify check --help
+pina verify record --help
+```
+
 For framework and extractor constraints:
 
 ```bash
@@ -64,6 +72,11 @@ jq -e '.functions | type == "array"' /tmp/profile.json
 - Use repeated `--example` flags instead of assuming comma-separated parsing.
 - Inspect `pina docs` before requesting a topic.
 - Never use the input `.so` path as the profile output path.
+- Treat exit code `2` from `verify check` or `verify record` as a verified hash mismatch, not an operational failure.
+- Run `pina build --verify` first and pass its printed content-addressed JSON path to `pina verify record --build-record`.
+- Never infer a repository, revision, cluster, authority, or uploader. The build record binds source provenance; every network target and signing identity remains explicit.
+- Use `--yes` only for a reviewed record plan. Mainnet submissions additionally require `--acknowledge-mainnet`; transaction export requires neither flag.
+- Never put secrets in a custom RPC URL. Pina passes the RPC origin to `solana-verify` as argv.
 
 ## Stable verification
 

--- a/docs/src/cli/index.md
+++ b/docs/src/cli/index.md
@@ -33,6 +33,7 @@ The shortcut runs `cargo run -p pina_cli -- ...` against the checked-out source.
 | ---------------------------------------------- | ------------------------------------------------------------ | ----------------------------------------- |
 | [`pina init`](./init.md)                       | Create a project-aware program scaffold                      | Files plus next steps                     |
 | [`pina build`](./build.md)                     | Build SBF, optionally with deterministic verification inputs | SBF, IDL, and optional build-record files |
+| [`pina verify`](./verify.md)                   | Compare deployments and record verified source               | Status or transaction                     |
 | [`pina generate`](./generate.md)               | Generate configured client ecosystems                        | Generated clients                         |
 | [`pina idl`](./idl.md)                         | Extract a Codama root-node IDL                               | JSON                                      |
 | [`pina docs`](./docs.md)                       | List or render bundled terminal docs                         | Terminal text                             |
@@ -46,6 +47,11 @@ The help tree is intentionally self-describing:
 ```bash
 pina --help
 pina build --help
+pina verify --help
+pina verify check --help
+pina verify record --help
+pina verify submit --help
+pina verify status --help
 pina generate --help
 pina idl --help
 pina docs --help
@@ -65,11 +71,13 @@ Long help includes the input contract, output behavior, defaults, and copyable e
 | `docs`            | Topic index or rendered Markdown  | Errors                              |
 | `init`            | Created path and next steps       | Errors                              |
 | `build`           | Published artifact summary        | Cargo output and errors             |
+| `verify check`    | Matching hash                     | Mismatch hashes and errors          |
+| `verify record`   | Upstream streamed progress        | Upstream diagnostics and errors     |
 | `generate`        | IDL and client summary            | Renderer output and errors          |
 | `profile`         | Report when `--output` is omitted | Errors                              |
 | `codama generate` | Completion summary                | Errors and renderer failures        |
 
-Successful commands exit with code `0`. Operational failures exit with code `1`. Invalid command-line syntax is rejected by Clap with a non-zero usage error before an operation begins.
+Successful commands exit with code `0`. Operational failures exit with code `1`. Verification hash mismatches exit with code `2`. Invalid command-line syntax is rejected by Clap with a non-zero usage error before an operation begins.
 
 For reliable automation, capture stdout only when the command documents it as machine-readable. See [Automation and Agent Usage](./automation.md) for a compact discovery protocol.
 

--- a/docs/src/cli/verify.md
+++ b/docs/src/cli/verify.md
@@ -1,0 +1,80 @@
+# `pina verify`
+
+Verify deployed executables and publish source-build records with the official `solana-verify` 0.5.1 workflow.
+
+Start with a deterministic build:
+
+```bash
+pina build --verify
+```
+
+That command prints a content-addressed JSON record beside its `.so` artifact under `target/pina/verifiable`. Pina re-reads the record, rejects filesystem aliases and unsupported schema/tool versions, and recomputes the artifact's trailing-zero-aware executable hash before it uses any provenance.
+
+## Compare a deployment
+
+```bash
+pina verify check \
+  --program-id <ADDRESS> \
+  --cluster devnet
+```
+
+Use `--program <PROGRAM.SO>` to select an executable directly or `--project <DIR>` to discover `target/deploy/<library>.so`. Pina delegates both hashes to `solana-verify`: executable hashing removes trailing zero padding before SHA-256, matching the official deployed-program comparison.
+
+| Exit code | Meaning                                                     |
+| --------- | ----------------------------------------------------------- |
+| `0`       | The local and deployed executable hashes match.             |
+| `2`       | The comparison completed, but the executable hashes differ. |
+| `1`       | Validation, tool execution, or RPC access failed.           |
+
+`check` is read-only.
+
+## Record verified source
+
+```bash
+pina verify record \
+  --program-id <ADDRESS> \
+  --cluster devnet \
+  --build-record ./target/pina/verifiable/my_program-<HASH>.json \
+  --authority ./upgrade-authority.json
+```
+
+Before invoking the repository rebuild, Pina verifies that the record's artifact hash matches the deployed program. It then passes the record's public repository, full revision, mount path, workspace path, library name, Cargo features, and default-feature choice to `verify-from-repo`. Arbitrary repository or revision overrides are intentionally unavailable.
+
+Interactive recording prints a plan and requires typing `record`. Automation must pass `--yes`. Submissions to mainnet and unknown remote RPC origins also require `--acknowledge-mainnet`; `--yes` does not imply that acknowledgement. Exports are non-mutating and require neither flag. The authority keypair also pays transaction fees because `solana-verify` 0.5.1 does not support a separate payer.
+
+Pina recognizes the upstream 0.5.1 hash-mismatch transcript as exit code `2`. This guard matters because that upstream release exits successfully when its repository rebuild differs and does not write a verification record.
+
+Repository recording uses upstream clone and Docker behavior and is supported only on Linux and macOS. Read-only comparison and remote-status commands remain available when the exact executable works on another platform.
+
+## Export for a multisig
+
+```bash
+pina verify record \
+  --program-id <ADDRESS> \
+  --cluster mainnet-beta \
+  --build-record ./target/pina/verifiable/my_program-<HASH>.json \
+  --export <MULTISIG_ADDRESS> \
+  --output ./verification.tx \
+  --export-encoding base64
+```
+
+Export never submits. It runs the separate upstream `export-pda-tx` operation after Pina's build-record/deployment hash preflight. That upstream operation encodes the source and build arguments but does not rebuild the repository; remote verification happens only after the transaction is submitted. Upstream progress remains diagnostic output; only the final validated base58 or base64 transaction payload is atomically written to `--output`. Supplying a public address after `--export` does not require an authority secret.
+
+## Remote verifier
+
+After an on-chain record exists:
+
+```bash
+pina verify submit --program-id <ADDRESS> --uploader <ADDRESS>
+pina verify status --program-id <ADDRESS>
+```
+
+These commands target the official mainnet remote verifier. `uploader` is the public address that created the record, not a keypair. Status is read-only.
+
+## Tool and RPC security
+
+Pina requires the exact version string `solana-verify 0.5.1` and never installs it. Select an executable explicitly with `pina verify --solana-verify <COMMAND> ...`.
+
+Cluster aliases are `mainnet-beta`, `devnet`, `testnet`, and `localnet`. A custom endpoint must be a credential-free HTTPS origin with no path, query, or fragment; loopback HTTP is allowed for local development. RPC endpoints are necessarily passed to `solana-verify` in process arguments, where the operating system's process listing may expose them. Put no credentials or access tokens in an RPC URL.
+
+Authority files must be private regular files, not symbolic links. Pina bounds the file size, parses the 64-byte Solana keypair, and cryptographically verifies that its public half matches its secret half before starting the network workflow. Before confirmation, Pina freezes the reviewed provenance in memory and copies the validated keypair into a private temporary file so replacing the original paths cannot change the approved submission. Keypair bytes are never printed or passed in arguments; only that private temporary path is passed to upstream `--keypair`.

--- a/packages/pina__skill/references/cli-and-codegen.md
+++ b/packages/pina__skill/references/cli-and-codegen.md
@@ -94,3 +94,25 @@ pina profile ./target/deploy/counter_program.so --json --output ./profile.json
 ```
 
 The report is a static estimate, not a validator execution trace. Use it for deterministic comparisons and investigate material changes in context.
+
+# Verified deployments
+
+Use the content-addressed record produced by the deterministic build. Never invent or override its repository, revision, paths, library, or Cargo feature set.
+
+```bash
+pina build --verify
+pina verify check --program-id <ADDRESS> --cluster devnet
+pina verify record \
+  --program-id <ADDRESS> \
+  --cluster devnet \
+  --build-record ./target/pina/verifiable/my_program-<HASH>.json \
+  --authority ./upgrade-authority.json
+```
+
+`pina verify check` is read-only: it compares the local artifact with the deployed executable and returns exit code `2` for a completed hash mismatch. Do not retry that result as an infrastructure failure.
+
+`pina verify record` rebuilds the exact repository revision from the validated build record and writes verification metadata on-chain. Review the program, cluster, record, and authority before adding `--yes`; mainnet and unknown remote RPC origins additionally require `--acknowledge-mainnet`.
+
+Use `pina verify record --export [AUTHORITY] --output verification.tx` when another signer or multisig must submit the transaction. Export performs Pina's deployed-hash preflight but never submits or rebuilds the repository, does not require `--yes` or `--acknowledge-mainnet`, and writes only the validated base58 or base64 transaction payload. Remote verification begins only after the exported transaction is submitted.
+
+`pina verify submit --program-id <ADDRESS> --uploader <ADDRESS>` submits an existing record to the official mainnet remote verifier. `pina verify status --program-id <ADDRESS>` is the corresponding read-only mainnet status query. Never place credentials in an RPC URL; the URL is necessarily visible in child-process arguments.


### PR DESCRIPTION
## Summary

- add read-only deployed executable checks with documented 0/2/1 exit semantics
- add immutable build-record publication, multisig transaction export, mainnet remote submission, and status workflows through pinned solana-verify 0.5.1
- harden RPC, repository, keypair, subprocess, confirmation, transcript, and exported-transaction boundaries
- add expressive leaf help, mdBook documentation, automation guidance, agent skill references, and a descriptive changeset

## Foundation

PR #233 is merged. This PR now targets `main` and contains exactly one verification commit above the merged deterministic-build and validated-build-record foundation.

## Verification

- `cargo test --all-features --locked -p pina_cli`
- `lint:all`
- `verify:docs`
- `mc check`
- Monochange affected-package verification for `pina_cli` and `pina_skill`
- `cargo clippy --all-features --locked -p pina_cli --bin pina -- -D warnings`
- workspace default and all-feature builds
- full workspace `test:all`, including fuzz-target compilation and npm package tests
- deterministic IDL regeneration and generated Rust, JavaScript, and Dart client checks
- full Pina build and test feature matrices
- full dependency and custom-lint security suite
- standard LLVM coverage suite
- Windows GNU cross-target all-feature test compilation
- exact patch coverage: 1,927 / 1,927 executable added Rust lines, 100%
- independent architecture and security review cleared exact SHA `0e5a3d4f9084f91f2b31d95e8c90689333c1cecc` atop merged main `e5c5db6e4437d3ef9ff8a0b534f14adaf60ca4f3`

The local pre-push wrapper was bypassed only after reproducing its unrelated Darwin Xcode 26.5/Nix `libfuzzer-sys` header failure. The standalone full workspace task, including fuzz-target compilation, passed; fresh GitHub CI is the authoritative cross-platform gate.

Created on behalf of Ifiok Jr. (`@ifiokjr`) using GPT-5 with high reasoning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `pina verify` workflows for checking deployed programs, recording verification data, exporting multisig transactions, and submitting or viewing verification status.
  * Added support for build-record provenance, executable hash comparisons, cluster selection, mainnet acknowledgements, and base64/base58 transaction exports.
  * Added clear exit codes for successful checks, mismatches, and operational errors.

* **Documentation**
  * Added CLI help, reference documentation, automation guidance, and skill documentation for verification workflows and security requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->