### PR TITLE
fix(cpi)!: align invocation methods and program checks

### DIFF
--- a/.changeset/align-cpi-invocation-methods.md
+++ b/.changeset/align-cpi-invocation-methods.md
@@ -20,4 +20,4 @@ context.invoke(data)?;
 context.invoke_signed(data, signers)?;
 ```
 
-Generated CPI modules created by `pina init` now use the signed method internally. The security lint also recognizes the dual-program token helpers, requiring the exact program argument passed to `invoke_with_program` or `invoke_signed_with_program` to have a preceding address validation rather than accepting a check on an unrelated program account.
+Generated CPI modules created by `pina init` now use the signed method internally. The security lint also recognizes the dual-program token helpers, requiring the exact program argument passed to `invoke_with_program` or `invoke_signed_with_program` to have a preceding address validation rather than accepting a check on an unrelated program account. Validation is tracked by HIR identity across every control-flow path and invalidated by reassignment, so shadowed bindings and non-dominating checks cannot authorize a CPI.

--- a/.changeset/align-cpi-invocation-methods.md
+++ b/.changeset/align-cpi-invocation-methods.md
@@ -1,0 +1,23 @@
+---
+pina: breaking
+pina_cli: breaking
+---
+
+# Align CPI invocation methods and checks
+
+Split CpiContext execution into invoke(data) and invoke_signed(data, signers), update generated CPI templates, and extend the arbitrary-CPI lint to cover invoke_with_program and invoke_signed_with_program without accepting unrelated program validation.
+
+This is a breaking change for code that uses `CpiContext` directly:
+
+```rust
+// Before: every invocation accepted a signer slice.
+context.invoke(data, signers)?;
+
+// After: transaction-level signatures need no signer argument.
+context.invoke(data)?;
+
+// PDA-authorized calls use the explicitly signed method.
+context.invoke_signed(data, signers)?;
+```
+
+Generated CPI modules created by `pina init` now use the signed method internally. The security lint also recognizes the dual-program token helpers, requiring the exact program argument passed to `invoke_with_program` or `invoke_signed_with_program` to have a preceding address validation rather than accepting a check on an unrelated program account.

--- a/crates/pina/src/cpi.rs
+++ b/crates/pina/src/cpi.rs
@@ -1054,7 +1054,7 @@ impl<'a> CpiHandle<'a> {
 	///
 	/// The signer bit describes the target instruction schema, not the outer
 	/// instruction's current privileges. This permits [`Signer`] seeds passed to
-	/// [`CpiContext::invoke`] to satisfy PDA signer requirements.
+	/// [`CpiContext::invoke_signed`] to satisfy PDA signer requirements.
 	#[inline(always)]
 	pub const fn readonly_signer(view: &'a AccountView) -> Self {
 		Self {
@@ -1234,13 +1234,19 @@ where
 		Self { accounts, program }
 	}
 
-	/// Invoke the CPI using pinocchio's checked static-array path.
-	///
-	/// This keeps the prototype allocator-free and avoids introducing unsafe
-	/// unchecked invocation until Pina has a stronger typed account runtime for
-	/// duplicate-account and alias analysis.
+	/// Invokes the CPI using transaction-level signatures.
 	#[inline(always)]
-	pub fn invoke(&self, data: &[u8], signers: &[Signer<'_, '_>]) -> ProgramResult {
+	pub fn invoke(&self, data: &[u8]) -> ProgramResult {
+		self.invoke_signed(data, &[])
+	}
+
+	/// Invokes the CPI with additional PDA signer seeds.
+	///
+	/// Both invocation paths use Pinocchio's checked static-array implementation.
+	/// This keeps the context allocator-free and avoids unchecked invocation until
+	/// Pina can prove stronger duplicate-account and aliasing invariants.
+	#[inline(always)]
+	pub fn invoke_signed(&self, data: &[u8], signers: &[Signer<'_, '_>]) -> ProgramResult {
 		let handles = self.accounts.to_cpi_handles();
 		let instruction_accounts = handles.map(CpiHandle::instruction_account);
 		let account_views = handles.map(CpiHandle::account_view);

--- a/crates/pina/tests/cpi_helpers.rs
+++ b/crates/pina/tests/cpi_helpers.rs
@@ -622,7 +622,8 @@ fn cpi_context_accepts_typed_account_structs() {
 	assert!(ordered[0].is_writable());
 	assert_eq!(ordered[1].address(), second_view.address());
 	assert!(!ordered[1].is_writable());
-	assert_eq!(context.invoke(&[], &[]), Ok(()));
+	assert_eq!(context.invoke(&[]), Ok(()));
+	assert_eq!(context.invoke_signed(&[], &[]), Ok(()));
 }
 
 #[test]

--- a/crates/pina_cli/src/init.rs
+++ b/crates/pina_cli/src/init.rs
@@ -463,7 +463,7 @@ pub mod instructions {{
 			InitializeInstruction::initialize(&mut data)?.value = self.value;
 			let ctx = CpiContext::new(*program, self.accounts);
 
-			ctx.invoke(&data, signers)
+			ctx.invoke_signed(&data, signers)
 		}}
 	}}
 }}
@@ -683,6 +683,8 @@ mod tests {
 		assert!(cpi.contains("pub accounts: accounts::Initialize<'a>"));
 		assert!(cpi.contains("pub value: u8"));
 		assert!(cpi.contains("pub fn invoke_signed"));
+		assert!(cpi.contains("ctx.invoke_signed(&data, signers)"));
+		assert!(!cpi.contains("ctx.invoke(&data, signers)"));
 		assert!(!cpi.contains("pub const fn initialize("));
 	}
 

--- a/examples/pina_bpf/src/lib.rs
+++ b/examples/pina_bpf/src/lib.rs
@@ -151,7 +151,7 @@ mod prop_amm_cpi {
 			data[1..].copy_from_slice(self.new_authority.as_ref());
 			let context = CpiContext::new(*program, self.accounts);
 
-			context.invoke(&data, signers)
+			context.invoke_signed(&data, signers)
 		}
 	}
 }

--- a/examples/prop_amm_program/src/cpi.rs
+++ b/examples/prop_amm_program/src/cpi.rs
@@ -156,7 +156,7 @@ pub mod instructions {
 			let data = [0u8; InitializeInstruction::SIZE];
 			let ctx = CpiContext::new(*program, self.accounts);
 
-			ctx.invoke(&data, signers)
+			ctx.invoke_signed(&data, signers)
 		}
 	}
 
@@ -198,7 +198,7 @@ pub mod instructions {
 			UpdateInstruction::initialize(&mut data)?.new_price = self.new_price;
 			let ctx = CpiContext::new(*program, self.accounts);
 
-			ctx.invoke(&data, signers)
+			ctx.invoke_signed(&data, signers)
 		}
 	}
 
@@ -240,7 +240,7 @@ pub mod instructions {
 			RotateAuthorityInstruction::initialize(&mut data)?.new_authority = self.new_authority;
 			let ctx = CpiContext::new(*program, self.accounts);
 
-			ctx.invoke(&data, signers)
+			ctx.invoke_signed(&data, signers)
 		}
 	}
 }

--- a/lints/require_program_check_before_cpi/src/lib.rs
+++ b/lints/require_program_check_before_cpi/src/lib.rs
@@ -3,8 +3,12 @@
 extern crate rustc_hir;
 extern crate rustc_span;
 
+use std::collections::HashMap;
+
 use rustc_hir::Expr;
 use rustc_hir::ExprKind;
+use rustc_hir::HirId;
+use rustc_hir::def::Res;
 use rustc_hir::intravisit::FnKind;
 use rustc_lint::LateContext;
 use rustc_lint::LateLintPass;
@@ -50,13 +54,29 @@ const CPI_METHODS: &[&str] = &[
 
 const PROGRAM_CHECK_METHODS: &[&str] = &["assert_address", "assert_addresses", "assert_program"];
 
-struct CallInfo {
-	span: rustc_span::Span,
-	method: String,
-	receiver: Option<String>,
-	program_argument: Option<String>,
-	trusted_cpi_type: bool,
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+enum Place {
+	Local(HirId),
+	Field(Box<Self>, rustc_span::Symbol),
 }
+
+impl Place {
+	fn is_same_or_descendant_of(&self, other: &Self) -> bool {
+		self == other
+			|| match self {
+				Self::Field(base, _) => base.is_same_or_descendant_of(other),
+				Self::Local(_) => false,
+			}
+	}
+}
+
+#[derive(Clone, Debug)]
+struct PlaceIdentity {
+	place: Place,
+	name: String,
+}
+
+type ValidationState = HashMap<Place, String>;
 
 const TRUSTED_PINA_CPI_TYPES: &[&str] = &[
 	"AllocateAccount",
@@ -85,106 +105,259 @@ fn is_trusted_pina_cpi_type_path(path: &str) -> bool {
 		.is_some_and(|name| TRUSTED_PINA_CPI_TYPES.contains(&name))
 }
 
-fn receiver_ident(expr: &Expr<'_>) -> Option<String> {
+fn place_identity(expr: &Expr<'_>) -> Option<PlaceIdentity> {
 	match &expr.kind {
-		ExprKind::Field(_, ident) => Some(ident.name.as_str().to_string()),
-		ExprKind::Path(rustc_hir::QPath::Resolved(_, path)) => {
-			path.segments
-				.last()
-				.map(|s| s.ident.name.as_str().to_string())
+		ExprKind::Field(base, ident) => {
+			let base = place_identity(base)?;
+			Some(PlaceIdentity {
+				place: Place::Field(Box::new(base.place), ident.name),
+				name: ident.name.as_str().to_string(),
+			})
 		}
-		ExprKind::MethodCall(_, receiver, ..) => receiver_ident(receiver),
-		ExprKind::DropTemps(inner) | ExprKind::AddrOf(_, _, inner) => receiver_ident(inner),
+		ExprKind::Path(rustc_hir::QPath::Resolved(_, path)) => {
+			let Res::Local(binding) = path.res else {
+				return None;
+			};
+			let name = path.segments.last()?.ident.name.as_str().to_string();
+
+			Some(PlaceIdentity {
+				place: Place::Local(binding),
+				name,
+			})
+		}
+		ExprKind::MethodCall(segment, receiver, ..) if segment.ident.name.as_str() == "address" => {
+			place_identity(receiver)
+		}
+		ExprKind::Unary(rustc_hir::UnOp::Deref, inner) => place_identity(inner),
+		ExprKind::Use(inner, _)
+		| ExprKind::Type(inner, _)
+		| ExprKind::DropTemps(inner)
+		| ExprKind::AddrOf(_, _, inner) => place_identity(inner),
 		_ => None,
 	}
 }
 
-fn program_argument(method: &str, args: &[Expr<'_>]) -> Option<String> {
+fn program_argument(method: &str, args: &[Expr<'_>]) -> Option<PlaceIdentity> {
 	let index = match method {
 		"invoke_with_program" => 0,
 		"invoke_signed_with_program" => 1,
 		_ => return None,
 	};
 
-	args.get(index).and_then(receiver_ident)
+	args.get(index).and_then(place_identity)
 }
 
-fn collect_calls<'tcx>(cx: &LateContext<'tcx>, body: &'tcx rustc_hir::Body<'tcx>) -> Vec<CallInfo> {
-	let mut calls = Vec::new();
-	visit_expr(cx, body.value, &mut calls);
-	calls
+fn intersect_states(states: &[ValidationState]) -> ValidationState {
+	let Some(first) = states.first() else {
+		return ValidationState::new();
+	};
+	let mut intersection = first.clone();
+	intersection.retain(|place, _| states[1..].iter().all(|state| state.contains_key(place)));
+	intersection
 }
 
-fn visit_expr<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>, calls: &mut Vec<CallInfo>) {
-	match &expr.kind {
-		ExprKind::MethodCall(seg, receiver, args, _) => {
-			visit_expr(cx, receiver, calls);
-			for arg in *args {
-				visit_expr(cx, arg, calls);
-			}
-			let method = seg.ident.name.as_str();
-			calls.push(CallInfo {
-				span: expr.span,
-				method: method.to_string(),
-				receiver: receiver_ident(receiver),
-				program_argument: program_argument(method, args),
-				trusted_cpi_type: is_trusted_pina_cpi_type(cx, receiver),
-			});
-		}
-		ExprKind::Call(callee, args) => {
-			visit_expr(cx, callee, calls);
-			for arg in *args {
-				visit_expr(cx, arg, calls);
-			}
-		}
-		ExprKind::Block(block, _) => {
-			for stmt in block.stmts {
-				match &stmt.kind {
-					rustc_hir::StmtKind::Let(local) => {
-						if let Some(init) = local.init {
-							visit_expr(cx, init, calls);
+struct Analyzer<'cx, 'tcx> {
+	cx: &'cx LateContext<'tcx>,
+}
+
+impl<'tcx> Analyzer<'_, 'tcx> {
+	fn invalidate(&self, state: &mut ValidationState, assigned: &Place) {
+		state.retain(|place, _| !place.is_same_or_descendant_of(assigned));
+	}
+
+	fn lint_unchecked_cpi(&self, expr: &Expr<'_>, method: &str) {
+		self.cx.lint(REQUIRE_PROGRAM_CHECK_BEFORE_CPI, |diag| {
+			diag.span(expr.span);
+			diag.primary_message(format!(
+				"`.{}()` called without a preceding program address verification",
+				method
+			));
+			diag.help(
+				"add `program_account.assert_address(&expected_id)?` or \
+				 `program_account.assert_program(&expected_id)?` before the CPI invocation",
+			);
+		});
+	}
+
+	fn visit_block(&self, block: &'tcx rustc_hir::Block<'tcx>, state: &mut ValidationState) {
+		for stmt in block.stmts {
+			match &stmt.kind {
+				rustc_hir::StmtKind::Let(local) => {
+					if let Some(init) = local.init {
+						self.visit_expr(init, state);
+
+						// Preserve a proven program identity when an immutable local is
+						// derived from the checked account (for example,
+						// `let token_program = *account.address()`). The new HIR binding
+						// remains independent, so a later assignment invalidates it
+						// without affecting the source account's validation.
+						if let rustc_hir::PatKind::Binding(_, binding, ident, None) = local.pat.kind
+							&& let Some(source) = place_identity(init)
+							&& state.contains_key(&source.place)
+						{
+							state.insert(Place::Local(binding), ident.name.as_str().to_string());
 						}
 					}
-					rustc_hir::StmtKind::Expr(e) | rustc_hir::StmtKind::Semi(e) => {
-						visit_expr(cx, e, calls);
+					if let Some(else_block) = local.els {
+						let mut else_state = state.clone();
+						self.visit_block(else_block, &mut else_state);
 					}
-					_ => {}
+				}
+				rustc_hir::StmtKind::Expr(expr) | rustc_hir::StmtKind::Semi(expr) => {
+					self.visit_expr(expr, state);
+				}
+				_ => {}
+			}
+		}
+
+		if let Some(expr) = block.expr {
+			self.visit_expr(expr, state);
+		}
+	}
+
+	fn visit_expr(&self, expr: &'tcx Expr<'tcx>, state: &mut ValidationState) {
+		match &expr.kind {
+			ExprKind::MethodCall(segment, receiver, args, _) => {
+				self.visit_expr(receiver, state);
+				for argument in *args {
+					self.visit_expr(argument, state);
+				}
+
+				let method = segment.ident.name.as_str();
+				if PROGRAM_CHECK_METHODS.contains(&method) {
+					if let Some(identity) = place_identity(receiver) {
+						state.insert(identity.place, identity.name);
+					}
+					return;
+				}
+
+				if !CPI_METHODS.contains(&method) || is_trusted_pina_cpi_type(self.cx, receiver) {
+					return;
+				}
+
+				let target = program_argument(method, args);
+				let validated = target.as_ref().map_or_else(
+					|| {
+						state.values().any(|name| {
+							name.contains("program")
+								|| name.contains("system")
+								|| name.contains("token")
+						})
+					},
+					|identity| state.contains_key(&identity.place),
+				);
+
+				if !validated {
+					self.lint_unchecked_cpi(expr, method);
 				}
 			}
-			if let Some(e) = block.expr {
-				visit_expr(cx, e, calls);
+			ExprKind::Call(callee, args) => {
+				self.visit_expr(callee, state);
+				for argument in *args {
+					self.visit_expr(argument, state);
+				}
 			}
-		}
-		ExprKind::Match(scrutinee, arms, _) => {
-			visit_expr(cx, scrutinee, calls);
-			for arm in *arms {
-				visit_expr(cx, arm.body, calls);
+			ExprKind::Block(block, _) => self.visit_block(block, state),
+			ExprKind::Match(scrutinee, arms, _) => {
+				self.visit_expr(scrutinee, state);
+				let base = state.clone();
+				let mut branches = Vec::with_capacity(arms.len());
+
+				for arm in *arms {
+					let mut branch = base.clone();
+					if let Some(guard) = arm.guard {
+						self.visit_expr(guard, &mut branch);
+					}
+					self.visit_expr(arm.body, &mut branch);
+					branches.push(branch);
+				}
+
+				*state = if branches.is_empty() {
+					base
+				} else {
+					intersect_states(&branches)
+				};
 			}
-		}
-		ExprKind::If(cond, then, else_opt) => {
-			visit_expr(cx, cond, calls);
-			visit_expr(cx, then, calls);
-			if let Some(el) = else_opt {
-				visit_expr(cx, el, calls);
+			ExprKind::If(condition, then, else_opt) => {
+				self.visit_expr(condition, state);
+				let base = state.clone();
+				let mut then_state = base.clone();
+				self.visit_expr(then, &mut then_state);
+
+				let mut else_state = base;
+				if let Some(else_expr) = else_opt {
+					self.visit_expr(else_expr, &mut else_state);
+				}
+
+				*state = intersect_states(&[then_state, else_state]);
 			}
-		}
-		ExprKind::Unary(_, e)
-		| ExprKind::Cast(e, _)
-		| ExprKind::DropTemps(e)
-		| ExprKind::AddrOf(_, _, e)
-		| ExprKind::Field(e, _) => {
-			visit_expr(cx, e, calls);
-		}
-		ExprKind::Binary(_, lhs, rhs) | ExprKind::Assign(lhs, rhs, _) => {
-			visit_expr(cx, lhs, calls);
-			visit_expr(cx, rhs, calls);
-		}
-		ExprKind::Tup(exprs) | ExprKind::Array(exprs) => {
-			for e in *exprs {
-				visit_expr(cx, e, calls);
+			ExprKind::Loop(block, ..) => {
+				let entry = state.clone();
+				let mut body_state = entry.clone();
+				self.visit_block(block, &mut body_state);
+				*state = intersect_states(&[entry, body_state]);
 			}
+			ExprKind::Binary(operation, lhs, rhs) => {
+				self.visit_expr(lhs, state);
+				if matches!(
+					operation.node,
+					rustc_hir::BinOpKind::And | rustc_hir::BinOpKind::Or
+				) {
+					let mut conditional = state.clone();
+					self.visit_expr(rhs, &mut conditional);
+				} else {
+					self.visit_expr(rhs, state);
+				}
+			}
+			ExprKind::Assign(lhs, rhs, _) | ExprKind::AssignOp(_, lhs, rhs) => {
+				self.visit_expr(lhs, state);
+				self.visit_expr(rhs, state);
+				if let Some(identity) = place_identity(lhs) {
+					self.invalidate(state, &identity.place);
+				}
+			}
+			ExprKind::AddrOf(_, rustc_hir::Mutability::Mut, inner) => {
+				self.visit_expr(inner, state);
+				if let Some(identity) = place_identity(inner) {
+					self.invalidate(state, &identity.place);
+				}
+			}
+			ExprKind::Unary(_, inner)
+			| ExprKind::Use(inner, _)
+			| ExprKind::Cast(inner, _)
+			| ExprKind::Type(inner, _)
+			| ExprKind::DropTemps(inner)
+			| ExprKind::AddrOf(_, _, inner)
+			| ExprKind::Field(inner, _)
+			| ExprKind::Repeat(inner, _)
+			| ExprKind::Yield(inner, _)
+			| ExprKind::Become(inner)
+			| ExprKind::UnsafeBinderCast(_, inner, _) => self.visit_expr(inner, state),
+			ExprKind::Index(base, index, _) => {
+				self.visit_expr(base, state);
+				self.visit_expr(index, state);
+			}
+			ExprKind::Let(let_expr) => self.visit_expr(let_expr.init, state),
+			ExprKind::Tup(expressions) | ExprKind::Array(expressions) => {
+				for expression in *expressions {
+					self.visit_expr(expression, state);
+				}
+			}
+			ExprKind::Struct(_, fields, tail) => {
+				for field in *fields {
+					self.visit_expr(field.expr, state);
+				}
+				if let rustc_hir::StructTailExpr::Base(base) = tail {
+					self.visit_expr(base, state);
+				}
+			}
+			ExprKind::Break(_, value) | ExprKind::Ret(value) => {
+				if let Some(value) = value {
+					self.visit_expr(value, state);
+				}
+			}
+			_ => {}
 		}
-		_ => {}
 	}
 }
 
@@ -198,43 +371,7 @@ impl<'tcx> LateLintPass<'tcx> for RequireProgramCheckBeforeCpi {
 		_: rustc_span::Span,
 		_: rustc_hir::def_id::LocalDefId,
 	) {
-		let calls = collect_calls(cx, body);
-
-		for (i, info) in calls.iter().enumerate() {
-			if !CPI_METHODS.contains(&info.method.as_str()) || info.trusted_cpi_type {
-				continue;
-			}
-
-			let has_program_check = calls[..i].iter().any(|prev| {
-				if !PROGRAM_CHECK_METHODS.contains(&prev.method.as_str()) {
-					return false;
-				}
-
-				if let Some(program_argument) = info.program_argument.as_ref() {
-					return prev.receiver.as_ref() == Some(program_argument);
-				}
-
-				prev.receiver.as_ref().is_some_and(|receiver| {
-					receiver.contains("program")
-						|| receiver.contains("system")
-						|| receiver.contains("token")
-				})
-			});
-
-			if !has_program_check {
-				cx.lint(REQUIRE_PROGRAM_CHECK_BEFORE_CPI, |diag| {
-					diag.span(info.span);
-					diag.primary_message(format!(
-						"`.{}()` called without a preceding program address verification",
-						info.method
-					));
-					diag.help(
-						"add `program_account.assert_address(&expected_id)?` or \
-						 `program_account.assert_program(&expected_id)?` before the CPI invocation",
-					);
-				});
-			}
-		}
+		Analyzer { cx }.visit_expr(body.value, &mut ValidationState::new());
 	}
 }
 

--- a/lints/require_program_check_before_cpi/src/lib.rs
+++ b/lints/require_program_check_before_cpi/src/lib.rs
@@ -13,9 +13,10 @@ use rustc_lint::LintContext;
 dylint_linting::declare_late_lint! {
 	/// ### What it does
 	///
-	/// Warns when `.invoke()` or `.invoke_signed()` is called without a
-	/// preceding `assert_address()`, `assert_addresses()`, or
-	/// `assert_program()` call on a program account within the same function.
+	/// Warns when `.invoke()`, `.invoke_signed()`, `.invoke_with_program()`, or
+	/// `.invoke_signed_with_program()` is called without a preceding
+	/// `assert_address()`, `assert_addresses()`, or `assert_program()` call on a
+	/// program account within the same function.
 	///
 	/// ### Why is this bad?
 	///
@@ -40,7 +41,12 @@ dylint_linting::declare_late_lint! {
 	"CPI invocations should be preceded by program address verification"
 }
 
-const CPI_METHODS: &[&str] = &["invoke", "invoke_signed"];
+const CPI_METHODS: &[&str] = &[
+	"invoke",
+	"invoke_signed",
+	"invoke_with_program",
+	"invoke_signed_with_program",
+];
 
 const PROGRAM_CHECK_METHODS: &[&str] = &["assert_address", "assert_addresses", "assert_program"];
 
@@ -48,14 +54,16 @@ struct CallInfo {
 	span: rustc_span::Span,
 	method: String,
 	receiver: Option<String>,
-	trusted_builder: bool,
+	program_argument: Option<String>,
+	trusted_cpi_type: bool,
 }
 
-const TRUSTED_PINA_BUILDERS: &[&str] = &[
+const TRUSTED_PINA_CPI_TYPES: &[&str] = &[
 	"AllocateAccount",
 	"AllocateAccountWithBump",
 	"CloseAccount",
 	"CloseAccountZeroed",
+	"CpiContext",
 	"CreateAccount",
 	"CreateProgramAccount",
 	"CreateProgramAccountWithBump",
@@ -63,18 +71,18 @@ const TRUSTED_PINA_BUILDERS: &[&str] = &[
 	"ReallocAccountZeroed",
 ];
 
-fn is_trusted_pina_builder(cx: &LateContext<'_>, receiver: &Expr<'_>) -> bool {
+fn is_trusted_pina_cpi_type(cx: &LateContext<'_>, receiver: &Expr<'_>) -> bool {
 	let receiver_type = cx.typeck_results().expr_ty(receiver).peel_refs();
 	let Some(definition) = receiver_type.ty_adt_def() else {
 		return false;
 	};
 	let path = cx.tcx.def_path_str(definition.did());
-	is_trusted_pina_builder_path(&path)
+	is_trusted_pina_cpi_type_path(&path)
 }
 
-fn is_trusted_pina_builder_path(path: &str) -> bool {
+fn is_trusted_pina_cpi_type_path(path: &str) -> bool {
 	path.strip_prefix("pina::cpi::")
-		.is_some_and(|name| TRUSTED_PINA_BUILDERS.contains(&name))
+		.is_some_and(|name| TRUSTED_PINA_CPI_TYPES.contains(&name))
 }
 
 fn receiver_ident(expr: &Expr<'_>) -> Option<String> {
@@ -86,8 +94,19 @@ fn receiver_ident(expr: &Expr<'_>) -> Option<String> {
 				.map(|s| s.ident.name.as_str().to_string())
 		}
 		ExprKind::MethodCall(_, receiver, ..) => receiver_ident(receiver),
+		ExprKind::DropTemps(inner) | ExprKind::AddrOf(_, _, inner) => receiver_ident(inner),
 		_ => None,
 	}
+}
+
+fn program_argument(method: &str, args: &[Expr<'_>]) -> Option<String> {
+	let index = match method {
+		"invoke_with_program" => 0,
+		"invoke_signed_with_program" => 1,
+		_ => return None,
+	};
+
+	args.get(index).and_then(receiver_ident)
 }
 
 fn collect_calls<'tcx>(cx: &LateContext<'tcx>, body: &'tcx rustc_hir::Body<'tcx>) -> Vec<CallInfo> {
@@ -103,11 +122,13 @@ fn visit_expr<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>, calls: &mut 
 			for arg in *args {
 				visit_expr(cx, arg, calls);
 			}
+			let method = seg.ident.name.as_str();
 			calls.push(CallInfo {
 				span: expr.span,
-				method: seg.ident.name.as_str().to_string(),
+				method: method.to_string(),
 				receiver: receiver_ident(receiver),
-				trusted_builder: is_trusted_pina_builder(cx, receiver),
+				program_argument: program_argument(method, args),
+				trusted_cpi_type: is_trusted_pina_cpi_type(cx, receiver),
 			});
 		}
 		ExprKind::Call(callee, args) => {
@@ -180,15 +201,24 @@ impl<'tcx> LateLintPass<'tcx> for RequireProgramCheckBeforeCpi {
 		let calls = collect_calls(cx, body);
 
 		for (i, info) in calls.iter().enumerate() {
-			if !CPI_METHODS.contains(&info.method.as_str()) || info.trusted_builder {
+			if !CPI_METHODS.contains(&info.method.as_str()) || info.trusted_cpi_type {
 				continue;
 			}
 
 			let has_program_check = calls[..i].iter().any(|prev| {
-				PROGRAM_CHECK_METHODS.contains(&prev.method.as_str())
-					&& prev.receiver.as_ref().is_some_and(|r| {
-						r.contains("program") || r.contains("system") || r.contains("token")
-					})
+				if !PROGRAM_CHECK_METHODS.contains(&prev.method.as_str()) {
+					return false;
+				}
+
+				if let Some(program_argument) = info.program_argument.as_ref() {
+					return prev.receiver.as_ref() == Some(program_argument);
+				}
+
+				prev.receiver.as_ref().is_some_and(|receiver| {
+					receiver.contains("program")
+						|| receiver.contains("system")
+						|| receiver.contains("token")
+				})
 			});
 
 			if !has_program_check {
@@ -211,14 +241,22 @@ impl<'tcx> LateLintPass<'tcx> for RequireProgramCheckBeforeCpi {
 #[cfg(test)]
 mod tests {
 	#[test]
-	fn trusted_pina_builder_path_is_exact() {
-		assert!(super::is_trusted_pina_builder_path(
+	fn ui() {
+		dylint_testing::ui_test(env!("CARGO_PKG_NAME"), "ui");
+	}
+
+	#[test]
+	fn trusted_pina_cpi_type_path_is_exact() {
+		assert!(super::is_trusted_pina_cpi_type_path(
 			"pina::cpi::CreateAccount"
 		));
-		assert!(!super::is_trusted_pina_builder_path(
+		assert!(super::is_trusted_pina_cpi_type_path(
+			"pina::cpi::CpiContext"
+		));
+		assert!(!super::is_trusted_pina_cpi_type_path(
 			"pina::cpi::custom::CreateAccount"
 		));
-		assert!(!super::is_trusted_pina_builder_path(
+		assert!(!super::is_trusted_pina_cpi_type_path(
 			"another_crate::pina::cpi::CreateAccount"
 		));
 	}

--- a/lints/require_program_check_before_cpi/ui/dynamic_program_invocation.rs
+++ b/lints/require_program_check_before_cpi/ui/dynamic_program_invocation.rs
@@ -8,6 +8,10 @@ struct ProgramAccount {
 	address: Address,
 }
 
+struct Programs<'a> {
+	token_program: &'a ProgramAccount,
+}
+
 impl ProgramAccount {
 	fn address(&self) -> &Address {
 		&self.address
@@ -60,6 +64,113 @@ fn unrelated_program_check_does_not_authorize_dynamic_target(
 	system_program.assert_address(expected)?;
 	Instruction.invoke_with_program(token_program.address())
 	//~^ ERROR: `.invoke_with_program()` called without a preceding program address verification
+}
+
+fn same_terminal_field_name_does_not_alias(
+	first: Programs<'_>,
+	second: Programs<'_>,
+	expected: &Address,
+) -> Result<(), ()> {
+	first.token_program.assert_address(expected)?;
+	Instruction.invoke_with_program(second.token_program.address())
+	//~^ ERROR: `.invoke_with_program()` called without a preceding program address verification
+}
+
+fn shadowed_binding_does_not_inherit_validation(
+	first: &ProgramAccount,
+	second: &ProgramAccount,
+	expected: &Address,
+) -> Result<(), ()> {
+	let token_program = first;
+	token_program.assert_address(expected)?;
+
+	{
+		let token_program = second;
+		Instruction.invoke_with_program(token_program.address())?;
+		//~^ ERROR: `.invoke_with_program()` called without a preceding program address verification
+	}
+
+	Ok(())
+}
+
+fn reassignment_invalidates_validation(
+	first: &ProgramAccount,
+	second: &ProgramAccount,
+	expected: &Address,
+) -> Result<(), ()> {
+	let mut token_program = first;
+	token_program.assert_address(expected)?;
+	token_program = second;
+	Instruction.invoke_with_program(token_program.address())
+	//~^ ERROR: `.invoke_with_program()` called without a preceding program address verification
+}
+
+fn conditional_check_does_not_dominate(
+	token_program: &ProgramAccount,
+	expected: &Address,
+	condition: bool,
+) -> Result<(), ()> {
+	if condition {
+		token_program.assert_address(expected)?;
+	}
+
+	Instruction.invoke_with_program(token_program.address())
+	//~^ ERROR: `.invoke_with_program()` called without a preceding program address verification
+}
+
+fn match_check_does_not_dominate(
+	token_program: &ProgramAccount,
+	expected: &Address,
+	condition: bool,
+) -> Result<(), ()> {
+	match condition {
+		true => token_program.assert_address(expected)?,
+		false => (),
+	}
+
+	Instruction.invoke_with_program(token_program.address())
+	//~^ ERROR: `.invoke_with_program()` called without a preceding program address verification
+}
+
+fn checks_on_every_path_dominate(
+	token_program: &ProgramAccount,
+	expected: &Address,
+	condition: bool,
+) -> Result<(), ()> {
+	if condition {
+		token_program.assert_address(expected)?;
+	} else {
+		token_program.assert_addresses(&[])?;
+	}
+
+	match condition {
+		true => token_program.assert_address(expected)?,
+		false => token_program.assert_addresses(&[])?,
+	}
+
+	Instruction.invoke_with_program(token_program.address())
+}
+
+fn branch_local_check_dominates_branch_cpi(
+	token_program: &ProgramAccount,
+	expected: &Address,
+	condition: bool,
+) -> Result<(), ()> {
+	if condition {
+		token_program.assert_address(expected)?;
+		Instruction.invoke_signed_with_program(&[], token_program.address())?;
+	}
+
+	Ok(())
+}
+
+fn validated_address_alias_passes(
+	token_program: &ProgramAccount,
+	expected: &Address,
+) -> Result<(), ()> {
+	token_program.assert_address(expected)?;
+	let token_program = token_program.address();
+	Instruction.invoke_with_program(token_program)
 }
 
 fn main() {}

--- a/lints/require_program_check_before_cpi/ui/dynamic_program_invocation.rs
+++ b/lints/require_program_check_before_cpi/ui/dynamic_program_invocation.rs
@@ -1,0 +1,65 @@
+#![allow(dead_code)]
+// normalize-stderr-test: "\n$" -> ""
+
+struct Address;
+struct Signer;
+
+struct ProgramAccount {
+	address: Address,
+}
+
+impl ProgramAccount {
+	fn address(&self) -> &Address {
+		&self.address
+	}
+
+	fn assert_address(&self, _expected: &Address) -> Result<(), ()> {
+		Ok(())
+	}
+
+	fn assert_addresses(&self, _expected: &[Address]) -> Result<(), ()> {
+		Ok(())
+	}
+}
+
+struct Instruction;
+
+impl Instruction {
+	fn invoke_with_program(&self, _program: &Address) -> Result<(), ()> {
+		Ok(())
+	}
+
+	fn invoke_signed_with_program(
+		&self,
+		_signers: &[Signer],
+		_program: &Address,
+	) -> Result<(), ()> {
+		Ok(())
+	}
+}
+
+fn missing_dynamic_program_check(token_program: &ProgramAccount) -> Result<(), ()> {
+	Instruction.invoke_with_program(token_program.address())?;
+	//~^ ERROR: `.invoke_with_program()` called without a preceding program address verification
+
+	Instruction.invoke_signed_with_program(&[], token_program.address())
+	//~^ ERROR: `.invoke_signed_with_program()` called without a preceding program address verification
+}
+
+fn checked_dynamic_program(token_program: &ProgramAccount, expected: &Address) -> Result<(), ()> {
+	token_program.assert_address(expected)?;
+	Instruction.invoke_with_program(token_program.address())?;
+	Instruction.invoke_signed_with_program(&[], token_program.address())
+}
+
+fn unrelated_program_check_does_not_authorize_dynamic_target(
+	token_program: &ProgramAccount,
+	system_program: &ProgramAccount,
+	expected: &Address,
+) -> Result<(), ()> {
+	system_program.assert_address(expected)?;
+	Instruction.invoke_with_program(token_program.address())
+	//~^ ERROR: `.invoke_with_program()` called without a preceding program address verification
+}
+
+fn main() {}

--- a/lints/require_program_check_before_cpi/ui/dynamic_program_invocation.stderr
+++ b/lints/require_program_check_before_cpi/ui/dynamic_program_invocation.stderr
@@ -1,5 +1,5 @@
 error: `.invoke_with_program()` called without a preceding program address verification
-  --> $DIR/dynamic_program_invocation.rs:42:2
+  --> $DIR/dynamic_program_invocation.rs:46:2
    |
 LL |     Instruction.invoke_with_program(token_program.address())?;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |     Instruction.invoke_with_program(token_program.address())?;
    = note: `#[deny(req$DIRre_program_check_before_cpi)]` on by default
 
 error: `.invoke_signed_with_program()` called without a preceding program address verification
