### PR TITLE
fix(cli): pin durable lint revision

### DIFF
--- a/.changeset/pin-durable-lint-revision.md
+++ b/.changeset/pin-durable-lint-revision.md
@@ -1,0 +1,7 @@
+---
+pina_cli: fix
+---
+
+# Pin security lints to a durable main revision
+
+Use the immutable squash commit containing the reviewed Dylint 6 lint suite so generated projects and `pina lint` fetch a revision that remains reachable from `main`.

--- a/crates/pina_cli/src/lint.rs
+++ b/crates/pina_cli/src/lint.rs
@@ -21,7 +21,7 @@ pub const DYLINT_LINK_VERSION: &str = "6.0.4";
 ///
 /// Update this only after reviewing changes below `lints/`. Unlike a release
 /// tag, a full commit ID cannot be redirected to different native lint code.
-pub const PINA_LINT_REVISION: &str = "7aff2afb89cd34a13e1e9d6ff854bc16d12263cc";
+pub const PINA_LINT_REVISION: &str = "f6f206e0a4e71ab70c3eeaded52d07cd66a270d8";
 
 const PINA_REPOSITORY: &str = "https://github.com/pina-rs/pina";
 const PINA_LINT_PATTERN: &str = "lints/*";

--- a/crates/pina_cli/tests/lint_command.rs
+++ b/crates/pina_cli/tests/lint_command.rs
@@ -189,7 +189,7 @@ fn lint_installs_pinned_tools_once_and_runs_release_lints() {
 	assert!(first_log.contains("--version 6.0.4 dylint-link"));
 	assert!(first_log.contains("dylint dylint --no-deps"));
 	assert!(first_log.contains("--git https://github.com/pina-rs/pina"));
-	assert!(first_log.contains("--rev 7aff2afb89cd34a13e1e9d6ff854bc16d12263cc"));
+	assert!(first_log.contains("--rev f6f206e0a4e71ab70c3eeaded52d07cd66a270d8"));
 	assert!(first_log.contains("--pattern lints/\\*"));
 	assert!(first_log.contains("--package lint-fixture"));
 	assert!(first_log.contains("link="));


### PR DESCRIPTION
## Summary

- pin `pina lint` and generated Dylint metadata to the immutable PR #250 squash commit that is durably reachable from `main`
- keep the integration assertion aligned with the emitted `--rev` argument
- record the `pina_cli` patch in a changeset

This follow-up is necessary because PR #250 was squash-merged: its originally pinned pre-squash commit remains available through the pull-request ref, but is not part of `main` ancestry. The squash commit contains the same reviewed lint tree byte-for-byte.

## Validation

- full pre-push `lint:push` gate
- focused `pina_cli` lint unit and integration tests
- focused LLVM coverage
- real `pina lint --project examples/counter_program` fetch and execution from revision `f6f206e0a4e71ab70c3eeaded52d07cd66a270d8`

Created on behalf of Ifiok Jr. (`@ifiokjr`) using GPT-5.6 at high reasoning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the pinned security lint revision to ensure generated projects and `pina lint` use the reviewed, immutable lint suite.
  * Improved revision stability by selecting a commit that remains reachable from the main codebase.

* **Tests**
  * Updated lint command verification to reflect the new pinned revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->