### PR TITLE
chore(deps): move dependency declarations to workspace level

### DIFF
--- a/.changeset/workspace-dependencies.md
+++ b/.changeset/workspace-dependencies.md
@@ -1,0 +1,9 @@
+---
+pina_cli: none
+---
+
+Move `pina_cli` dependency declarations to workspace level.
+
+- Move `comfy-table`, `owo-colors`, `rayon`, and `termimad` from direct `pina_cli` dependencies into `[workspace.dependencies]`.
+- Normalize the `base64`, `bs58`, and `url` workspace entries to `default-features = false` with caret version requirements.
+- `pina_cli` now opts into `default-features = true` explicitly per dependency, so resolved features are unchanged.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,12 +93,13 @@ rust-version = "1.89.0"
 
 [workspace.dependencies]
 atomic-write-file = { default-features = false, version = "^0.3" }
-base64 = "0.22.1"
-bs58 = "0.5.1"
+base64 = { default-features = false, version = "^0.22.1" }
+bs58 = { default-features = false, version = "^0.5.1" }
 cargo_metadata = { default-features = false, version = "^0.23" }
 clap = { default-features = false, version = "^4", features = ["derive", "std"] }
 clap_complete = { default-features = false, version = "^4" }
 codama-nodes = { default-features = false, version = "0.13.1" }
+comfy-table = { default-features = false, version = "^8.0.0" }
 darling = { default-features = false, version = "0.24.0" }
 ed25519-dalek = { version = "2.2.0", default-features = false }
 flate2 = { default-features = true, version = "1.1.2" }
@@ -112,6 +113,7 @@ mollusk-svm = { default-features = false, version = "0.15.0" }
 num-derive = { version = "^0.5", default-features = false }
 num-traits = { version = "^0.2", default-features = false }
 object = { default-features = false, version = "^0.40.0" }
+owo-colors = { default-features = false, version = "^4.0" }
 pastey = { default-features = false, version = "^0.2" }
 pinocchio = { default-features = false, version = "^0.11", features = ["cpi"] }
 pinocchio-associated-token-account = { default-features = false, version = "^0.4" }
@@ -123,6 +125,7 @@ prettyplease = { default-features = false, version = "^0.3" }
 proc-macro2 = { default-features = false, version = "^1" }
 proptest = { default-features = false, version = "^1", features = ["std"] }
 quote = { default-features = false, version = "^1" }
+rayon = { default-features = false, version = "^1.10" }
 same-file = { default-features = false, version = "^1" }
 semver = { default-features = false, version = "^1" }
 serde = { default-features = false, version = "^1" }
@@ -140,11 +143,12 @@ solana-sdk-ids = { version = "^3", default-features = false }
 solana-system-interface = { version = "^3", default-features = false }
 syn = { default-features = false, version = "^3", features = ["full"] }
 tempfile = { default-features = false, version = "^3" }
+termimad = { default-features = false, version = "^0.35.1" }
 thiserror = { default-features = false, version = "^2" }
 tokio = { default-features = false, version = "^1" }
 toml = { default-features = false, version = "^1", features = ["parse", "serde"] }
 trybuild = { default-features = false, version = "^1" }
-url = "2.5.4"
+url = { default-features = false, version = "^2.5.4" }
 walkdir = { default-features = false, version = "^2" }
 zeropod = { default-features = false, version = "0.3.5", features = ["solana-address", "solana-program-error"] }
 

--- a/crates/pina_cli/Cargo.toml
+++ b/crates/pina_cli/Cargo.toml
@@ -16,26 +16,26 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-atomic-write-file = { workspace = true }
-base64 = { workspace = true }
-bs58 = { workspace = true }
+atomic-write-file = { workspace = true, default-features = true }
+base64 = { workspace = true, default-features = true }
+bs58 = { workspace = true, default-features = true }
 cargo_metadata = { workspace = true, default-features = true }
 clap = { workspace = true, default-features = true }
 clap_complete = { workspace = true, default-features = true }
 codama-nodes = { workspace = true, default-features = true }
-comfy-table = "8.0.0"
+comfy-table = { workspace = true, default-features = true }
 ed25519-dalek = { workspace = true, default-features = true }
-flate2 = { workspace = true }
+flate2 = { workspace = true, default-features = true }
 fs2 = { workspace = true, default-features = true }
 getrandom = { workspace = true, default-features = true }
 heck = { workspace = true, default-features = true }
 http = { workspace = true, default-features = true }
-owo-colors = "4.0"
+owo-colors = { workspace = true, default-features = true }
 pina_codama_renderer = { workspace = true }
 pina_profile = { workspace = true }
 proc-macro2 = { workspace = true, features = ["span-locations"], default-features = true }
 quote = { workspace = true, default-features = true }
-rayon = "1.10"
+rayon = { workspace = true, default-features = true }
 same-file = { workspace = true, default-features = true }
 semver = { workspace = true, default-features = true }
 serde = { workspace = true, features = ["derive"], default-features = true }
@@ -44,10 +44,10 @@ sha2 = { workspace = true, default-features = true }
 solana-address = { workspace = true, default-features = true }
 syn = { workspace = true, default-features = true, features = ["full", "extra-traits", "visit", "printing"] }
 tempfile = { workspace = true, default-features = true }
-termimad = "0.35.1"
+termimad = { workspace = true, default-features = true }
 thiserror = { workspace = true, default-features = true }
 toml = { workspace = true, default-features = true }
-url = { workspace = true }
+url = { workspace = true, default-features = true }
 walkdir = { workspace = true, default-features = true }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary

Finishes the workspace-level dependency consolidation for `pina_cli`:

- Moves `comfy-table`, `owo-colors`, `rayon`, and `termimad` from direct `pina_cli` dependencies into `[workspace.dependencies]`
- Normalizes the `base64`, `bs58`, and `url` workspace entries to `default-features = false` with caret version requirements
- `pina_cli` now opts into `default-features = true` explicitly per dependency, so resolved features and versions are unchanged

## Notes

- `Cargo.lock` is untouched — resolved versions are identical
- Includes `.changeset/workspace-dependencies.md` (`pina_cli: none`) per the changeset policy (same pattern as the #167 dependency refresh)

## Test plan

- [x] `cargo metadata --no-deps` validates the workspace wiring
- [x] `dprint check` passes on all touched files
- [ ] Full CI suite

Created on behalf of Ifiok Jr. (`@ifiokjr`) by codex (gpt-5.1-codex, high thinking).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized dependency configuration across the workspace.
  * Preserved existing feature behavior while centralizing shared dependency versions.
  * Updated version constraints and feature settings for several command-line application dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->