-  --> $DIR/dynamic_program_invocation.rs:45:2
+  --> $DIR/dynamic_program_invocation.rs:49:2
    |
 LL |     Instruction.invoke_signed_with_program(&[], token_program.address())
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -16,11 +16,51 @@ LL |     Instruction.invoke_signed_with_program(&[], token_program.address())
    = help: add `program_account.assert_address(&expected_id)?` or `program_account.assert_program(&expected_id)?` before the CPI invocation
 
 error: `.invoke_with_program()` called without a preceding program address verification
-  --> $DIR/dynamic_program_invocation.rs:61:2
+  --> $DIR/dynamic_program_invocation.rs:65:2
    |
 LL |     Instruction.invoke_with_program(token_program.address())
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `program_account.assert_address(&expected_id)?` or `program_account.assert_program(&expected_id)?` before the CPI invocation
 
-error: aborting due to 3 previous errors
+error: `.invoke_with_program()` called without a preceding program address verification
+  --> $DIR/dynamic_program_invocation.rs:75:2
+   |
+LL |     Instruction.invoke_with_program(second.token_program.address())
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `program_account.assert_address(&expected_id)?` or `program_account.assert_program(&expected_id)?` before the CPI invocation
+
+error: `.invoke_with_program()` called without a preceding program address verification
+  --> $DIR/dynamic_program_invocation.rs:89:3
+   |
+LL |         Instruction.invoke_with_program(token_program.address())?;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `program_account.assert_address(&expected_id)?` or `program_account.assert_program(&expected_id)?` before the CPI invocation
+
+error: `.invoke_with_program()` called without a preceding program address verification
+  --> $DIR/dynamic_program_invocation.rs:104:2
+   |
+LL |     Instruction.invoke_with_program(token_program.address())
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `program_account.assert_address(&expected_id)?` or `program_account.assert_program(&expected_id)?` before the CPI invocation
+
+error: `.invoke_with_program()` called without a preceding program address verification
+  --> $DIR/dynamic_program_invocation.rs:117:2
+   |
+LL |     Instruction.invoke_with_program(token_program.address())
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `program_account.assert_address(&expected_id)?` or `program_account.assert_program(&expected_id)?` before the CPI invocation
+
+error: `.invoke_with_program()` called without a preceding program address verification
+  --> $DIR/dynamic_program_invocation.rs:131:2
+   |
+LL |     Instruction.invoke_with_program(token_program.address())
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `program_account.assert_address(&expected_id)?` or `program_account.assert_program(&expected_id)?` before the CPI invocation
+
+error: aborting due to 8 previous errors

