### PR TITLE
chore(deps): update base64, ed25519-dalek, and sha2

### DIFF
--- a/.changeset/crypto-deps-refresh.md
+++ b/.changeset/crypto-deps-refresh.md
@@ -1,0 +1,13 @@
+---
+pina_cli: fix
+---
+
+Update crypto dependencies.
+
+- `base64` 0.22 → 0.23 (SIMD engine additions; measured binary-size-neutral, the CLI uses the scalar engine so SIMD paths are dead-stripped).
+- `ed25519-dalek` 2.2 → 3.0 (curve25519-dalek 5, MSRV 1.85; required no code changes).
+- `sha2` 0.10 → 0.11 (digest 0.11, `std` feature replaced by `alloc`); digest arrays no longer implement `LowerHex`, so the eleven hash-formatting sites in `pina_cli` (library and tests) now map bytes explicitly with identical output.
+
+CLI release binary measured −592 B (−0.007%, noise); SBF program artifact byte-identical — `sha2 0.10.9` stays pinned in the program graph by `solana-address 2.6.1` and is unaffected by this change.
+
+This repeats the revert of #255 with the test-target compilation fixed, so all CLI portability checks pass.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,6 +576,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,6 +665,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -996,6 +1011,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1212,6 +1233,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1221,10 +1251,26 @@ dependencies = [
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
- "fiat-crypto",
+ "fiat-crypto 0.2.9",
  "rand_core 0.6.4",
  "rustc_version",
  "serde",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "curve25519-dalek-derive",
+ "digest 0.11.3",
+ "fiat-crypto 0.3.0",
+ "rustc_version",
  "subtle",
  "zeroize",
 ]
@@ -1345,7 +1391,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
@@ -1418,9 +1464,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
- "crypto-common",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1459,30 +1516,28 @@ dependencies = [
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
- "signature",
+ "signature 2.2.0",
  "spki",
 ]
 
 [[package]]
 name = "ed25519"
-version = "2.2.3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
 dependencies = [
- "pkcs8",
- "signature",
+ "signature 3.0.0",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 5.0.0",
  "ed25519",
- "serde",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "subtle",
  "zeroize",
 ]
