### PR TITLE
fix(ci): acknowledge breaking changesets in semver checks

### DIFF
--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -46,9 +46,10 @@ jobs:
           fi
 
           # Check if any changeset file contains a major change type
+          # ('major' and 'breaking' both bump major per monochange.toml)
           changeset_acknowledged=false
           if ls .changeset/*.md 1>/dev/null 2>&1; then
-            if grep -lE '^[a-zA-Z_]+: major$' .changeset/*.md 1>/dev/null 2>&1; then
+            if grep -lE '^[a-zA-Z_]+: (major|breaking)$' .changeset/*.md 1>/dev/null 2>&1; then
               changeset_acknowledged=true
               echo "Found major changeset — breaking change acknowledged via changeset"
             fi
@@ -65,7 +66,7 @@ jobs:
           echo ""
           echo "  1. Add '!' to your PR title (e.g. 'feat!: my breaking change' or 'fix(pina)!: remove deprecated api')"
           echo ""
-          echo "  2. Add a changeset file with a 'major' change type:"
+          echo "  2. Add a changeset file with a 'major' or 'breaking' change type:"
           echo "     Run 'monochange run change' or create a file in .changeset/ with:"
           echo "     ---"
           echo "     package_name: major"


### PR DESCRIPTION
## Summary

The `semver` workflow only recognized `major` changesets when deciding whether detected breaking changes were acknowledged, but `monochange.toml` treats both `major` and `breaking` as major-bumping change types:

```toml
[changelog.types]
major = { bump = "major", section = "breaking" }
breaking = { bump = "major", section = "breaking" }
```

Since #244 added `.changeset/adopt-cpi-instruction-builders.md` with `pina: breaking`, every PR based on current `main` — including docs-only ones — now fails `semver-checks` with **Breaking changes detected but not acknowledged**, because the baseline (published `pina v0.10.0`) still contains the removed CPI free functions.

## Changes

- Accept `breaking` alongside `major` in the acknowledgment grep
- Update the failure hint to mention both change types

## Test plan

- [x] CI `semver-checks` passes on this PR with the fixed acknowledgment logic

Created on behalf of Ifiok Jr. (`@ifiokjr`) by codex (gpt-5.1-codex, high thinking).