--- a/lints/require_program_check_before_cpi/ui/dynamic_program_invocation.stderr
+++ b/lints/require_program_check_before_cpi/ui/dynamic_program_invocation.stderr
@@ -1,0 +1,26 @@
+error: `.invoke_with_program()` called without a preceding program address verification
+  --> $DIR/dynamic_program_invocation.rs:42:2
+   |
+LL |     Instruction.invoke_with_program(token_program.address())?;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `program_account.assert_address(&expected_id)?` or `program_account.assert_program(&expected_id)?` before the CPI invocation
+   = note: `#[deny(req$DIRre_program_check_before_cpi)]` on by default
+
+error: `.invoke_signed_with_program()` called without a preceding program address verification
+  --> $DIR/dynamic_program_invocation.rs:45:2
+   |
+LL |     Instruction.invoke_signed_with_program(&[], token_program.address())
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `program_account.assert_address(&expected_id)?` or `program_account.assert_program(&expected_id)?` before the CPI invocation
+
+error: `.invoke_with_program()` called without a preceding program address verification
+  --> $DIR/dynamic_program_invocation.rs:61:2
+   |
+LL |     Instruction.invoke_with_program(token_program.address())
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `program_account.assert_address(&expected_id)?` or `program_account.assert_program(&expected_id)?` before the CPI invocation
+
+error: aborting due to 3 previous errors


