### PR TITLE
fix(ci): allow release comments on pull requests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -293,7 +293,7 @@ jobs:
               *-win32-*) binary_name=pina.exe ;;
             esac
             platform_report="$RUNNER_TEMP/$(basename "$package_dir")-pack.json"
-            npm pack "$package_dir" --dry-run --json > "$platform_report"
+            npm pack "./$package_dir" --dry-run --json > "$platform_report"
             jq -e --arg path "bin/$binary_name" \
               'any(.[0].files[]; .path == $path)' \
               "$platform_report" >/dev/null || {

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -124,6 +124,7 @@ jobs:
       actions: write
       contents: write
       issues: write
+      pull-requests: write
     steps:
       - name: checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Summary

- grant the release tag job `pull-requests: write` for related PR comments
- force platform `npm pack` validation to use explicit local filesystem paths
- preserve the existing tag, draft-release, and trusted-publication boundaries

## Incidents

1. `comment-released-issues` received HTTP 403 on related PR #214 because the job only had `issues: write`.
2. npm 11 interpreted `packages/pina__cli-darwin-arm64` as GitHub shorthand and attempted SSH; `./packages/...` correctly packs the local package. This failed before any registry publication.

## Verification

- `actionlint .github/workflows/release-pr.yml .github/workflows/publish.yml`
- full pre-push workspace gate
- local `npm pack ./packages/pina__cli-darwin-arm64 --dry-run --json` at 0.10.0
- `dprint check`
- `mc check`

Created on behalf of Ifiok Jr. (@ifiokjr) by Codex (GPT-5, high reasoning).