### PR TITLE
fix(test): stabilize shell fixtures on Linux

### DIFF
--- a/.changeset/stable-shell-fixtures.md
+++ b/.changeset/stable-shell-fixtures.md
@@ -1,0 +1,9 @@
+---
+pina_cli:
+  bump: none
+  type: none
+---
+
+# Stabilize generated shell fixtures on Linux CI
+
+Execute dynamic test bodies through a stable checked-in shell driver instead of asking the kernel to execute files immediately after writing them. This removes overlay-filesystem `ETXTBSY` races from coverage runs without changing production behavior.

--- a/crates/pina_cli/src/idl_metadata.rs
+++ b/crates/pina_cli/src/idl_metadata.rs
@@ -1746,45 +1746,42 @@ mod tests {
 
 	#[cfg(unix)]
 	fn fake_runner(directory: &Path, capture: &Path, stdout: &str) -> PathBuf {
-		use std::os::unix::fs::PermissionsExt;
-
 		let fixture_name = capture
 			.file_stem()
 			.and_then(|name| name.to_str())
 			.unwrap_or("runner");
 		let runner = directory.join(format!("fake-npx-{fixture_name}.sh"));
-		let script = format!(
-			"#!/bin/sh\nprintf '%s\\n' \"$@\" > '{}'\nprintf '{}'\n",
+		let body = format!(
+			"printf '%s\\n' \"$@\" > '{}'\nprintf '{}'\n",
 			capture.display(),
 			stdout.replace('\\', "\\\\").replace('\'', "'\\''")
 		);
-		std::fs::write(&runner, script)
-			.unwrap_or_else(|error| panic!("runner write failed: {error}"));
-		let mut permissions = std::fs::metadata(&runner)
-			.unwrap_or_else(|error| panic!("runner metadata failed: {error}"))
-			.permissions();
-		permissions.set_mode(0o755);
-		std::fs::set_permissions(&runner, permissions)
-			.unwrap_or_else(|error| panic!("runner permissions failed: {error}"));
 
-		runner
+		fake_runner_with_body(&runner, &body)
 	}
 
 	#[cfg(unix)]
 	fn fake_runner_script(directory: &Path, body: &str) -> PathBuf {
-		use std::os::unix::fs::PermissionsExt;
-
 		let runner = directory.join("fake-script.sh");
-		std::fs::write(&runner, format!("#!/bin/sh\n{body}\n"))
-			.unwrap_or_else(|error| panic!("runner write failed: {error}"));
-		let mut permissions = std::fs::metadata(&runner)
-			.unwrap_or_else(|error| panic!("runner metadata failed: {error}"))
-			.permissions();
-		permissions.set_mode(0o755);
-		std::fs::set_permissions(&runner, permissions)
-			.unwrap_or_else(|error| panic!("runner permissions failed: {error}"));
+		fake_runner_with_body(&runner, body)
+	}
 
-		runner
+	#[cfg(unix)]
+	fn fake_runner_with_body(runner: &Path, body: &str) -> PathBuf {
+		use std::os::unix::fs::symlink;
+
+		let mut body_path = runner.as_os_str().to_owned();
+		body_path.push(".body");
+		std::fs::write(PathBuf::from(body_path), format!("{body}\n"))
+			.unwrap_or_else(|error| panic!("runner body write failed: {error}"));
+		if !runner.exists() {
+			let driver =
+				Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/shell-driver.sh");
+			symlink(driver, runner)
+				.unwrap_or_else(|error| panic!("runner driver link failed: {error}"));
+		}
+
+		runner.to_path_buf()
 	}
 
 	#[test]

--- a/crates/pina_cli/src/workflow.rs
+++ b/crates/pina_cli/src/workflow.rs
@@ -519,15 +519,14 @@ mod tests {
 
 	#[cfg(unix)]
 	fn executable_script(directory: &Path, name: &str, body: &str) -> PathBuf {
-		use std::os::unix::fs::PermissionsExt;
+		use std::os::unix::fs::symlink;
 
 		let path = directory.join(name);
-		fs::write(&path, format!("#!/bin/sh\n{body}\n")).expect("write test executable");
-		let mut permissions = fs::metadata(&path)
-			.expect("read test executable metadata")
-			.permissions();
-		permissions.set_mode(0o755);
-		fs::set_permissions(&path, permissions).expect("make test file executable");
+		let mut body_path = path.as_os_str().to_owned();
+		body_path.push(".body");
+		fs::write(PathBuf::from(body_path), format!("{body}\n")).expect("write test script body");
+		let driver = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/shell-driver.sh");
+		symlink(driver, &path).expect("link stable test shell driver");
 		path
 	}
 

--- a/crates/pina_cli/tests/fixtures/shell-driver.sh
+++ b/crates/pina_cli/tests/fixtures/shell-driver.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$0.body" "$@"


### PR DESCRIPTION
## Summary

- execute dynamic CLI test bodies through a stable checked-in shell driver
- avoid Linux overlay-filesystem `ETXTBSY` races in workflow and Program Metadata fixtures
- keep generated arguments and output behavior unchanged

## Verification

- `cargo test -p pina_cli --all-features`
- `cargo clippy -p pina_cli --all-features -- -D warnings`
- full `cargo llvm-cov --all-features --locked -p pina_cli`
- affected race tests passed 40 consecutive runs
- `test:idl`
- Monochange changeset validation and affected-package verification

Created on behalf of Ifiok Jr. (@ifiokjr) by Codex (GPT-5, high reasoning).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved Unix test execution reliability by routing generated test scripts through a stable shell driver.
  * Reduced intermittent coverage-run failures caused by filesystem execution races.
  * Production behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->