### PR TITLE
fix(release): sync npm platform dependency ranges

### DIFF
--- a/.changeset/sync-release-npm-ranges.md
+++ b/.changeset/sync-release-npm-ranges.md
@@ -1,0 +1,9 @@
+---
+pina_cli_npm:
+  bump: patch
+  type: fix
+---
+
+# Synchronize npm platform dependency ranges during releases
+
+Update `@pina-rs/cli` platform dependency ranges after Monochange prepares a release, then refresh the pnpm lockfile before committing the release pull request. This keeps every optional native package aligned with the launcher version and prevents release validation from accepting stale dependency ranges.

--- a/monochange.toml
+++ b/monochange.toml
@@ -66,6 +66,7 @@ help_text = "Prepare, format, commit, and open the release pull request."
 steps = [
 	{ name = "prepare release", type = "PrepareRelease", allow_empty_changesets = true, inputs = { format = "json" } },
 	{ name = "preserve macro test dependency range", type = "Command", shell = "bash", command = "scripts/preserve-pina-dev-dependency-range.sh", when = "{{ number_of_changesets > 0 }}" },
+	{ name = "sync npm platform dependency ranges", type = "Command", shell = "bash", command = "node scripts/npm/sync-release-versions.mjs && pnpm install --lockfile-only", when = "{{ number_of_changesets > 0 }}" },
 	{ name = "format release commit", type = "Command", shell = "bash", command = "fix:format", when = "{{ number_of_changesets > 0 }}" },
 	{ name = "commit release", type = "CommitRelease", inputs = { stage_all = true, no_verify = true }, when = "{{ number_of_changesets > 0 }}" },
 	{ name = "open release request", type = "OpenReleaseRequest", inputs = { stage_all = true, no_verify = true }, when = "{{ number_of_changesets > 0 }}" },

--- a/scripts/npm/sync-release-versions.mjs
+++ b/scripts/npm/sync-release-versions.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { packageDirectoryName, platforms } from "./package-cli.mjs";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = resolve(scriptDirectory, "../..");
+
+function readManifest(path) {
+	return JSON.parse(readFileSync(path, "utf8"));
+}
+
+export function synchronizePlatformDependencies(
+	cliManifest,
+	platformManifests,
+) {
+	const optionalDependencies = cliManifest.optionalDependencies;
+	if (
+		optionalDependencies === undefined ||
+		optionalDependencies === null ||
+		Array.isArray(optionalDependencies) ||
+		typeof optionalDependencies !== "object"
+	) {
+		throw new Error("@pina-rs/cli must define optionalDependencies");
+	}
+
+	const expectedNames = new Set(
+		platforms.map((specification) => specification.packageName),
+	);
+	const actualNames = new Set(Object.keys(optionalDependencies));
+	if (
+		expectedNames.size !== actualNames.size ||
+		[...expectedNames].some((name) => !actualNames.has(name))
+	) {
+		throw new Error(
+			"@pina-rs/cli optionalDependencies must match the release matrix",
+		);
+	}
+
+	const versions = new Map(
+		platformManifests.map((manifest) => [manifest.name, manifest.version]),
+	);
+	for (const specification of platforms) {
+		const version = versions.get(specification.packageName);
+		if (version === undefined) {
+			throw new Error(`Missing manifest for ${specification.packageName}`);
+		}
+
+		if (version !== cliManifest.version) {
+			throw new Error(
+				`${specification.packageName} is ${version}, expected ${cliManifest.version}`,
+			);
+		}
+
+		optionalDependencies[specification.packageName] = `^${version}`;
+	}
+
+	return cliManifest;
+}
+
+export function main() {
+	const packagesDirectory = join(repositoryRoot, "packages");
+	const cliManifestPath = join(
+		packagesDirectory,
+		packageDirectoryName("@pina-rs/cli"),
+		"package.json",
+	);
+	const cliManifest = readManifest(cliManifestPath);
+	const platformManifests = platforms.map((specification) =>
+		readManifest(
+			join(
+				packagesDirectory,
+				packageDirectoryName(specification.packageName),
+				"package.json",
+			),
+		)
+	);
+
+	synchronizePlatformDependencies(cliManifest, platformManifests);
+	writeFileSync(
+		cliManifestPath,
+		`${JSON.stringify(cliManifest, null, "\t")}\n`,
+	);
+}
+
+if (
+	process.argv[1] &&
+	resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))
+) {
+	main();
+}

--- a/scripts/npm/tests/sync-release-versions.test.mjs
+++ b/scripts/npm/tests/sync-release-versions.test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { platforms } from "../package-cli.mjs";
+import { synchronizePlatformDependencies } from "../sync-release-versions.mjs";
+
+function releaseManifests(version) {
+	return platforms.map((specification) => ({
+		name: specification.packageName,
+		version,
+	}));
+}
+
+function cliManifest(version, dependencyVersion) {
+	return {
+		name: "@pina-rs/cli",
+		optionalDependencies: Object.fromEntries(
+			platforms.map((specification) => [
+				specification.packageName,
+				`^${dependencyVersion}`,
+			]),
+		),
+		version,
+	};
+}
+
+test("release versions synchronize every platform dependency", () => {
+	const manifest = synchronizePlatformDependencies(
+		cliManifest("0.10.0", "0.9.0"),
+		releaseManifests("0.10.0"),
+	);
+
+	assert.deepEqual(
+		new Set(Object.values(manifest.optionalDependencies)),
+		new Set(["^0.10.0"]),
+	);
+});
+
+test("release versions reject a platform version mismatch", () => {
+	const manifests = releaseManifests("0.10.0");
+	manifests[0].version = "0.9.0";
+
+	assert.throws(
+		() =>
+			synchronizePlatformDependencies(
+				cliManifest("0.10.0", "0.9.0"),
+				manifests,
+			),
+		/@pina-rs\/cli-linux-arm64-gnu is 0\.9\.0, expected 0\.10\.0/,
+	);
+});
+
+test("release versions reject an incomplete dependency matrix", () => {
+	const manifest = cliManifest("0.10.0", "0.9.0");
+	delete manifest.optionalDependencies[platforms[0].packageName];
+
+	assert.throws(
+		() => synchronizePlatformDependencies(manifest, releaseManifests("0.10.0")),
+		/optionalDependencies must match the release matrix/,
+	);
+});


### PR DESCRIPTION
## Summary

- synchronize `@pina-rs/cli` optional native dependency ranges after Monochange prepares a release
- refresh `pnpm-lock.yaml` before the release commit is created
- validate the complete platform matrix and reject missing or mismatched package versions
- add regression tests for version synchronization and malformed release inputs

## Why

Release PR #225 correctly bumped every npm package to 0.10.0 but retained `^0.9.0` optional dependency ranges in `@pina-rs/cli`, causing the package-integrity CI check to fail.

## Verification

- `pnpm test:npm-packages`
- `mc step validate`
- `mc check`
- `dprint check`
- real temporary `mc step prepare-release` for 0.10.0, followed by dependency synchronization, lockfile refresh, and `pnpm check:npm-packages`
- full pre-push Rust/lint/docs gates passed until a local generated-client `node_modules` symlink caused the existing IDL output-tree safety check to stop the hook; fresh GitHub CI is authoritative

Created on behalf of Ifiok Jr. (@ifiokjr) by Codex (GPT-5, high reasoning).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CLI releases so platform-specific packages consistently use versions compatible with the launcher.
  - Added validation to detect missing or mismatched platform package versions before a release is published.

- **Chores**
  - Automated synchronization of platform dependency ranges during the release process.
  - Refreshed package metadata and lockfile information to keep published installations consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->