### PR TITLE
fix(lints): reduce security lint false positives

### DIFF
--- a/.changeset/reduce-security-lint-false-positives.md
+++ b/.changeset/reduce-security-lint-false-positives.md
@@ -1,0 +1,7 @@
+---
+pina: fix
+---
+
+# Reduce false positives in security lints
+
+Make the security lint suite recognize semantically equivalent safe patterns: resolved account-borrow and CPI methods, dominating constant bounds, identifier-based asset arithmetic, immutable token-program aliases, direct token CPI builders, and canonical legacy Token Program exemptions. Opaque wrappers remain conservative, while the expanded UI fixtures document each accepted and rejected pattern.

--- a/lints/deny_account_borrows_across_cpi/src/lib.rs
+++ b/lints/deny_account_borrows_across_cpi/src/lib.rs
@@ -36,25 +36,65 @@ const CPI_METHODS: &[&str] = &[
 	"invoke_signed_with_program",
 ];
 
-fn contains_mutable_borrow(expr: &Expr<'_>) -> bool {
+fn method_def_path(cx: &LateContext<'_>, expr: &Expr<'_>) -> Option<String> {
+	cx.typeck_results()
+		.type_dependent_def_id(expr.hir_id)
+		.map(|def_id| cx.tcx.def_path_str(def_id))
+}
+
+fn is_account_borrow(cx: &LateContext<'_>, expr: &Expr<'_>, method: &str) -> bool {
+	if !BORROW_METHODS.contains(&method) {
+		return false;
+	}
+
+	method_def_path(cx, expr).is_some_and(|path| {
+		let path = path.to_ascii_lowercase();
+		match method {
+			"try_borrow_mut" => path.contains("accountview::try_borrow_mut"),
+			"as_account_mut" => path.contains("asaccount::as_account_mut"),
+			_ => false,
+		}
+	})
+}
+
+fn is_cpi_invocation(cx: &LateContext<'_>, expr: &Expr<'_>, method: &str) -> bool {
+	if !CPI_METHODS.contains(&method) {
+		return false;
+	}
+
+	method_def_path(cx, expr).is_some_and(|path| {
+		let path = path.to_ascii_lowercase();
+		path.starts_with("pina::")
+			|| path.starts_with("pinocchio::")
+			|| path.starts_with("pinocchio_")
+			|| path.split("::").any(|segment| {
+				segment == "cpi"
+					|| segment == "instructions"
+					|| segment.ends_with("instruction")
+					|| segment.starts_with("cpi")
+			})
+	})
+}
+
+fn contains_mutable_borrow(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
 	match &expr.kind {
 		ExprKind::MethodCall(segment, receiver, args, _) => {
-			BORROW_METHODS.contains(&segment.ident.name.as_str())
-				|| contains_mutable_borrow(receiver)
+			is_account_borrow(cx, expr, segment.ident.name.as_str())
+				|| contains_mutable_borrow(cx, receiver)
 				|| args
 					.iter()
-					.any(|argument| contains_mutable_borrow(argument))
+					.any(|argument| contains_mutable_borrow(cx, argument))
 		}
 		ExprKind::Match(scrutinee, ..)
 		| ExprKind::DropTemps(scrutinee)
 		| ExprKind::Use(scrutinee, _)
 		| ExprKind::Type(scrutinee, _)
-		| ExprKind::UnsafeBinderCast(_, scrutinee, _) => contains_mutable_borrow(scrutinee),
+		| ExprKind::UnsafeBinderCast(_, scrutinee, _) => contains_mutable_borrow(cx, scrutinee),
 		ExprKind::Call(callee, args) => {
-			contains_mutable_borrow(callee)
+			contains_mutable_borrow(cx, callee)
 				|| args
 					.iter()
-					.any(|argument| contains_mutable_borrow(argument))
+					.any(|argument| contains_mutable_borrow(cx, argument))
 		}
 		_ => false,
 	}
@@ -88,7 +128,7 @@ impl<'tcx> Analyzer<'_, 'tcx> {
 				rustc_hir::StmtKind::Let(local) => {
 					if let Some(initializer) = local.init {
 						self.visit_expr(initializer, active);
-						if contains_mutable_borrow(initializer)
+						if contains_mutable_borrow(self.cx, initializer)
 							&& let rustc_hir::PatKind::Binding(_, binding, ..) = local.pat.kind
 						{
 							active.insert(binding, initializer.span);
@@ -121,7 +161,7 @@ impl<'tcx> Analyzer<'_, 'tcx> {
 				}
 
 				let method = segment.ident.name.as_str();
-				if CPI_METHODS.contains(&method) && !active.is_empty() {
+				if is_cpi_invocation(self.cx, expr, method) && !active.is_empty() {
 					self.cx.lint(DENY_ACCOUNT_BORROWS_ACROSS_CPI, |diag| {
 						diag.span(expr.span);
 						diag.primary_message(

--- a/lints/deny_account_borrows_across_cpi/ui/account_borrows.rs
+++ b/lints/deny_account_borrows_across_cpi/ui/account_borrows.rs
@@ -1,10 +1,20 @@
+// normalize-stderr-test: "\n$" -> ""
+
 #![allow(dead_code)]
 
-struct Account;
+struct AccountView;
 struct Guard;
 struct Cpi;
+struct Cache;
+struct Scheduler;
 
-impl Account {
+impl AccountView {
+	fn try_borrow_mut(&mut self) -> Result<Guard, ()> {
+		Ok(Guard)
+	}
+}
+
+impl Cache {
 	fn try_borrow_mut(&mut self) -> Result<Guard, ()> {
 		Ok(Guard)
 	}
@@ -16,30 +26,46 @@ impl Cpi {
 	}
 }
 
-fn process(account: &mut Account, cpi: &Cpi) -> Result<(), ()> {
+impl Scheduler {
+	fn invoke(&self) -> Result<(), ()> {
+		Ok(())
+	}
+}
+
+fn process(account: &mut AccountView, cpi: &Cpi) -> Result<(), ()> {
 	let guard = account.try_borrow_mut()?;
 	drop(guard);
 	cpi.invoke()
 }
 
-fn process_borrowed(account: &mut Account, cpi: &Cpi) -> Result<(), ()> {
+fn process_borrowed(account: &mut AccountView, cpi: &Cpi) -> Result<(), ()> {
 	let _guard = account.try_borrow_mut()?;
 	cpi.invoke()
 	//~^ ERROR: CPI invoked while a mutable account-data borrow is still alive
 }
 
-fn process_return_payload(account: &mut Account, cpi: &Cpi) -> Result<(), ()> {
+fn process_return_payload(account: &mut AccountView, cpi: &Cpi) -> Result<(), ()> {
 	let _guard = account.try_borrow_mut()?;
 	return cpi.invoke();
 	//~^ ERROR: CPI invoked while a mutable account-data borrow is still alive
 }
 
-fn process_break_payload(account: &mut Account, cpi: &Cpi) -> Result<(), ()> {
+fn process_break_payload(account: &mut AccountView, cpi: &Cpi) -> Result<(), ()> {
 	let _guard = account.try_borrow_mut()?;
 	loop {
 		break cpi.invoke();
 		//~^ ERROR: CPI invoked while a mutable account-data borrow is still alive
 	}
+}
+
+fn process_unrelated_borrow(cache: &mut Cache, cpi: &Cpi) -> Result<(), ()> {
+	let _guard = cache.try_borrow_mut()?;
+	cpi.invoke()
+}
+
+fn process_unrelated_invoke(account: &mut AccountView, scheduler: &Scheduler) -> Result<(), ()> {
+	let _guard = account.try_borrow_mut()?;
+	scheduler.invoke()
 }
 
 fn main() {}

--- a/lints/deny_account_borrows_across_cpi/ui/account_borrows.stderr
+++ b/lints/deny_account_borrows_across_cpi/ui/account_borrows.stderr
@@ -1,26 +1,26 @@
 error: CPI invoked while a mutable account-data borrow is still alive
-  --> $DIR/account_borrows.rs:27:2
+  --> $DIR/account_borrows.rs:43:2
    |
 LL |     cpi.invoke()
    |     ^^^^^^^^^^^^
    |
-   = help: copy the required values, then call `drop(guard)` or end the borrow's scope before invoking another program
+   = help: copy the req$DIRred values, then call `drop(guard)` or end the borrow's scope before invoking another program
    = note: `#[deny(deny_account_borrows_across_cpi)]` on by default
 
 error: CPI invoked while a mutable account-data borrow is still alive
-  --> $DIR/account_borrows.rs:33:9
+  --> $DIR/account_borrows.rs:49:9
    |
 LL |     return cpi.invoke();
    |            ^^^^^^^^^^^^
    |
-   = help: copy the required values, then call `drop(guard)` or end the borrow's scope before invoking another program
+   = help: copy the req$DIRred values, then call `drop(guard)` or end the borrow's scope before invoking another program
 
 error: CPI invoked while a mutable account-data borrow is still alive
-  --> $DIR/account_borrows.rs:40:9
+  --> $DIR/account_borrows.rs:56:9
    |
 LL |         break cpi.invoke();
    |               ^^^^^^^^^^^^
    |
-   = help: copy the required values, then call `drop(guard)` or end the borrow's scope before invoking another program
+   = help: copy the req$DIRred values, then call `drop(guard)` or end the borrow's scope before invoking another program
 
 error: aborting due to 3 previous errors

--- a/lints/deny_heap_allocations_in_onchain_instruction_handlers/src/lib.rs
+++ b/lints/deny_heap_allocations_in_onchain_instruction_handlers/src/lib.rs
@@ -62,7 +62,7 @@ impl<'tcx> LateLintPass<'tcx> for DenyHeapAllocationsInOnchainInstructionHandler
 			return;
 		}
 
-		let facts = shared::collect_function_facts(body);
+		let facts = shared::collect_function_facts(cx, body);
 		for call in &facts.calls {
 			let matches_heap_pattern = TARGET_METHODS.contains(&call.method.as_str())
 				|| call

--- a/lints/readme.md
+++ b/lints/readme.md
@@ -196,7 +196,7 @@ let amount = {
 transfer.invoke()?;
 ```
 
-An explicit `drop(guard)` or the end of a nested block releases the guard. The analysis follows block scope and explicit drops; borrows hidden inside custom wrapper constructors are outside its current model.
+An explicit `drop(guard)` or the end of a nested block releases the guard. The analysis follows block scope and explicit drops. It resolves method definitions before classifying a borrow or CPI, so an unrelated type that happens to define `try_borrow_mut()` or `invoke()` does not trigger the lint. Account borrows hidden inside custom wrapper constructors and CPIs hidden behind opaque helpers are outside its current model.
 
 ### `require_consistent_token_program`
 
@@ -209,7 +209,7 @@ let mint = mint.as_token_mint_for_program(&program_id)?;
 transfer.invoke_with_program(&program_id)?;
 ```
 
-The lint compares exact identifier paths, including module-qualified constants, so `token::ID` and `token_2022::ID` cannot collapse to the same terminal name. It also rejects reassignment of a program binding between token operations, because the same lexical name would otherwise hide a changed value. Copy and reuse a single immutable, validated address instead of independently deriving, mutating, or hard-coding program IDs.
+The lint compares resolved identifier paths, including module-qualified constants, so `token::ID` and `token_2022::ID` cannot collapse to the same terminal name. Immutable local aliases are traced back to their original identity, allowing clear names for parsing and CPI without reporting a mismatch. It still rejects reassignment of a program binding between token operations, because the same lexical name would otherwise hide a changed value. Copy and reuse a single immutable, validated address instead of independently deriving, mutating, or hard-coding program IDs.
 
 ### `require_explicit_token_2022_extension_policy`
 
@@ -224,6 +224,8 @@ let mint = mint_account
 ```
 
 Extensions can alter transfer, fee, hook, freeze, and authority semantics. Pina therefore requires an allow-list instead of treating the legacy base layout as a complete policy. The analysis pairs a policy with the concrete mint-view binding or with the same direct method chain; a policy asserted on a different mint does not satisfy the rule. Keep each policy adjacent to its mint load so the pairing also remains obvious to reviewers.
+
+An `as_token_mint_for_program(&token::ID)` call with the canonical legacy SPL Token ID is exempt because Token-2022 extensions cannot be present. Dynamic program identities and the explicit Token-2022 loaders still require a policy.
 
 Both policies are inherent, chainable methods on `TokenMintRef` and `TokenAccountRef`; they return the validated view rather than wrapping it in a separate free-function API.
 
@@ -240,11 +242,11 @@ let after = vault.as_token_account_for_program(&program_id)?.amount();
 let received = after.checked_sub(before).ok_or(ProgramError::ArithmeticOverflow)?;
 ```
 
-Token-2022 transfer fees can make `received` differ from the requested amount; Solana's [on-chain Token-2022 guide](https://www.solana-program.com/docs/token-2022/onchain) describes this accounting requirement. The lint pairs each source-visible `Transfer::new` or `TransferChecked::new` constructor with the invocation of that exact builder. It requires the closest destination reads on each side of the transfer to have no intervening CPI, then applies a custody-name heuristic and tracks direct receiver expressions. Opaque builder wrappers are rejected because they prevent exact CPI association. Custody accounts should therefore use explicit names and direct reloads.
+Token-2022 transfer fees can make `received` differ from the requested amount; Solana's [on-chain Token-2022 guide](https://www.solana-program.com/docs/token-2022/onchain) describes this accounting requirement. The lint pairs each source-visible `Transfer::new` or `TransferChecked::new` constructor with the direct invocation of that exact builder. It requires the closest destination reads on each side of the transfer to have no intervening CPI, then applies a custody-name heuristic and tracks direct receiver expressions. A static `invoke()` is exempt only when the resolved constructor belongs to the canonical `pinocchio_token` crate, including Pina's `token` re-export; local look-alikes and Token-2022 builders remain covered. Opaque builder wrappers are not diagnosed because the analysis cannot associate them with a particular invocation; audit such wrappers manually or keep the transfer direct in the instruction handler.
 
 ### `require_checked_asset_arithmetic`
 
-Detects raw `+`, `-`, `*`, and `/`, plus saturating or wrapping arithmetic, when an operand name contains an economic term such as `amount`, `balance`, `lamport`, `price`, `reward`, `stake`, or `supply`.
+Detects raw `+`, `-`, `*`, and `/`, plus saturating or wrapping arithmetic, when an operand has an economic identifier component such as `amount`, `balance`, `lamport`, `price`, `reward`, `stake`, or `supply`.
 
 ```rust
 let next_balance = balance
@@ -252,20 +254,23 @@ let next_balance = balance
 	.ok_or(ProgramError::ArithmeticOverflow)?;
 ```
 
-Saturating arithmetic is rejected because silently clamping economic state can violate conservation just as surely as wrapping. The naming heuristic favors clear domain names and may not recognize opaque abbreviations.
+Saturating arithmetic is rejected because silently clamping economic state can violate conservation just as surely as wrapping. Components are split at Rust identifier separators, so `vault_balance` is covered while an unrelated name such as `rebalance_attempts` is not. The naming heuristic favors clear domain names and may not recognize opaque abbreviations.
 
 ### `require_bounded_remaining_accounts`
 
-Detects loops whose source mentions `remaining` unless the iterator visibly uses `.take(MAX)`.
+Detects loops whose source mentions `remaining` unless the iterator visibly uses `.take(MAX)` or a dominating constant-bound length guard rejects oversized input first.
 
 ```rust
 const MAX_REMAINING_ACCOUNTS: usize = 16;
-for account in remaining.iter().take(MAX_REMAINING_ACCOUNTS) {
+if remaining.len() > MAX_REMAINING_ACCOUNTS {
+	return Err(ProgramError::InvalidArgument);
+}
+for account in remaining {
 	process(account)?;
 }
 ```
 
-Remaining accounts are caller-controlled; an explicit bound keeps worst-case compute auditable. The lint checks source-level loop syntax. A helper iterator with an internal bound should expose the bound at the instruction call site if it is expected to satisfy this rule.
+Remaining accounts are caller-controlled; an explicit bound keeps worst-case compute auditable. Rejecting an oversized list is preferred when every supplied account must be processed, while `.take(MAX)` is suitable only when ignoring surplus accounts is intentional. The guard must compare `remaining.len()` against an integer literal or resolved constant, return early on the oversized path, and dominate the loop. A runtime limit, branch-local check, late check, or opaque helper does not satisfy the rule because it does not establish a source-visible protocol maximum on every path.
 
 ## Performance reference
 

--- a/lints/require_associated_token_address_before_ata_cast/src/lib.rs
+++ b/lints/require_associated_token_address_before_ata_cast/src/lib.rs
@@ -51,7 +51,7 @@ impl<'tcx> LateLintPass<'tcx> for RequireAssociatedTokenAddressBeforeAtaCast {
 			return;
 		}
 
-		let facts = shared::collect_function_facts(body);
+		let facts = shared::collect_function_facts(cx, body);
 		for (index, call) in facts.calls.iter().enumerate() {
 			if !TARGET_METHODS.contains(&call.method.as_str()) {
 				continue;

--- a/lints/require_bounded_remaining_accounts/src/lib.rs
+++ b/lints/require_bounded_remaining_accounts/src/lib.rs
@@ -1,10 +1,18 @@
 #![feature(rustc_private)]
 
+#[path = "../../shared.rs"]
+mod shared;
+
 extern crate rustc_hir;
 extern crate rustc_span;
 
+use std::collections::HashSet;
+
+use rustc_hir::BinOpKind;
 use rustc_hir::Expr;
 use rustc_hir::ExprKind;
+use rustc_hir::def::DefKind;
+use rustc_hir::def::Res;
 use rustc_hir::intravisit::FnKind;
 use rustc_lint::LateContext;
 use rustc_lint::LateLintPass;
@@ -13,8 +21,9 @@ use rustc_lint::LintContext;
 dylint_linting::declare_late_lint! {
 	/// ### What it does
 	///
-	/// Rejects loops over remaining accounts unless the iterator includes an
-	/// explicit `.take(MAX)` bound.
+	/// Rejects loops over remaining accounts unless the iterator has an explicit
+	/// `.take(MAX)` bound or a dominating constant-bound length check rejects
+	/// oversized input first.
 	///
 	/// ### Why is this bad?
 	///
@@ -25,116 +34,210 @@ dylint_linting::declare_late_lint! {
 	"remaining-account loops require an explicit maximum"
 }
 
-fn visit_block(cx: &LateContext<'_>, block: &rustc_hir::Block<'_>) {
-	for statement in block.stmts {
-		match &statement.kind {
-			rustc_hir::StmtKind::Let(local) => {
-				if let Some(initializer) = local.init {
-					visit_expr(cx, initializer);
-				}
-			}
-			rustc_hir::StmtKind::Expr(expr) | rustc_hir::StmtKind::Semi(expr) => {
-				visit_expr(cx, expr);
-			}
-			_ => {}
+fn is_constant_bound(expr: &Expr<'_>) -> bool {
+	match &expr.kind {
+		ExprKind::Lit(_) => true,
+		ExprKind::Path(rustc_hir::QPath::Resolved(_, path)) => {
+			matches!(path.res, Res::Def(DefKind::Const | DefKind::AssocConst, _))
 		}
-	}
-	if let Some(expr) = block.expr {
-		visit_expr(cx, expr);
+		ExprKind::Unary(_, inner)
+		| ExprKind::Cast(inner, _)
+		| ExprKind::DropTemps(inner)
+		| ExprKind::AddrOf(_, _, inner) => is_constant_bound(inner),
+		_ => false,
 	}
 }
 
-fn visit_expr(cx: &LateContext<'_>, expr: &Expr<'_>) {
-	match &expr.kind {
-		ExprKind::Loop(block, ..) => {
-			let snippet = cx
-				.sess()
-				.source_map()
-				.span_to_snippet(expr.span)
-				.unwrap_or_default();
-			let loop_header = snippet
-				.split_once('{')
-				.map_or(snippet.as_str(), |(header, _)| header);
-			if loop_header.to_ascii_lowercase().contains("remaining")
-				&& !loop_header.contains(".take(")
-			{
-				cx.lint(REQUIRE_BOUNDED_REMAINING_ACCOUNTS, |diag| {
-					diag.span(expr.span);
-					diag.primary_message(
-						"remaining accounts are processed without an explicit bound",
-					);
-					diag.help(
-						"define a protocol maximum and iterate with \
-						 `remaining.iter().take(MAX_REMAINING_ACCOUNTS)`",
-					);
-				});
-			}
+fn remaining_len_identity(expr: &Expr<'_>) -> Option<String> {
+	let ExprKind::MethodCall(segment, receiver, arguments, _) = &expr.kind else {
+		return None;
+	};
+	if segment.ident.name.as_str() != "len" || !arguments.is_empty() {
+		return None;
+	}
 
-			visit_block(cx, block);
+	let identity = shared::expression_identity(receiver)?;
+	identity
+		.to_ascii_lowercase()
+		.contains("remaining")
+		.then_some(identity)
+}
+
+fn bounded_identity(condition: &Expr<'_>) -> Option<String> {
+	let ExprKind::Binary(operation, left, right) = &condition.kind else {
+		return None;
+	};
+
+	match operation.node {
+		BinOpKind::Gt | BinOpKind::Ge if is_constant_bound(right) => remaining_len_identity(left),
+		BinOpKind::Lt | BinOpKind::Le if is_constant_bound(left) => remaining_len_identity(right),
+		_ => None,
+	}
+}
+
+fn expression_returns(expr: &Expr<'_>) -> bool {
+	match &expr.kind {
+		ExprKind::Ret(_) => true,
+		ExprKind::Block(block, _) => {
+			block.expr.is_some_and(expression_returns)
+				|| block.stmts.last().is_some_and(|statement| {
+					match &statement.kind {
+						rustc_hir::StmtKind::Expr(expr) | rustc_hir::StmtKind::Semi(expr) => {
+							expression_returns(expr)
+						}
+						_ => false,
+					}
+				})
 		}
-		ExprKind::MethodCall(_, receiver, args, _) => {
-			visit_expr(cx, receiver);
-			for argument in *args {
-				visit_expr(cx, argument);
+		ExprKind::DropTemps(inner) => expression_returns(inner),
+		_ => false,
+	}
+}
+
+fn header_contains_identity(header: &str, identity: &str) -> bool {
+	header.match_indices(identity).any(|(start, matched)| {
+		let before = header[..start].chars().next_back();
+		let after = header[start + matched.len()..].chars().next();
+		let is_boundary = |character: Option<char>| {
+			character.is_none_or(|character| !character.is_ascii_alphanumeric() && character != '_')
+		};
+
+		is_boundary(before) && is_boundary(after)
+	})
+}
+
+struct Analyzer<'cx, 'tcx> {
+	cx: &'cx LateContext<'tcx>,
+}
+
+impl<'tcx> Analyzer<'_, 'tcx> {
+	fn visit_block(&self, block: &'tcx rustc_hir::Block<'tcx>, bounded: &mut HashSet<String>) {
+		for statement in block.stmts {
+			match &statement.kind {
+				rustc_hir::StmtKind::Let(local) => {
+					if let Some(initializer) = local.init {
+						self.visit_expr(initializer, bounded);
+					}
+				}
+				rustc_hir::StmtKind::Expr(expr) | rustc_hir::StmtKind::Semi(expr) => {
+					self.visit_expr(expr, bounded);
+				}
+				_ => {}
 			}
 		}
-		ExprKind::Call(callee, args) => {
-			visit_expr(cx, callee);
-			for argument in *args {
-				visit_expr(cx, argument);
+		if let Some(expr) = block.expr {
+			self.visit_expr(expr, bounded);
+		}
+	}
+
+	fn visit_expr(&self, expr: &'tcx Expr<'tcx>, bounded: &mut HashSet<String>) {
+		match &expr.kind {
+			ExprKind::Loop(block, ..) => {
+				let snippet = self
+					.cx
+					.sess()
+					.source_map()
+					.span_to_snippet(expr.span)
+					.unwrap_or_default();
+				let loop_header = snippet
+					.split_once('{')
+					.map_or(snippet.as_str(), |(header, _)| header);
+				let mentions_remaining = loop_header.to_ascii_lowercase().contains("remaining");
+				let has_validated_bound = bounded
+					.iter()
+					.any(|identity| header_contains_identity(loop_header, identity));
+				if mentions_remaining && !loop_header.contains(".take(") && !has_validated_bound {
+					self.cx.lint(REQUIRE_BOUNDED_REMAINING_ACCOUNTS, |diag| {
+						diag.span(expr.span);
+						diag.primary_message(
+							"remaining accounts are processed without an explicit bound",
+						);
+						diag.help(
+							"reject `remaining.len() > MAX_REMAINING_ACCOUNTS` before the loop, \
+							 or iterate with `remaining.iter().take(MAX_REMAINING_ACCOUNTS)`",
+						);
+					});
+				}
+
+				let mut nested = bounded.clone();
+				self.visit_block(block, &mut nested);
 			}
-		}
-		ExprKind::Block(block, _) => visit_block(cx, block),
-		ExprKind::Match(scrutinee, arms, _) => {
-			visit_expr(cx, scrutinee);
-			for arm in *arms {
-				visit_expr(cx, arm.body);
+			ExprKind::If(condition, then, otherwise) => {
+				self.visit_expr(condition, bounded);
+				let mut branch = bounded.clone();
+				self.visit_expr(then, &mut branch);
+				if let Some(otherwise) = otherwise {
+					let mut branch = bounded.clone();
+					self.visit_expr(otherwise, &mut branch);
+				} else if expression_returns(then)
+					&& let Some(identity) = bounded_identity(condition)
+				{
+					bounded.insert(identity);
+				}
 			}
-		}
-		ExprKind::If(condition, then, otherwise) => {
-			visit_expr(cx, condition);
-			visit_expr(cx, then);
-			if let Some(otherwise) = otherwise {
-				visit_expr(cx, otherwise);
+			ExprKind::MethodCall(_, receiver, arguments, _) => {
+				self.visit_expr(receiver, bounded);
+				for argument in *arguments {
+					self.visit_expr(argument, bounded);
+				}
 			}
-		}
-		ExprKind::Unary(_, inner)
-		| ExprKind::Use(inner, _)
-		| ExprKind::Cast(inner, _)
-		| ExprKind::Type(inner, _)
-		| ExprKind::DropTemps(inner)
-		| ExprKind::AddrOf(_, _, inner)
-		| ExprKind::Field(inner, _)
-		| ExprKind::Repeat(inner, _)
-		| ExprKind::Yield(inner, _)
-		| ExprKind::Become(inner)
-		| ExprKind::UnsafeBinderCast(_, inner, _) => visit_expr(cx, inner),
-		ExprKind::Binary(_, left, right)
-		| ExprKind::Assign(left, right, _)
-		| ExprKind::AssignOp(_, left, right) => {
-			visit_expr(cx, left);
-			visit_expr(cx, right);
-		}
-		ExprKind::Index(base, index, _) => {
-			visit_expr(cx, base);
-			visit_expr(cx, index);
-		}
-		ExprKind::Let(let_expr) => visit_expr(cx, let_expr.init),
-		ExprKind::Tup(expressions) | ExprKind::Array(expressions) => {
-			for expression in *expressions {
-				visit_expr(cx, expression);
+			ExprKind::Call(callee, arguments) => {
+				self.visit_expr(callee, bounded);
+				for argument in *arguments {
+					self.visit_expr(argument, bounded);
+				}
 			}
-		}
-		ExprKind::Struct(_, fields, tail) => {
-			for field in *fields {
-				visit_expr(cx, field.expr);
+			ExprKind::Block(block, _) => {
+				let mut nested = bounded.clone();
+				self.visit_block(block, &mut nested);
 			}
-			if let rustc_hir::StructTailExpr::Base(base) = tail {
-				visit_expr(cx, base);
+			ExprKind::Match(scrutinee, arms, _) => {
+				self.visit_expr(scrutinee, bounded);
+				for arm in *arms {
+					let mut branch = bounded.clone();
+					self.visit_expr(arm.body, &mut branch);
+				}
 			}
+			ExprKind::Unary(_, inner)
+			| ExprKind::Use(inner, _)
+			| ExprKind::Cast(inner, _)
+			| ExprKind::Type(inner, _)
+			| ExprKind::DropTemps(inner)
+			| ExprKind::AddrOf(_, _, inner)
+			| ExprKind::Field(inner, _)
+			| ExprKind::Repeat(inner, _)
+			| ExprKind::Yield(inner, _)
+			| ExprKind::Become(inner)
+			| ExprKind::UnsafeBinderCast(_, inner, _) => self.visit_expr(inner, bounded),
+			ExprKind::Binary(_, left, right)
+			| ExprKind::Assign(left, right, _)
+			| ExprKind::AssignOp(_, left, right) => {
+				self.visit_expr(left, bounded);
+				self.visit_expr(right, bounded);
+			}
+			ExprKind::Index(base, index, _) => {
+				self.visit_expr(base, bounded);
+				self.visit_expr(index, bounded);
+			}
+			ExprKind::Let(let_expr) => self.visit_expr(let_expr.init, bounded),
+			ExprKind::Tup(expressions) | ExprKind::Array(expressions) => {
+				for expression in *expressions {
+					self.visit_expr(expression, bounded);
+				}
+			}
+			ExprKind::Struct(_, fields, tail) => {
+				for field in *fields {
+					self.visit_expr(field.expr, bounded);
+				}
+				if let rustc_hir::StructTailExpr::Base(base) = tail {
+					self.visit_expr(base, bounded);
+				}
+			}
+			ExprKind::Ret(Some(inner)) | ExprKind::Break(_, Some(inner)) => {
+				self.visit_expr(inner, bounded);
+			}
+			_ => {}
 		}
-		ExprKind::Ret(Some(inner)) | ExprKind::Break(_, Some(inner)) => visit_expr(cx, inner),
-		_ => {}
 	}
 }
 
@@ -148,7 +251,7 @@ impl<'tcx> LateLintPass<'tcx> for RequireBoundedRemainingAccounts {
 		_: rustc_span::Span,
 		_: rustc_hir::def_id::LocalDefId,
 	) {
-		visit_expr(cx, body.value);
+		Analyzer { cx }.visit_expr(body.value, &mut HashSet::new());
 	}
 }
 

--- a/lints/require_bounded_remaining_accounts/ui/remaining_accounts.rs
+++ b/lints/require_bounded_remaining_accounts/ui/remaining_accounts.rs
@@ -1,9 +1,37 @@
+// normalize-stderr-test: "\n$" -> ""
+
 #![allow(dead_code)]
 
 fn process(remaining: &[u8]) {
 	for account in remaining.iter().take(8) {
 		let _ = account;
 	}
+}
+
+const MAX_REMAINING_ACCOUNTS: usize = 8;
+
+fn process_rejects_oversized(remaining: &[u8]) -> Result<(), ()> {
+	if remaining.len() > MAX_REMAINING_ACCOUNTS {
+		return Err(());
+	}
+
+	for account in remaining {
+		let _ = account;
+	}
+
+	Ok(())
+}
+
+fn process_reversed_guard(remaining: &[u8]) -> Result<(), ()> {
+	if MAX_REMAINING_ACCOUNTS < remaining.len() {
+		return Err(());
+	}
+
+	for account in remaining {
+		let _ = account;
+	}
+
+	Ok(())
 }
 
 fn process_unbounded(remaining: &[u8]) {
@@ -23,6 +51,32 @@ fn process_loop_initializer(remaining: &[u8]) {
 		};
 		break;
 	}
+}
+
+fn process_non_dominating_guard(remaining: &[u8], check_limit: bool) -> Result<(), ()> {
+	if check_limit && remaining.len() > MAX_REMAINING_ACCOUNTS {
+		return Err(());
+	}
+
+	for account in remaining {
+		//~^ ERROR: remaining accounts are processed without an explicit bound
+		let _ = account;
+	}
+
+	Ok(())
+}
+
+fn process_runtime_limit(remaining: &[u8], limit: usize) -> Result<(), ()> {
+	if remaining.len() > limit {
+		return Err(());
+	}
+
+	for account in remaining {
+		//~^ ERROR: remaining accounts are processed without an explicit bound
+		let _ = account;
+	}
+
+	Ok(())
 }
 
 fn process_return_payload(remaining: &[u8]) {

--- a/lints/require_bounded_remaining_accounts/ui/remaining_accounts.stderr
+++ b/lints/require_bounded_remaining_accounts/ui/remaining_accounts.stderr
@@ -1,5 +1,5 @@
 error: remaining accounts are processed without an explicit bound
-  --> $DIR/remaining_accounts.rs:10:2
+  --> $DIR/remaining_accounts.rs:38:2
    |
 LL | /     for account in remaining {
 LL | |         //~^ ERROR: remaining accounts are processed without an explicit bound
@@ -7,11 +7,11 @@ LL | |         let _ = account;
 LL | |     }
    | |_____^
    |
-   = help: define a protocol maximum and iterate with `remaining.iter().take(MAX_REMAINING_ACCOUNTS)`
+   = help: reject `remaining.len() > MAX_REMAINING_ACCOUNTS` before the loop, or iterate with `remaining.iter().take(MAX_REMAINING_ACCOUNTS)`
    = note: `#[deny(req$DIRre_bounded_remaining_accounts)]` on by default
 
 error: remaining accounts are processed without an explicit bound
-  --> $DIR/remaining_accounts.rs:19:4
+  --> $DIR/remaining_accounts.rs:47:4
    |
 LL | /             for account in remaining {
 LL | |                 //~^ ERROR: remaining accounts are processed without an explicit bound
@@ -19,10 +19,32 @@ LL | |                 let _ = account;
 LL | |             }
    | |_____________^
    |
-   = help: define a protocol maximum and iterate with `remaining.iter().take(MAX_REMAINING_ACCOUNTS)`
+   = help: reject `remaining.len() > MAX_REMAINING_ACCOUNTS` before the loop, or iterate with `remaining.iter().take(MAX_REMAINING_ACCOUNTS)`
 
 error: remaining accounts are processed without an explicit bound
-  --> $DIR/remaining_accounts.rs:29:9
+  --> $DIR/remaining_accounts.rs:61:2
+   |
+LL | /     for account in remaining {
+LL | |         //~^ ERROR: remaining accounts are processed without an explicit bound
+LL | |         let _ = account;
+LL | |     }
+   | |_____^
+   |
+   = help: reject `remaining.len() > MAX_REMAINING_ACCOUNTS` before the loop, or iterate with `remaining.iter().take(MAX_REMAINING_ACCOUNTS)`
+
+error: remaining accounts are processed without an explicit bound
+  --> $DIR/remaining_accounts.rs:74:2
+   |
+LL | /     for account in remaining {
+LL | |         //~^ ERROR: remaining accounts are processed without an explicit bound
+LL | |         let _ = account;
+LL | |     }
+   | |_____^
+   |
+   = help: reject `remaining.len() > MAX_REMAINING_ACCOUNTS` before the loop, or iterate with `remaining.iter().take(MAX_REMAINING_ACCOUNTS)`
+
+error: remaining accounts are processed without an explicit bound
+  --> $DIR/remaining_accounts.rs:83:9
    |
 LL |       return for account in remaining {
    |  ____________^
@@ -31,10 +53,10 @@ LL | |         let _ = account;
 LL | |     };
    | |_____^
    |
-   = help: define a protocol maximum and iterate with `remaining.iter().take(MAX_REMAINING_ACCOUNTS)`
+   = help: reject `remaining.len() > MAX_REMAINING_ACCOUNTS` before the loop, or iterate with `remaining.iter().take(MAX_REMAINING_ACCOUNTS)`
 
 error: remaining accounts are processed without an explicit bound
-  --> $DIR/remaining_accounts.rs:37:9
+  --> $DIR/remaining_accounts.rs:91:9
    |
 LL |           break for account in remaining {
    |  _______________^
@@ -43,6 +65,6 @@ LL | |             let _ = account;
 LL | |         };
    | |_________^
    |
-   = help: define a protocol maximum and iterate with `remaining.iter().take(MAX_REMAINING_ACCOUNTS)`
+   = help: reject `remaining.len() > MAX_REMAINING_ACCOUNTS` before the loop, or iterate with `remaining.iter().take(MAX_REMAINING_ACCOUNTS)`
 
-error: aborting due to 4 previous errors
+error: aborting due to 6 previous errors

--- a/lints/require_canonical_bump_before_pda_write/src/lib.rs
+++ b/lints/require_canonical_bump_before_pda_write/src/lib.rs
@@ -43,7 +43,7 @@ impl<'tcx> LateLintPass<'tcx> for RequireCanonicalBumpBeforePdaWrite {
 			return;
 		}
 
-		let facts = shared::collect_function_facts(body);
+		let facts = shared::collect_function_facts(cx, body);
 		for (index, call) in facts.calls.iter().enumerate() {
 			if call.method != "assert_seeds_with_bump" {
 				continue;

--- a/lints/require_canonical_instruction_dispatch_for_idl/src/lib.rs
+++ b/lints/require_canonical_instruction_dispatch_for_idl/src/lib.rs
@@ -58,7 +58,7 @@ impl<'tcx> LateLintPass<'tcx> for RequireCanonicalInstructionDispatchForIdl {
 			return;
 		}
 
-		let facts = shared::collect_function_facts(body);
+		let facts = shared::collect_function_facts(cx, body);
 		if !facts.has_match {
 			cx.lint(REQUIRE_CANONICAL_INSTRUCTION_DISPATCH_FOR_IDL, |diag| {
 				diag.primary_message(

--- a/lints/require_checked_asset_arithmetic/src/lib.rs
+++ b/lints/require_checked_asset_arithmetic/src/lib.rs
@@ -29,7 +29,8 @@ dylint_linting::declare_late_lint! {
 }
 
 const ASSET_TERMS: &[&str] = &[
-	"amount", "balance", "lamport", "price", "reward", "stake", "supply",
+	"amount", "amounts", "balance", "balances", "lamport", "lamports", "price", "prices", "reward",
+	"rewards", "stake", "staked", "supply",
 ];
 const UNCHECKED_METHODS: &[&str] = &[
 	"saturating_add",
@@ -44,8 +45,10 @@ const UNCHECKED_METHODS: &[&str] = &[
 
 fn looks_like_asset(expr: &Expr<'_>) -> bool {
 	shared::expression_identity(expr).is_some_and(|identity| {
-		let identity = identity.to_ascii_lowercase();
-		ASSET_TERMS.iter().any(|term| identity.contains(term))
+		identity
+			.to_ascii_lowercase()
+			.split(|character: char| !character.is_ascii_alphanumeric())
+			.any(|component| ASSET_TERMS.contains(&component))
 	})
 }
 

--- a/lints/require_checked_asset_arithmetic/ui/asset_arithmetic.rs
+++ b/lints/require_checked_asset_arithmetic/ui/asset_arithmetic.rs
@@ -1,3 +1,5 @@
+// normalize-stderr-test: "\n$" -> ""
+
 #![allow(dead_code)]
 
 fn process(balance: u64, amount: u64) -> Result<u64, ()> {
@@ -6,6 +8,10 @@ fn process(balance: u64, amount: u64) -> Result<u64, ()> {
 
 fn process_non_asset(raw_value: u64) -> u64 {
 	raw_value + 1
+}
+
+fn process_name_contains_asset_fragment(rebalance_attempts: u64, unstaked_epochs: u64) -> u64 {
+	rebalance_attempts + unstaked_epochs
 }
 
 fn process_unchecked(balance: u64, amount: u64) -> u64 {

--- a/lints/require_checked_asset_arithmetic/ui/asset_arithmetic.stderr
+++ b/lints/require_checked_asset_arithmetic/ui/asset_arithmetic.stderr
@@ -1,14 +1,14 @@
 error: asset arithmetic can overflow, underflow, or silently saturate
- --> $DIR/asset_arithmetic.rs:12:2
-  |
+  --> $DIR/asset_arithmetic.rs:18:2
+   |
 LL |     balance - amount
-  |     ^^^^^^^^^^^^^^^^
-  |
-  = help: use `checked_add`, `checked_sub`, `checked_mul`, or `checked_div` and return an explicit program error on failure
-  = note: `#[deny(req$DIRre_checked_asset_arithmetic)]` on by default
+   |     ^^^^^^^^^^^^^^^^
+   |
+   = help: use `checked_add`, `checked_sub`, `checked_mul`, or `checked_div` and return an explicit program error on failure
+   = note: `#[deny(req$DIRre_checked_asset_arithmetic)]` on by default
 
 error: asset arithmetic can overflow, underflow, or silently saturate
-  --> $DIR/asset_arithmetic.rs:17:2
+  --> $DIR/asset_arithmetic.rs:23:2
    |
 LL |     balance.saturating_sub(amount)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ LL |     balance.saturating_sub(amount)
    = help: use `checked_add`, `checked_sub`, `checked_mul`, or `checked_div` and return an explicit program error on failure
 
 error: asset arithmetic can overflow, underflow, or silently saturate
-  --> $DIR/asset_arithmetic.rs:22:9
+  --> $DIR/asset_arithmetic.rs:28:9
    |
 LL |     return balance - amount;
    |            ^^^^^^^^^^^^^^^^
@@ -24,7 +24,7 @@ LL |     return balance - amount;
    = help: use `checked_add`, `checked_sub`, `checked_mul`, or `checked_div` and return an explicit program error on failure
 
 error: asset arithmetic can overflow, underflow, or silently saturate
-  --> $DIR/asset_arithmetic.rs:28:23
+  --> $DIR/asset_arithmetic.rs:34:23
    |
 LL |         let _next_balance = balance - amount;
    |                             ^^^^^^^^^^^^^^^^
@@ -32,7 +32,7 @@ LL |         let _next_balance = balance - amount;
    = help: use `checked_add`, `checked_sub`, `checked_mul`, or `checked_div` and return an explicit program error on failure
 
 error: asset arithmetic can overflow, underflow, or silently saturate
-  --> $DIR/asset_arithmetic.rs:36:9
+  --> $DIR/asset_arithmetic.rs:42:9
    |
 LL |         break balance - amount;
    |               ^^^^^^^^^^^^^^^^

--- a/lints/require_consistent_token_program/src/lib.rs
+++ b/lints/require_consistent_token_program/src/lib.rs
@@ -28,7 +28,7 @@ dylint_linting::declare_late_lint! {
 	"token operations in one instruction must share one program identity"
 }
 
-fn program_argument(call: &shared::CallInfo) -> Option<&str> {
+fn program_argument(call: &shared::CallInfo) -> Option<(usize, &str)> {
 	let index = match call.method.as_str() {
 		"as_token_mint_for_program" | "as_token_account_for_program" => 0,
 		"as_associated_token_account"
@@ -39,7 +39,38 @@ fn program_argument(call: &shared::CallInfo) -> Option<&str> {
 		_ => return None,
 	};
 
-	call.args.get(index).and_then(Option::as_deref)
+	call.args
+		.get(index)
+		.and_then(Option::as_deref)
+		.map(|argument| (index, argument))
+}
+
+fn canonical_identity<'a>(
+	call: &'a shared::CallInfo,
+	argument_index: usize,
+	mut identity: &'a str,
+	facts: &'a shared::FunctionFacts,
+) -> &'a str {
+	let mut visited = HashSet::new();
+	let mut binding = call.arg_bindings.get(argument_index).copied().flatten();
+	while let Some(current) = binding
+		&& visited.insert(current)
+	{
+		if facts
+			.assignments
+			.iter()
+			.any(|assignment| assignment.identity == identity)
+		{
+			break;
+		}
+		let Some(alias) = facts.aliases.get(&current) else {
+			break;
+		};
+		identity = &alias.identity;
+		binding = alias.binding;
+	}
+
+	identity
 }
 
 impl<'tcx> LateLintPass<'tcx> for RequireConsistentTokenProgram {
@@ -59,15 +90,15 @@ impl<'tcx> LateLintPass<'tcx> for RequireConsistentTokenProgram {
 			return;
 		}
 
-		let facts = shared::collect_function_facts(body);
+		let facts = shared::collect_function_facts(cx, body);
 		let mut expected = None;
 		let mut previous_usage = None;
 		let mut reported_reassignments = HashSet::new();
 		for call in &facts.calls {
-			let Some(argument) = program_argument(call) else {
+			let Some((argument_index, argument)) = program_argument(call) else {
 				continue;
 			};
-			let identity = argument;
+			let identity = canonical_identity(call, argument_index, argument, &facts);
 			let Some(first) = expected else {
 				expected = Some(identity);
 				previous_usage = Some(call);

--- a/lints/require_consistent_token_program/ui/token_program.rs
+++ b/lints/require_consistent_token_program/ui/token_program.rs
@@ -1,3 +1,5 @@
+// normalize-stderr-test: "\n$" -> ""
+
 #![allow(dead_code)]
 
 struct Account;
@@ -41,6 +43,30 @@ fn process_mixed_constants(mint: &Account, vault: &Account, owner: &[u8]) -> Res
 	mint.as_token_mint_for_program(&token::ID)?;
 	vault.assert_associated_token_address(owner, owner, &token_2022::ID)
 	//~^ ERROR: token operation uses `token_2022::ID` after the instruction established `token::ID`
+}
+
+fn process_equivalent_aliases(
+	mint: &Account,
+	vault: &Account,
+	owner: &[u8],
+	program: &[u8],
+) -> Result<(), ()> {
+	let parsing_program = program;
+	let cpi_program = parsing_program;
+	mint.as_token_mint_for_program(parsing_program)?;
+	vault.assert_associated_token_address(owner, owner, cpi_program)
+}
+
+fn process_shadowed_program(
+	mint: &Account,
+	vault: &Account,
+	owner: &[u8],
+	program: &[u8],
+) -> Result<(), ()> {
+	mint.as_token_mint_for_program(program)?;
+	let program = &token_2022::ID;
+	vault.assert_associated_token_address(owner, owner, program)
+	//~^ ERROR: token operation uses `token_2022::ID` after the instruction established `program`
 }
 
 fn process_reassigned(

--- a/lints/require_consistent_token_program/ui/token_program.stderr
+++ b/lints/require_consistent_token_program/ui/token_program.stderr
@@ -1,5 +1,5 @@
 error: token operation uses `other_program` after the instruction established `program`
-  --> $DIR/token_program.rs:36:2
+  --> $DIR/token_program.rs:38:2
    |
 LL |     vault.assert_associated_token_address(owner, owner, other_program)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,19 +8,27 @@ LL |     vault.assert_associated_token_address(owner, owner, other_program)
    = note: `#[deny(req$DIRre_consistent_token_program)]` on by default
 
 error: token operation uses `token_2022::ID` after the instruction established `token::ID`
-  --> $DIR/token_program.rs:42:2
+  --> $DIR/token_program.rs:44:2
    |
 LL |     vault.assert_associated_token_address(owner, owner, &token_2022::ID)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: validate the token-program account once, copy its address, and pass that same value to token parsing, ATA checks, and CPI
 
+error: token operation uses `token_2022::ID` after the instruction established `program`
+  --> $DIR/token_program.rs:68:2
+   |
+LL |     vault.assert_associated_token_address(owner, owner, program)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: validate the token-program account once, copy its address, and pass that same value to token parsing, ATA checks, and CPI
+
 error: token-program value `program` was reassigned between token operations
-  --> $DIR/token_program.rs:54:2
+  --> $DIR/token_program.rs:80:2
    |
 LL |     vault.assert_associated_token_address(owner, owner, program)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: validate the token-program account once, copy its address into an immutable binding, and reuse that binding for every token operation
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors

--- a/lints/require_explicit_discriminators_and_seed_namespaces/src/lib.rs
+++ b/lints/require_explicit_discriminators_and_seed_namespaces/src/lib.rs
@@ -56,7 +56,7 @@ impl<'tcx> LateLintPass<'tcx> for RequireExplicitDiscriminatorsAndSeedNamespaces
 			return;
 		}
 
-		let facts = shared::collect_function_facts(body);
+		let facts = shared::collect_function_facts(cx, body);
 		let has_named_seed_constant = facts.paths.iter().any(|path| {
 			path.rsplit("::")
 				.next()

--- a/lints/require_explicit_token_2022_extension_policy/src/lib.rs
+++ b/lints/require_explicit_token_2022_extension_policy/src/lib.rs
@@ -33,6 +33,22 @@ const TARGET_METHODS: &[&str] = &[
 ];
 const POLICY_METHODS: &[&str] = &["assert_extensions_allowed", "assert_no_extensions"];
 
+fn is_explicit_legacy_load(call: &shared::CallInfo) -> bool {
+	if call.method != "as_token_mint_for_program" {
+		return false;
+	}
+
+	call.arg_def_crates
+		.first()
+		.and_then(Option::as_deref)
+		.is_some_and(|crate_name| crate_name == "pinocchio_token")
+		&& call
+			.arg_def_paths
+			.first()
+			.and_then(Option::as_deref)
+			.is_some_and(|path| path.ends_with("::ID"))
+}
+
 fn policy_matches(load: &shared::CallInfo, policy: &shared::CallInfo) -> bool {
 	if !POLICY_METHODS.contains(&policy.method.as_str()) {
 		return false;
@@ -67,9 +83,9 @@ impl<'tcx> LateLintPass<'tcx> for RequireExplicitToken2022ExtensionPolicy {
 			return;
 		}
 
-		let facts = shared::collect_function_facts(body);
+		let facts = shared::collect_function_facts(cx, body);
 		for (index, call) in facts.calls.iter().enumerate() {
-			if !TARGET_METHODS.contains(&call.method.as_str()) {
+			if !TARGET_METHODS.contains(&call.method.as_str()) || is_explicit_legacy_load(call) {
 				continue;
 			}
 			let next_load = facts.calls[index + 1..]

--- a/lints/require_explicit_token_2022_extension_policy/ui/auxiliary/pinocchio_token.rs
+++ b/lints/require_explicit_token_2022_extension_policy/ui/auxiliary/pinocchio_token.rs
@@ -1,0 +1,1 @@
+pub static ID: [u8; 1] = [1];

--- a/lints/require_explicit_token_2022_extension_policy/ui/extension_policy.rs
+++ b/lints/require_explicit_token_2022_extension_policy/ui/extension_policy.rs
@@ -1,4 +1,9 @@
+// aux-build: pinocchio_token.rs
+// normalize-stderr-test: "\n$" -> ""
+
 #![allow(dead_code)]
+
+extern crate pinocchio_token;
 
 struct Account;
 struct Mint;
@@ -22,6 +27,12 @@ impl Mint {
 fn process(account: &Account, program: &[u8]) -> Result<(), ()> {
 	let mint = account.as_token_mint_for_program(program)?;
 	mint.assert_no_extensions()
+}
+
+fn process_explicit_legacy(account: &Account) -> Result<(), ()> {
+	account
+		.as_token_mint_for_program(&pinocchio_token::ID)
+		.map(|_| ())
 }
 
 fn process_without_policy(account: &Account, program: &[u8]) -> Result<(), ()> {

--- a/lints/require_explicit_token_2022_extension_policy/ui/extension_policy.stderr
+++ b/lints/require_explicit_token_2022_extension_policy/ui/extension_policy.stderr
@@ -1,5 +1,5 @@
 error: Token-2022-capable mint loaded without an explicit extension policy
-  --> $DIR/extension_policy.rs:28:2
+  --> $DIR/extension_policy.rs:39:2
    |
 LL |     account.as_token_mint_for_program(program).map(|_| ())
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |     account.as_token_mint_for_program(program).map(|_| ())
    = note: `#[deny(req$DIRre_explicit_token_2022_extension_policy)]` on by default
 
 error: Token-2022-capable mint loaded without an explicit extension policy
-  --> $DIR/extension_policy.rs:39:2
+  --> $DIR/extension_policy.rs:50:2
    |
 LL |     second.as_token_mint_for_program(program).map(|_| ())
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ LL |     second.as_token_mint_for_program(program).map(|_| ())
    = help: bind the mint view and call `assert_no_extensions()` or `assert_extensions_allowed(&[...])` before using its base fields
 
 error: Token-2022-capable mint loaded without an explicit extension policy
-  --> $DIR/extension_policy.rs:49:2
+  --> $DIR/extension_policy.rs:60:2
    |
 LL |     account.as_token_mint_for_program(program).map(|_| ())
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -24,7 +24,7 @@ LL |     account.as_token_mint_for_program(program).map(|_| ())
    = help: bind the mint view and call `assert_no_extensions()` or `assert_extensions_allowed(&[...])` before using its base fields
 
 error: Token-2022-capable mint loaded without an explicit extension policy
-  --> $DIR/extension_policy.rs:54:29
+  --> $DIR/extension_policy.rs:65:29
    |
 LL |     let selected = choose_mint(account.as_token_mint_for_program(program)?);
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/lints/require_post_cpi_balance_reload/src/lib.rs
+++ b/lints/require_post_cpi_balance_reload/src/lib.rs
@@ -49,10 +49,25 @@ fn is_transfer_constructor(cx: &LateContext<'_>, call: &shared::CallInfo) -> boo
 	snippet.contains("Transfer::new(") || snippet.contains("TransferChecked::new(")
 }
 
+fn is_explicit_legacy_constructor(call: &shared::CallInfo) -> bool {
+	call.def_crate.as_deref() == Some("pinocchio_token")
+		&& call.def_path.as_deref().is_some_and(|path| {
+			path.contains("instructions::Transfer::new")
+				|| path.contains("instructions::TransferChecked::new")
+		})
+}
+
 fn is_cpi_invocation(call: &shared::CallInfo) -> bool {
 	matches!(
 		call.method.as_str(),
 		"invoke" | "invoke_signed" | "invoke_with_program" | "invoke_signed_with_program"
+	)
+}
+
+fn is_dynamic_token_invocation(call: &shared::CallInfo) -> bool {
+	matches!(
+		call.method.as_str(),
+		"invoke_with_program" | "invoke_signed_with_program"
 	)
 }
 
@@ -102,7 +117,7 @@ impl<'tcx> LateLintPass<'tcx> for RequirePostCpiBalanceReload {
 			return;
 		}
 
-		let facts = shared::collect_function_facts(body);
+		let facts = shared::collect_function_facts(cx, body);
 		for (index, call) in facts.calls.iter().enumerate() {
 			if !is_transfer_constructor(cx, call) {
 				continue;
@@ -118,9 +133,15 @@ impl<'tcx> LateLintPass<'tcx> for RequirePostCpiBalanceReload {
 				.iter()
 				.position(|next| invocation_matches(call, next));
 			let Some(invocation) = invocation.map(|offset| index + 1 + offset) else {
-				lint_balance_reload(cx, call.span, destination);
+				// The transfer builder was passed through an opaque wrapper. Avoid a
+				// deny-level guess when the actual invocation cannot be associated.
 				continue;
 			};
+			if !is_dynamic_token_invocation(&facts.calls[invocation])
+				&& is_explicit_legacy_constructor(call)
+			{
+				continue;
+			}
 
 			let reads_amount = |candidate: &shared::CallInfo| {
 				candidate.method == "amount" && candidate.receiver.as_deref() == Some(destination)

--- a/lints/require_post_cpi_balance_reload/ui/auxiliary/pinocchio_token.rs
+++ b/lints/require_post_cpi_balance_reload/ui/auxiliary/pinocchio_token.rs
@@ -1,0 +1,15 @@
+#![allow(dead_code)]
+
+pub mod instructions {
+	pub struct TransferChecked;
+
+	impl TransferChecked {
+		pub fn new<T>(_: &T, _: &T, _: &T, _: &T, _: u64, _: u8) -> Self {
+			Self
+		}
+
+		pub fn invoke(&self) -> Result<(), ()> {
+			Ok(())
+		}
+	}
+}

--- a/lints/require_post_cpi_balance_reload/ui/balance_reload.rs
+++ b/lints/require_post_cpi_balance_reload/ui/balance_reload.rs
@@ -1,8 +1,19 @@
+// aux-build: pinocchio_token.rs
+// normalize-stderr-test: "\n$" -> ""
+
 #![allow(dead_code)]
+
+extern crate pinocchio_token;
 
 struct Account;
 struct CreateAccount;
 struct TransferChecked;
+
+mod token_2022 {
+	pub(crate) mod instructions {
+		pub(crate) use crate::TransferChecked;
+	}
+}
 
 impl Account {
 	fn amount(&self) -> u64 {
@@ -16,6 +27,10 @@ impl TransferChecked {
 	}
 
 	fn invoke(&self) -> Result<(), ()> {
+		Ok(())
+	}
+
+	fn invoke_with_program(&self, _program: &Account) -> Result<(), ()> {
 		Ok(())
 	}
 }
@@ -45,9 +60,28 @@ fn process_non_transfer_constructor(
 
 fn process(source: &Account, mint: &Account, vault: &Account, owner: &Account) -> Result<(), ()> {
 	let _before = vault.amount();
-	TransferChecked::new(source, mint, vault, owner, 10, 0).invoke()?;
+	TransferChecked::new(source, mint, vault, owner, 10, 0).invoke_with_program(owner)?;
 	let _after = vault.amount();
 	Ok(())
+}
+
+fn process_legacy_without_reload(
+	source: &Account,
+	mint: &Account,
+	vault: &Account,
+	owner: &Account,
+) -> Result<(), ()> {
+	pinocchio_token::instructions::TransferChecked::new(source, mint, vault, owner, 10, 0).invoke()
+}
+
+fn process_static_token_2022_without_reload(
+	source: &Account,
+	mint: &Account,
+	vault: &Account,
+	owner: &Account,
+) -> Result<(), ()> {
+	token_2022::instructions::TransferChecked::new(source, mint, vault, owner, 10, 0).invoke()
+	//~^ ERROR: transfer into `vault` is not accounted from its observed balance delta
 }
 
 fn process_without_reload(
@@ -56,7 +90,7 @@ fn process_without_reload(
 	vault: &Account,
 	owner: &Account,
 ) -> Result<(), ()> {
-	TransferChecked::new(source, mint, vault, owner, 10, 0).invoke()
+	TransferChecked::new(source, mint, vault, owner, 10, 0).invoke_with_program(owner)
 	//~^ ERROR: transfer into `vault` is not accounted from its observed balance delta
 }
 
@@ -69,7 +103,7 @@ fn process_unrelated_cpi_before_transfer(
 	let transfer = TransferChecked::new(source, mint, vault, owner, 10, 0);
 	let _before = vault.amount();
 	CreateAccount::new(source, mint, vault, owner, 10).invoke()?;
-	transfer.invoke()
+	transfer.invoke_with_program(owner)
 	//~^ ERROR: transfer into `vault` is not accounted from its observed balance delta
 }
 
@@ -81,7 +115,7 @@ fn process_unrelated_cpi_before_reload(
 ) -> Result<(), ()> {
 	let transfer = TransferChecked::new(source, mint, vault, owner, 10, 0);
 	let _before = vault.amount();
-	transfer.invoke()?;
+	transfer.invoke_with_program(owner)?;
 	//~^ ERROR: transfer into `vault` is not accounted from its observed balance delta
 	CreateAccount::new(source, mint, vault, owner, 10).invoke()?;
 	let _after = vault.amount();
@@ -96,7 +130,6 @@ fn process_wrapped_transfer(
 ) -> Result<(), ()> {
 	let _before = vault.amount();
 	let selected = choose_transfer(TransferChecked::new(source, mint, vault, owner, 10, 0));
-	//~^ ERROR: transfer into `vault` is not accounted from its observed balance delta
 	selected.invoke()?;
 	let _after = vault.amount();
 	Ok(())

--- a/lints/require_post_cpi_balance_reload/ui/balance_reload.stderr
+++ b/lints/require_post_cpi_balance_reload/ui/balance_reload.stderr
@@ -1,33 +1,33 @@
 error: transfer into `vault` is not accounted from its observed balance delta
-  --> $DIR/balance_reload.rs:59:2
+  --> $DIR/balance_reload.rs:83:2
    |
-LL |     TransferChecked::new(source, mint, vault, owner, 10, 0).invoke()
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     token_2022::instructions::TransferChecked::new(source, mint, vault, owner, 10, 0).invoke()
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: read the destination amount before CPI, drop the borrow, invoke the transfer, reload the amount, and use `checked_sub` for the received value
    = note: `#[deny(req$DIRre_post_cpi_balance_reload)]` on by default
 
 error: transfer into `vault` is not accounted from its observed balance delta
-  --> $DIR/balance_reload.rs:72:2
+  --> $DIR/balance_reload.rs:93:2
    |
-LL |     transfer.invoke()
-   |     ^^^^^^^^^^^^^^^^^
-   |
-   = help: read the destination amount before CPI, drop the borrow, invoke the transfer, reload the amount, and use `checked_sub` for the received value
-
-error: transfer into `vault` is not accounted from its observed balance delta
-  --> $DIR/balance_reload.rs:84:2
-   |
-LL |     transfer.invoke()?;
-   |     ^^^^^^^^^^^^^^^^^
+LL |     TransferChecked::new(source, mint, vault, owner, 10, 0).invoke_with_program(owner)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: read the destination amount before CPI, drop the borrow, invoke the transfer, reload the amount, and use `checked_sub` for the received value
 
 error: transfer into `vault` is not accounted from its observed balance delta
-  --> $DIR/balance_reload.rs:98:33
+  --> $DIR/balance_reload.rs:106:2
    |
-LL |     let selected = choose_transfer(TransferChecked::new(source, mint, vault, owner, 10, 0));
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     transfer.invoke_with_program(owner)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: read the destination amount before CPI, drop the borrow, invoke the transfer, reload the amount, and use `checked_sub` for the received value
+
+error: transfer into `vault` is not accounted from its observed balance delta
+  --> $DIR/balance_reload.rs:118:2
+   |
+LL |     transfer.invoke_with_program(owner)?;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: read the destination amount before CPI, drop the borrow, invoke the transfer, reload the amount, and use `checked_sub` for the received value
 

--- a/lints/require_program_owned_before_lamport_mutation/src/lib.rs
+++ b/lints/require_program_owned_before_lamport_mutation/src/lib.rs
@@ -51,7 +51,7 @@ impl<'tcx> LateLintPass<'tcx> for RequireProgramOwnedBeforeLamportMutation {
 			return;
 		}
 
-		let facts = shared::collect_function_facts(body);
+		let facts = shared::collect_function_facts(cx, body);
 		for (index, call) in facts.calls.iter().enumerate() {
 			if !TARGET_METHODS.contains(&call.method.as_str()) {
 				continue;

--- a/lints/require_sysvar_assert_before_sysvar_use/src/lib.rs
+++ b/lints/require_sysvar_assert_before_sysvar_use/src/lib.rs
@@ -95,7 +95,7 @@ impl<'tcx> LateLintPass<'tcx> for RequireSysvarAssertBeforeSysvarUse {
 			return;
 		}
 
-		let facts = shared::collect_function_facts(body);
+		let facts = shared::collect_function_facts(cx, body);
 		for (index, call) in facts.calls.iter().enumerate() {
 			if call.method == "assert_sysvar" {
 				continue;

--- a/lints/require_type_assert_before_zero_copy_cast/src/lib.rs
+++ b/lints/require_type_assert_before_zero_copy_cast/src/lib.rs
@@ -71,7 +71,7 @@ impl<'tcx> LateLintPass<'tcx> for RequireTypeAssertBeforeZeroCopyCast {
 			return;
 		}
 
-		let facts = shared::collect_function_facts(body);
+		let facts = shared::collect_function_facts(cx, body);
 		for (index, call) in facts.calls.iter().enumerate() {
 			let is_cast_method =
 				call.receiver.is_some() && TARGET_METHODS.contains(&call.method.as_str());

--- a/lints/require_writable_before_account_resize/src/lib.rs
+++ b/lints/require_writable_before_account_resize/src/lib.rs
@@ -51,7 +51,7 @@ impl<'tcx> LateLintPass<'tcx> for RequireWritableBeforeAccountResize {
 			return;
 		}
 
-		let facts = shared::collect_function_facts(body);
+		let facts = shared::collect_function_facts(cx, body);
 		for (index, call) in facts.calls.iter().enumerate() {
 			if !TARGET_METHODS.contains(&call.method.as_str()) {
 				continue;

--- a/lints/require_zeroed_before_close/src/lib.rs
+++ b/lints/require_zeroed_before_close/src/lib.rs
@@ -51,7 +51,7 @@ impl<'tcx> LateLintPass<'tcx> for RequireZeroedBeforeClose {
 			return;
 		}
 
-		let facts = shared::collect_function_facts(body);
+		let facts = shared::collect_function_facts(cx, body);
 		for (index, call) in facts.calls.iter().enumerate() {
 			if !TARGET_METHODS.contains(&call.method.as_str()) {
 				continue;

--- a/lints/shared.rs
+++ b/lints/shared.rs
@@ -4,10 +4,14 @@ extern crate rustc_ast;
 extern crate rustc_hir;
 extern crate rustc_span;
 
+use std::collections::HashMap;
+
 use rustc_ast::LitKind;
 use rustc_hir::Body;
 use rustc_hir::Expr;
 use rustc_hir::ExprKind;
+use rustc_hir::HirId;
+use rustc_lint::LateContext;
 use rustc_span::Span;
 
 #[derive(Debug, Clone)]
@@ -17,9 +21,20 @@ pub struct CallInfo {
 	pub receiver: Option<String>,
 	pub receiver_span: Option<Span>,
 	pub path: Option<String>,
+	pub def_path: Option<String>,
+	pub def_crate: Option<String>,
 	pub is_type_relative: bool,
 	pub args: Vec<Option<String>>,
+	pub arg_def_paths: Vec<Option<String>>,
+	pub arg_def_crates: Vec<Option<String>>,
+	pub arg_bindings: Vec<Option<HirId>>,
 	pub result_binding: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AliasInfo {
+	pub identity: String,
+	pub binding: Option<HirId>,
 }
 
 #[derive(Debug, Clone)]
@@ -35,12 +50,36 @@ pub struct FunctionFacts {
 	pub has_byte_string: bool,
 	pub paths: Vec<String>,
 	pub assignments: Vec<AssignmentInfo>,
+	pub aliases: HashMap<HirId, AliasInfo>,
 }
 
-pub fn collect_function_facts(body: &Body<'_>) -> FunctionFacts {
+pub fn collect_function_facts(cx: &LateContext<'_>, body: &Body<'_>) -> FunctionFacts {
 	let mut facts = FunctionFacts::default();
-	collect_from_expr(body.value, &mut facts, None);
+	collect_from_expr(cx, body.value, &mut facts, None);
 	facts
+}
+
+fn definition_identity(cx: &LateContext<'_>, def_id: rustc_hir::def_id::DefId) -> (String, String) {
+	(
+		cx.tcx.def_path_str(def_id),
+		cx.tcx.crate_name(def_id.krate).as_str().to_string(),
+	)
+}
+
+fn expression_definition(cx: &LateContext<'_>, expr: &Expr<'_>) -> Option<(String, String)> {
+	match &expr.kind {
+		ExprKind::Path(path) => {
+			match cx.qpath_res(path, expr.hir_id) {
+				rustc_hir::def::Res::Def(_, def_id) => Some(definition_identity(cx, def_id)),
+				_ => None,
+			}
+		}
+		ExprKind::Unary(_, inner)
+		| ExprKind::Cast(inner, _)
+		| ExprKind::DropTemps(inner)
+		| ExprKind::AddrOf(_, _, inner) => expression_definition(cx, inner),
+		_ => None,
+	}
 }
 
 pub fn receiver_name(expr: &Expr<'_>) -> Option<String> {
@@ -78,6 +117,32 @@ pub fn expression_identity(expr: &Expr<'_>) -> Option<String> {
 	}
 }
 
+pub fn expression_local_binding(expr: &Expr<'_>) -> Option<HirId> {
+	match &expr.kind {
+		ExprKind::Path(rustc_hir::QPath::Resolved(_, path)) => {
+			match path.res {
+				rustc_hir::def::Res::Local(binding) => Some(binding),
+				_ => None,
+			}
+		}
+		ExprKind::MethodCall(_, receiver, ..) | ExprKind::Match(receiver, ..) => {
+			expression_local_binding(receiver)
+		}
+		ExprKind::Unary(_, inner)
+		| ExprKind::Cast(inner, _)
+		| ExprKind::DropTemps(inner)
+		| ExprKind::AddrOf(_, _, inner)
+		| ExprKind::Index(inner, ..) => expression_local_binding(inner),
+		ExprKind::Block(block, _) => block.expr.and_then(expression_local_binding),
+		ExprKind::Call(callee, args) => {
+			args.first()
+				.and_then(|argument| expression_local_binding(argument))
+				.or_else(|| expression_local_binding(callee))
+		}
+		_ => None,
+	}
+}
+
 pub fn has_prior_method_with_receiver_match(
 	calls: &[CallInfo],
 	index: usize,
@@ -107,6 +172,7 @@ pub fn def_path_matches(def_path: &str, needles: &[&str]) -> bool {
 }
 
 fn collect_from_block(
+	cx: &LateContext<'_>,
 	block: &rustc_hir::Block<'_>,
 	facts: &mut FunctionFacts,
 	result_binding: Option<&str>,
@@ -116,30 +182,52 @@ fn collect_from_block(
 			rustc_hir::StmtKind::Let(local) => {
 				if let Some(init) = local.init {
 					let binding = match local.pat.kind {
-						rustc_hir::PatKind::Binding(_, _, ident, _) => {
-							Some(ident.name.as_str().to_string())
+						rustc_hir::PatKind::Binding(_, binding, ident, _) => {
+							Some((binding, ident.name.as_str().to_string()))
 						}
 						_ => None,
 					};
-					collect_from_expr(init, facts, binding.as_deref());
+					if let (Some((binding, _)), Some(identity)) =
+						(binding.as_ref(), expression_identity(init))
+					{
+						facts.aliases.insert(
+							*binding,
+							AliasInfo {
+								identity,
+								binding: expression_local_binding(init),
+							},
+						);
+					}
+					collect_from_expr(
+						cx,
+						init,
+						facts,
+						binding.as_ref().map(|(_, name)| name.as_str()),
+					);
 				}
 			}
 			rustc_hir::StmtKind::Expr(expr) | rustc_hir::StmtKind::Semi(expr) => {
-				collect_from_expr(expr, facts, None);
+				collect_from_expr(cx, expr, facts, None);
 			}
 			_ => {}
 		}
 	}
 	if let Some(expr) = block.expr {
-		collect_from_expr(expr, facts, result_binding);
+		collect_from_expr(cx, expr, facts, result_binding);
 	}
 }
 
-fn collect_from_expr(expr: &Expr<'_>, facts: &mut FunctionFacts, result_binding: Option<&str>) {
-	collect_from_expr_inner(expr, facts, result_binding, false);
+fn collect_from_expr(
+	cx: &LateContext<'_>,
+	expr: &Expr<'_>,
+	facts: &mut FunctionFacts,
+	result_binding: Option<&str>,
+) {
+	collect_from_expr_inner(cx, expr, facts, result_binding, false);
 }
 
 fn collect_from_expr_inner(
+	cx: &LateContext<'_>,
 	expr: &Expr<'_>,
 	facts: &mut FunctionFacts,
 	result_binding: Option<&str>,
@@ -147,28 +235,45 @@ fn collect_from_expr_inner(
 ) {
 	match &expr.kind {
 		ExprKind::MethodCall(path_segment, receiver, args, _) => {
-			collect_from_expr(receiver, facts, result_binding);
+			collect_from_expr(cx, receiver, facts, result_binding);
 			for arg in *args {
-				collect_from_expr(arg, facts, None);
+				collect_from_expr(cx, arg, facts, None);
 			}
+			let definition = cx
+				.typeck_results()
+				.type_dependent_def_id(expr.hir_id)
+				.map(|def_id| definition_identity(cx, def_id));
 			facts.calls.push(CallInfo {
 				span: expr.span,
 				method: path_segment.ident.name.as_str().to_string(),
 				receiver: expression_identity(receiver),
 				receiver_span: Some(receiver.span),
 				path: None,
+				def_path: definition.as_ref().map(|(path, _)| path.clone()),
+				def_crate: definition.map(|(_, crate_name)| crate_name),
 				is_type_relative: false,
 				args: args.iter().map(expression_identity).collect(),
+				arg_def_paths: args
+					.iter()
+					.map(|argument| expression_definition(cx, argument).map(|(path, _)| path))
+					.collect(),
+				arg_def_crates: args
+					.iter()
+					.map(|argument| {
+						expression_definition(cx, argument).map(|(_, crate_name)| crate_name)
+					})
+					.collect(),
+				arg_bindings: args.iter().map(expression_local_binding).collect(),
 				result_binding: result_binding.map(str::to_string),
 			});
 		}
 		ExprKind::Call(callee, args) => {
-			collect_from_expr(callee, facts, None);
+			collect_from_expr(cx, callee, facts, None);
 			for arg in *args {
 				let binding = forward_call_argument_binding
 					.then_some(result_binding)
 					.flatten();
-				collect_from_expr(arg, facts, binding);
+				collect_from_expr(cx, arg, facts, binding);
 			}
 			if let rustc_hir::ExprKind::Path(path) = &callee.kind {
 				let (path_name, is_type_relative) = match path {
@@ -190,38 +295,56 @@ fn collect_from_expr_inner(
 					.next()
 					.unwrap_or(&path_name)
 					.to_string();
+				let definition = match cx.qpath_res(path, callee.hir_id) {
+					rustc_hir::def::Res::Def(_, def_id) => Some(definition_identity(cx, def_id)),
+					_ => None,
+				};
 				facts.calls.push(CallInfo {
 					span: expr.span,
 					method,
 					receiver: None,
 					receiver_span: None,
 					path: Some(path_name),
+					def_path: definition.as_ref().map(|(path, _)| path.clone()),
+					def_crate: definition.map(|(_, crate_name)| crate_name),
 					is_type_relative,
 					args: args.iter().map(expression_identity).collect(),
+					arg_def_paths: args
+						.iter()
+						.map(|argument| expression_definition(cx, argument).map(|(path, _)| path))
+						.collect(),
+					arg_def_crates: args
+						.iter()
+						.map(|argument| {
+							expression_definition(cx, argument).map(|(_, crate_name)| crate_name)
+						})
+						.collect(),
+					arg_bindings: args.iter().map(expression_local_binding).collect(),
 					result_binding: result_binding.map(str::to_string),
 				});
 			}
 		}
 		ExprKind::Block(block, _) | ExprKind::Loop(block, ..) => {
-			collect_from_block(block, facts, result_binding);
+			collect_from_block(cx, block, facts, result_binding);
 		}
 		ExprKind::Match(scrutinee, arms, source) => {
 			facts.has_match = true;
 			collect_from_expr_inner(
+				cx,
 				scrutinee,
 				facts,
 				result_binding,
 				matches!(source, rustc_hir::MatchSource::TryDesugar(_)),
 			);
 			for arm in *arms {
-				collect_from_expr(arm.body, facts, result_binding);
+				collect_from_expr(cx, arm.body, facts, result_binding);
 			}
 		}
 		ExprKind::If(cond, then, else_opt) => {
-			collect_from_expr(cond, facts, None);
-			collect_from_expr(then, facts, result_binding);
+			collect_from_expr(cx, cond, facts, None);
+			collect_from_expr(cx, then, facts, result_binding);
 			if let Some(el) = else_opt {
-				collect_from_expr(el, facts, result_binding);
+				collect_from_expr(cx, el, facts, result_binding);
 			}
 		}
 		ExprKind::Unary(_, expr)
@@ -235,11 +358,11 @@ fn collect_from_expr_inner(
 		| ExprKind::Yield(expr, _)
 		| ExprKind::Become(expr)
 		| ExprKind::UnsafeBinderCast(_, expr, _) => {
-			collect_from_expr(expr, facts, result_binding);
+			collect_from_expr(cx, expr, facts, result_binding);
 		}
 		ExprKind::Binary(_, lhs, rhs) => {
-			collect_from_expr(lhs, facts, result_binding);
-			collect_from_expr(rhs, facts, result_binding);
+			collect_from_expr(cx, lhs, facts, result_binding);
+			collect_from_expr(cx, rhs, facts, result_binding);
 		}
 		ExprKind::Assign(lhs, rhs, _) | ExprKind::AssignOp(_, lhs, rhs) => {
 			if let Some(identity) = expression_identity(lhs) {
@@ -248,31 +371,31 @@ fn collect_from_expr_inner(
 					identity,
 				});
 			}
-			collect_from_expr(lhs, facts, None);
-			collect_from_expr(rhs, facts, None);
+			collect_from_expr(cx, lhs, facts, None);
+			collect_from_expr(cx, rhs, facts, None);
 		}
 		ExprKind::Index(base, index, _) => {
-			collect_from_expr(base, facts, result_binding);
-			collect_from_expr(index, facts, None);
+			collect_from_expr(cx, base, facts, result_binding);
+			collect_from_expr(cx, index, facts, None);
 		}
 		ExprKind::Let(let_expr) => {
-			collect_from_expr(let_expr.init, facts, result_binding);
+			collect_from_expr(cx, let_expr.init, facts, result_binding);
 		}
 		ExprKind::Tup(exprs) | ExprKind::Array(exprs) => {
 			for e in *exprs {
-				collect_from_expr(e, facts, result_binding);
+				collect_from_expr(cx, e, facts, result_binding);
 			}
 		}
 		ExprKind::Struct(_, fields, tail) => {
 			for field in *fields {
-				collect_from_expr(field.expr, facts, result_binding);
+				collect_from_expr(cx, field.expr, facts, result_binding);
 			}
 			if let rustc_hir::StructTailExpr::Base(base) = tail {
-				collect_from_expr(base, facts, result_binding);
+				collect_from_expr(cx, base, facts, result_binding);
 			}
 		}
 		ExprKind::Ret(Some(inner)) | ExprKind::Break(_, Some(inner)) => {
-			collect_from_expr(inner, facts, result_binding);
+			collect_from_expr(cx, inner, facts, result_binding);
 		}
 		ExprKind::Lit(lit) => {
 			if matches!(lit.node, LitKind::ByteStr(..)) {


### PR DESCRIPTION
## Summary

- resolve account-borrow and CPI method definitions before classifying calls, avoiding unrelated same-name APIs
- accept dominating constant-bound remaining-account guards, trace immutable token-program aliases, and match economic identifiers by exact component
- exempt only compiler-resolved legacy `pinocchio_token` operations from Token-2022 policy and reload requirements while retaining dynamic-program coverage
- skip deny-level post-CPI guesses for opaque transfer-builder wrappers and document each refined scope and limitation
- add UI coverage for accepted and rejected edge cases, including local-module spoofing attempts

## Validation

- `devenv shell lint:all`
- focused UI suites for all six refined lints
- `devenv shell cargo test --workspace --all-features --locked`
- `devenv shell env CC=/usr/bin/clang CXX=/usr/bin/clang++ cargo check --manifest-path crates/pina_fuzz/fuzz/Cargo.toml --all-targets --locked`
- full `lint:push` pre-push suite with system Clang

Created on behalf of Ifiok Jr. (@ifiokjr) using GPT-5 Codex with high reasoning.