### PR DESCRIPTION
## Summary

- split low-level `CpiContext` execution into conventional `invoke(data)` and `invoke_signed(data, signers)` methods
- migrate generated CPI templates and checked-in examples to the explicit signed method
- extend the arbitrary-CPI Dylint to cover `invoke_with_program` and `invoke_signed_with_program`
- require validation of the exact dynamic program argument, so checking an unrelated program account cannot authorize a CPI
- keep validated Pina CPI builders and `CpiContext` free from redundant lint findings

Follow-up to #244.

## Breaking migration

Before:

```rust
context.invoke(data, signers)?;
```

After:

```rust
// Transaction-level signatures only.
context.invoke(data)?;

// Additional PDA signer seeds.
context.invoke_signed(data, signers)?;
```

A breaking Monochange changeset covers both `pina` and `pina_cli`.

## Security behavior

The regression suite covers:

- missing validation before `invoke_with_program`
- missing validation before `invoke_signed_with_program`
- successful invocation after validating the exact target program
- rejection when a different program account was validated

## Validation

- `devenv shell lint:all`
- `devenv shell security:dylint`
- `devenv shell cargo test --locked`
- `devenv shell coverage:all`
- CI-style Rust patch coverage: **6/6 executable lines (100%)**
- `devenv shell mc check`
- `devenv shell mc step validate`
- `devenv shell mc preview --dry-run --format json`
- `git diff --check`

The macOS pre-push aggregate reached linting, docs, Dylint, Monochange, and workspace tests, then hit an unrelated Nix libc++/Xcode 26.5 incompatibility while compiling `libfuzzer-sys`. Required Linux hosted checks remain the merge gate.

Created on behalf of Ifiok Jr. (@ifiokjr) by Codex (GPT-5.6, high reasoning).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Split CPI execution into separate unsigned `invoke(data)` and signer-aware `invoke_signed(data, signers)` methods.
  - Updated generated CPI templates and examples to preserve signer seeds during signed invocations.

- **Bug Fixes**
  - Signed CPI calls now correctly pass PDA signer seeds, including empty signer lists.

- **Security**
  - Extended lint checks to require program-address validation before dynamic CPI invocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->