@@ -1661,6 +1716,12 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1894,6 +1955,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2123,7 +2193,7 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "sha2 0.10.9",
- "signature",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -2177,7 +2247,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e79019718125edc905a079a70cfa5f3820bc76139fc91d6f9abc27ea2a887139"
 dependencies = [
  "arrayref",
- "base64",
+ "base64 0.22.1",
  "digest 0.9.0",
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
@@ -2672,7 +2742,7 @@ name = "pina_cli"
 version = "0.10.0"
 dependencies = [
  "atomic-write-file",
- "base64",
+ "base64 0.23.1",
  "bs58",
  "cargo_metadata",
  "clap",
@@ -2698,7 +2768,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "solana-address",
  "syn 3.0.3",
  "tempfile",
@@ -3469,6 +3539,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha2-const-stable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3530,6 +3611,12 @@ dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 
 [[package]]
 name = "simd-adler32"
@@ -3608,7 +3695,7 @@ dependencies = [
  "borsh",
  "bytemuck",
  "bytemuck_derive",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "five8",
  "five8_const",
  "serde",
@@ -3755,7 +3842,7 @@ checksum = "14b4d2a4bf0d0b0a86c22111917e86e8bd39a7b31420fb2c7d73eb83761fc7af"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "solana-define-syscall 5.2.0",
  "subtle",
  "thiserror 2.0.20",
@@ -4122,7 +4209,7 @@ version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99a3895314c34396758131a8af156944453ebe18e70d2a5cde67eec899df48a1"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bincode",
  "cfg-if",
  "itertools 0.14.0",
@@ -4511,7 +4598,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ada7045bbfdd802af08fbc9c7e2b56ddabb20599d22e4c3840fcef5e7afb8324"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bincode",
  "lazy_static",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ rust-version = "1.89.0"
 
 [workspace.dependencies]
 atomic-write-file = { default-features = false, version = "^0.3" }
-base64 = { default-features = false, version = "^0.22.1" }
+base64 = { default-features = false, version = "^0.23.1" }
 bs58 = { default-features = false, version = "^0.5.1" }
 cargo_metadata = { default-features = false, version = "^0.23" }
 clap = { default-features = false, version = "^4", features = ["derive", "std"] }
@@ -101,7 +101,7 @@ clap_complete = { default-features = false, version = "^4" }
 codama-nodes = { default-features = false, version = "0.13.1" }
 comfy-table = { default-features = false, version = "^8.0.0" }
 darling = { default-features = false, version = "0.24.0" }
-ed25519-dalek = { version = "2.2.0", default-features = false }
+ed25519-dalek = { version = "3.0.0", default-features = false }
 flate2 = { default-features = true, version = "1.1.2" }
 fs2 = { default-features = false, version = "^0.4" }
 getrandom = { default-features = false, version = "0.4.2" }
@@ -130,7 +130,7 @@ same-file = { default-features = false, version = "^1" }
 semver = { default-features = false, version = "^1" }
 serde = { default-features = false, version = "^1" }
 serde_json = { default-features = false, version = "^1", features = ["std"] }
-sha2 = { default-features = false, version = "^0.10", features = ["std"] }
+sha2 = { default-features = false, version = "^0.11" }
 solana-account = { version = "^4", default-features = false }
 solana-account-info = { version = "^3", default-features = false }
 solana-address = { default-features = false, version = "^2.0", features = ["bytemuck", "curve25519", "decode"] }

--- a/crates/pina_cli/src/commands.rs
+++ b/crates/pina_cli/src/commands.rs
@@ -966,7 +966,7 @@ mod tests {
 
 	fn record_options(temp: &TempDir, confirmed: bool) -> pina_cli::verification::RecordOptions {
 		let artifact_bytes = vec![7_u8; 128];
-		let hash = format!("{:x}", Sha256::digest(&artifact_bytes));
+		let hash = Sha256::digest(&artifact_bytes).iter().map(|byte| format!("{byte:02x}")).collect::<String>();
 		let record_dir = temp.path().join("record with spaces");
 		fs::create_dir_all(&record_dir).unwrap();
 		let record = record_dir.join(format!("fixture-{hash}.json"));

--- a/crates/pina_cli/src/verifiable.rs
+++ b/crates/pina_cli/src/verifiable.rs
@@ -1143,7 +1143,11 @@ fn sha256_file(path: &Path) -> Result<String, VerifyBuildError> {
 		hasher.update(&buffer[..read]);
 	}
 
-	Ok(format!("{:x}", hasher.finalize()))
+	Ok(hasher
+		.finalize()
+		.iter()
+		.map(|byte| format!("{byte:02x}"))
+		.collect::<String>())
 }
 
 fn executable_hash(path: &Path) -> Result<String, VerifyBuildError> {
@@ -1181,7 +1185,11 @@ fn executable_hash(path: &Path) -> Result<String, VerifyBuildError> {
 		}
 	}
 
-	Ok(format!("{:x}", hasher.finalize()))
+	Ok(hasher
+		.finalize()
+		.iter()
+		.map(|byte| format!("{byte:02x}"))
+		.collect::<String>())
 }
 
 fn portable_path(path: &Path) -> String {
@@ -1496,14 +1504,14 @@ mod tests {
 		let path = temp.path().join("program.so");
 		fs::write(&path, b"program\0\0")
 			.unwrap_or_else(|error| panic!("fixture write failed: {error}"));
-		let expected = format!("{:x}", Sha256::digest(b"program"));
+		let expected = Sha256::digest(b"program").iter().map(|byte| format!("{byte:02x}")).collect::<String>();
 		assert_eq!(
 			executable_hash(&path).unwrap_or_else(|error| panic!("hash failed: {error}")),
 			expected
 		);
 		assert_eq!(
 			sha256_file(&path).unwrap_or_else(|error| panic!("raw hash failed: {error}")),
-			format!("{:x}", Sha256::digest(b"program\0\0"))
+			Sha256::digest(b"program\0\0").iter().map(|byte| format!("{byte:02x}")).collect::<String>()
 		);
 
 		let mut large = vec![0_u8; 2 * 1024 * 1024];
@@ -1513,7 +1521,7 @@ mod tests {
 			.unwrap_or_else(|error| panic!("large fixture write failed: {error}"));
 		assert_eq!(
 			executable_hash(&path).unwrap_or_else(|error| panic!("streaming hash failed: {error}")),
-			format!("{:x}", Sha256::digest(&large[..64 * 1024 + 8]))
+			Sha256::digest(&large[..64 * 1024 + 8]).iter().map(|byte| format!("{byte:02x}")).collect::<String>()
 		);
 	}
 
@@ -1709,7 +1717,7 @@ mod tests {
 	fn record_reader_validates_size_shape_hash_and_accessors() {
 		let temp = TempDir::new().unwrap_or_else(|error| panic!("temp dir failed: {error}"));
 		let artifact_contents = b"program\0\0";
-		let hash = format!("{:x}", Sha256::digest(b"program"));
+		let hash = Sha256::digest(b"program").iter().map(|byte| format!("{byte:02x}")).collect::<String>();
 		let record_path = temp.path().join(format!("program-{hash}.json"));
 		let artifact_path = record_path.with_extension("so");
 		let manifest = valid_manifest(&hash);
@@ -1965,7 +1973,7 @@ mod tests {
 		let artifact = snapshot.path().join("program.so");
 		fs::write(&artifact, b"program")
 			.unwrap_or_else(|error| panic!("artifact write failed: {error}"));
-		let hash = format!("{:x}", Sha256::digest(b"program"));
+		let hash = Sha256::digest(b"program").iter().map(|byte| format!("{byte:02x}")).collect::<String>();
 		let verified = VerifiedBuild {
 			_snapshot: snapshot,
 			artifact,

--- a/crates/pina_cli/src/verification.rs
+++ b/crates/pina_cli/src/verification.rs
@@ -1513,7 +1513,7 @@ mod tests {
 	}
 
 	fn record_hash() -> String {
-		format!("{:x}", Sha256::digest([7_u8; 128]))
+		Sha256::digest([7_u8; 128]).iter().map(|byte| format!("{byte:02x}")).collect::<String>()
 	}
 
 	fn record_program_for_test(
@@ -1875,7 +1875,7 @@ mod tests {
 		default_features: bool,
 	) -> PathBuf {
 		let bytes = vec![7_u8; 128];
-		let hash = format!("{:x}", Sha256::digest(&bytes));
+		let hash = Sha256::digest(&bytes).iter().map(|byte| format!("{byte:02x}")).collect::<String>();
 		let record = temp.path().join(format!("verify_fixture-{hash}.json"));
 		let artifact = record.with_extension("so");
 		let json = serde_json::json!({

--- a/crates/pina_cli/tests/verification_command.rs
+++ b/crates/pina_cli/tests/verification_command.rs
@@ -64,7 +64,7 @@ esac
 
 fn create_record_and_keypair(temp: &TempDir) -> (std::path::PathBuf, std::path::PathBuf, String) {
 	let bytes = vec![7_u8; 128];
-	let hash = format!("{:x}", Sha256::digest(&bytes));
+	let hash = Sha256::digest(&bytes).iter().map(|byte| format!("{byte:02x}")).collect::<String>();
 	let record = temp.path().join(format!("fixture-{hash}.json"));
 	let artifact = record.with_extension("so");
 	let json = serde_json::json!({


### PR DESCRIPTION
## Why

#255 attempted this dependency update but was merged before CI finished and shipped three broken checks (`windows CLI`, `check`, `preview`), so it was reverted in `87b0adf1`. This PR redoes the same update with all three failure causes fixed — and with local validation of every previously-failing surface before opening.

| Dependency | From | To | Notes |
|---|---|---|---|
| `base64` | ^0.22.1 | ^0.23.1 | Drop-in; new SIMD engines are dead-stripped for the scalar engine the CLI uses |
| `ed25519-dalek` | 2.2.0 | 3.0.0 | Drop-in, zero code changes (curve25519-dalek 5, MSRV 1.85) |
| `sha2` | ^0.10 (`std`) | ^0.11 | digest 0.11; `std` removed upstream, digest arrays no longer implement `LowerHex` |

## How the previous breakage is addressed

1. **Full `LowerHex` migration** — **eleven** hash-formatting sites in `pina_cli`, not just the two library ones that #255 fixed: library (`verifiable.rs` ×2) plus test modules (`verifiable.rs` ×5, `verification.rs` ×2, `commands.rs` ×1, `tests/verification_command.rs` ×1). Output is byte-identical.
2. **Valid changeset type** — #255's `pina_cli: patch` isn't in this repo's monochange config and broke `preview` + `changeset-policy` for every PR on main. This changeset uses `fix`, verified locally.
3. **Merged-before-CI in #255 can't repeat** — this PR waits for the full suite; merges only when green.

## Pre-merged validation (locally, mirroring CI)

- `cargo test -p pina_cli --all-features`: 443 passed, 0 failed (covers the Windows portability surface)
- `monochange preview --format md`: dry-run v0.11.0 succeeds (the `preview` surface)
- `monochange step affected-packages --verify`: passed (the `check`/changeset-policy surface)
- `dprint check`: clean

Size evidence from the scratch-worktree measurements: CLI release binary −592 B (−0.007%, noise); `libpina_bpf.so` byte-identical (`sha2 0.10.9` stays pinned in the program graph by `solana-address 2.6.1`).

_Created on behalf of Ifiok Jr. ([`@ifiokjr`](https://github.com/ifiokjr)) by codex using gpt-5.1-codex at high thinking._