### PR TITLE
fix(pina_cli): migrate remaining sha2 0.11 hash formatting in tests

### DIFF
--- a/.changeset/crypto-deps-refresh.md
+++ b/.changeset/crypto-deps-refresh.md
@@ -1,5 +1,5 @@
 ---
-pina_cli: patch
+pina_cli: fix
 ---
 
 Update crypto dependencies.

--- a/.changeset/sha2-011-test-hash-migration.md
+++ b/.changeset/sha2-011-test-hash-migration.md
@@ -1,0 +1,7 @@
+---
+pina_cli: fix
+---
+
+Fix sha2 0.11 digest formatting in test code.
+
+The #255 dependency update migrated the two lib call sites but missed nine `format!("{:x}", Sha256::digest(..))` uses across `pina_cli` test modules, where sha2 0.11 digest arrays no longer implement `LowerHex`. The Windows CLI portability job and any compilation of the test targets therefore failed. Hash formatting now maps bytes explicitly, producing identical output.

--- a/crates/pina_cli/src/commands.rs
+++ b/crates/pina_cli/src/commands.rs
@@ -966,7 +966,7 @@ mod tests {
 
 	fn record_options(temp: &TempDir, confirmed: bool) -> pina_cli::verification::RecordOptions {
 		let artifact_bytes = vec![7_u8; 128];
-		let hash = format!("{:x}", Sha256::digest(&artifact_bytes));
+		let hash = Sha256::digest(&artifact_bytes).iter().map(|byte| format!("{byte:02x}")).collect::<String>();
 		let record_dir = temp.path().join("record with spaces");
 		fs::create_dir_all(&record_dir).unwrap();
 		let record = record_dir.join(format!("fixture-{hash}.json"));

--- a/crates/pina_cli/src/verifiable.rs
+++ b/crates/pina_cli/src/verifiable.rs
@@ -1504,14 +1504,14 @@ mod tests {
 		let path = temp.path().join("program.so");
 		fs::write(&path, b"program\0\0")
 			.unwrap_or_else(|error| panic!("fixture write failed: {error}"));
-		let expected = format!("{:x}", Sha256::digest(b"program"));
+		let expected = Sha256::digest(b"program").iter().map(|byte| format!("{byte:02x}")).collect::<String>();
 		assert_eq!(
 			executable_hash(&path).unwrap_or_else(|error| panic!("hash failed: {error}")),
 			expected
 		);
 		assert_eq!(
 			sha256_file(&path).unwrap_or_else(|error| panic!("raw hash failed: {error}")),
-			format!("{:x}", Sha256::digest(b"program\0\0"))
+			Sha256::digest(b"program\0\0").iter().map(|byte| format!("{byte:02x}")).collect::<String>()
 		);
 
 		let mut large = vec![0_u8; 2 * 1024 * 1024];
@@ -1521,7 +1521,7 @@ mod tests {
 			.unwrap_or_else(|error| panic!("large fixture write failed: {error}"));
 		assert_eq!(
 			executable_hash(&path).unwrap_or_else(|error| panic!("streaming hash failed: {error}")),
-			format!("{:x}", Sha256::digest(&large[..64 * 1024 + 8]))
+			Sha256::digest(&large[..64 * 1024 + 8]).iter().map(|byte| format!("{byte:02x}")).collect::<String>()
 		);
 	}
 
@@ -1717,7 +1717,7 @@ mod tests {
 	fn record_reader_validates_size_shape_hash_and_accessors() {
 		let temp = TempDir::new().unwrap_or_else(|error| panic!("temp dir failed: {error}"));
 		let artifact_contents = b"program\0\0";
-		let hash = format!("{:x}", Sha256::digest(b"program"));
+		let hash = Sha256::digest(b"program").iter().map(|byte| format!("{byte:02x}")).collect::<String>();
 		let record_path = temp.path().join(format!("program-{hash}.json"));
 		let artifact_path = record_path.with_extension("so");
 		let manifest = valid_manifest(&hash);
@@ -1973,7 +1973,7 @@ mod tests {
 		let artifact = snapshot.path().join("program.so");
 		fs::write(&artifact, b"program")
 			.unwrap_or_else(|error| panic!("artifact write failed: {error}"));
-		let hash = format!("{:x}", Sha256::digest(b"program"));
+		let hash = Sha256::digest(b"program").iter().map(|byte| format!("{byte:02x}")).collect::<String>();
 		let verified = VerifiedBuild {
 			_snapshot: snapshot,
 			artifact,

--- a/crates/pina_cli/src/verification.rs
+++ b/crates/pina_cli/src/verification.rs
@@ -1513,7 +1513,7 @@ mod tests {
 	}
 
 	fn record_hash() -> String {
-		format!("{:x}", Sha256::digest([7_u8; 128]))
+		Sha256::digest([7_u8; 128]).iter().map(|byte| format!("{byte:02x}")).collect::<String>()
 	}
 
 	fn record_program_for_test(
@@ -1875,7 +1875,7 @@ mod tests {
 		default_features: bool,
 	) -> PathBuf {
 		let bytes = vec![7_u8; 128];
-		let hash = format!("{:x}", Sha256::digest(&bytes));
+		let hash = Sha256::digest(&bytes).iter().map(|byte| format!("{byte:02x}")).collect::<String>();
 		let record = temp.path().join(format!("verify_fixture-{hash}.json"));
 		let artifact = record.with_extension("so");
 		let json = serde_json::json!({

--- a/crates/pina_cli/tests/verification_command.rs
+++ b/crates/pina_cli/tests/verification_command.rs
@@ -64,7 +64,7 @@ esac
 
 fn create_record_and_keypair(temp: &TempDir) -> (std::path::PathBuf, std::path::PathBuf, String) {
 	let bytes = vec![7_u8; 128];
-	let hash = format!("{:x}", Sha256::digest(&bytes));
+	let hash = Sha256::digest(&bytes).iter().map(|byte| format!("{byte:02x}")).collect::<String>();
 	let record = temp.path().join(format!("fixture-{hash}.json"));
 	let artifact = record.with_extension("so");
 	let json = serde_json::json!({


### PR DESCRIPTION
## Summary

Follow-up to #255, fixing the fallout of that PR having been merged before CI finished:

1. **Nine test-module call sites** of `format!("{:x}", Sha256::digest(..))` did not get the sha2 0.11 `LowerHex` migration (`verifiable.rs` ×5, `verification.rs` ×2, `commands.rs` ×1, `tests/verification_command.rs` ×1) — compiling `pina_cli`'s test targets failed, breaking the `windows CLI` portability job. Hex formatting now maps bytes explicitly, producing identical output.
2. **The changeset type`patch` is not valid in this repo's monochange config** (`preview` + `changeset-policy` jobs fail with: *valid types: breaking, docs, feat, fix, major, none*). Imports `crypto-deps-refresh.md` from main — which poisons every PR based on current `main` — to `pina_cli: fix`, and uses `fix` for this PR's changeset too.

## Test plan

- [x] `cargo test -p pina_cli --all-features`: **443 passed, 0 failed** (full suite)
- [x] `dprint check` clean
- [x] changeset types now within monochange's valid set
- [ ] Full CI suite (`windows CLI` + `preview` + `check` included)

_Created on behalf of Ifiok Jr. ([`@ifiokjr`](https://github.com/ifiokjr)) by codex using gpt-5.1-codex at high thinking._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with updated cryptographic libraries.
  - Fixed SHA-256 hash formatting across verification workflows and test environments, including Windows.
  - Preserved existing lowercase hexadecimal hash output and artifact identifiers.

- **Maintenance**
  - Refreshed core encoding, signing, and hashing components.
  - Confirmed that generated program artifacts remain byte-identical after the update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->