### PR TITLE
feat(cli): download precompiled security lints

### DIFF
--- a/.changeset/1787992486-pina-cli.md
+++ b/.changeset/1787992486-pina-cli.md
@@ -1,0 +1,7 @@
+---
+pina_cli: feat
+---
+
+# Download precompiled security lints
+
+`pina lint` now downloads verified, precompiled `cargo-dylint`, `dylint-link`, and native Pina lint libraries instead of installing those components from source. Automated releases reuse a version-keyed Dylint tool release or build, attest, and publish its complete host matrix without a follow-up commit pin.

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -30,6 +30,7 @@ jobs:
       (github.event_name != 'release' || startsWith(github.event.release.tag_name, 'v'))
     permissions:
       contents: read # Read documentation and source files from the repository.
+      pages: read # Read the GitHub Pages site configuration.
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -17,8 +17,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: "pages"
@@ -26,11 +24,18 @@ concurrency:
 
 jobs:
   build:
-    if: github.repository_owner == 'pina-rs'
+    name: build documentation
+    if: >-
+      github.repository_owner == 'pina-rs' &&
+      (github.event_name != 'release' || startsWith(github.event.release.tag_name, 'v'))
+    permissions:
+      contents: read # Read documentation and source files from the repository.
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: setup
         uses: ./.github/actions/devenv
@@ -54,8 +59,12 @@ jobs:
           path: docs/book
 
   deploy:
+    name: deploy documentation
     if: github.repository_owner == 'pina-rs'
     needs: build
+    permissions:
+      id-token: write # Authenticate the Pages deployment with GitHub OIDC.
+      pages: write # Publish the built documentation artifact to GitHub Pages.
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,318 @@ env:
   RELEASE_ASSET_TAG: ${{ inputs.tag || github.ref_name }}
 
 jobs:
+  prepare_dylint_tools:
+    name: resolve Dylint tool release
+    if: >-
+      github.repository_owner == 'pina-rs' &&
+      startsWith(inputs.tag || github.ref_name, 'v')
+    outputs:
+      commit: ${{ steps.release.outputs.commit }}
+      required: ${{ steps.release.outputs.required }}
+      tag: ${{ steps.release.outputs.tag }}
+      version: ${{ steps.release.outputs.version }}
+    permissions:
+      contents: read # Inspect the versioned Dylint tool release.
+    runs-on: ubuntu-24.04
+    steps:
+      - name: checkout release tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          persist-credentials: false
+      - name: check for a complete Dylint tool release
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(jq -er .dylintVersion crates/pina_cli/lints.json)"
+          tag="dylint-v${version}"
+          {
+            echo "commit=$(git rev-parse HEAD)"
+            echo "version=$version"
+            echo "tag=$tag"
+          } >> "$GITHUB_OUTPUT"
+
+          if ! release="$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$tag" 2>/dev/null)"; then
+            echo "No $tag release exists; native Dylint tools will be built."
+            echo "required=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$(jq -r .draft <<< "$release")" != false ]; then
+            echo "::error::The existing $tag release is still a draft." >&2
+            exit 1
+          fi
+          while IFS= read -r target; do
+            asset="pina-dylint-tools-${target}-v${version}.tar.gz"
+            jq -e --arg asset "$asset" \
+              'any(.assets[]; .name == $asset and ((.digest // "") | startswith("sha256:")))' \
+              <<< "$release" >/dev/null || {
+                echo "::error::The existing $tag release is missing verified asset $asset." >&2
+                exit 1
+              }
+          done < <(jq -r '.targets[]' crates/pina_cli/lints.json)
+          echo "The complete $tag release already exists; no Dylint tools will be rebuilt."
+          echo "required=false" >> "$GITHUB_OUTPUT"
+
+  build_dylint_tools:
+    name: build Dylint tools ${{ matrix.target }}
+    needs: prepare_dylint_tools
+    if: needs.prepare_dylint_tools.outputs.required == 'true'
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
+          - target: aarch64-apple-darwin
+            os: macos-15
+          - target: aarch64-pc-windows-msvc
+            os: windows-11-arm
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-24.04
+          - target: x86_64-apple-darwin
+            os: macos-15-intel
+          - target: x86_64-pc-windows-msvc
+            os: windows-2025
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    steps:
+      - name: checkout release tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          persist-credentials: false
+      - name: install stable Rust
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: stable
+      - name: setup node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          package-manager-cache: false
+      - name: build native Dylint tools
+        env:
+          DYLINT_TARGET: ${{ matrix.target }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          node scripts/lints/build-dylint-tools.mjs \
+            --target "$DYLINT_TARGET" \
+            --output-dir "$RUNNER_TEMP/dylint-assets"
+      - name: upload native Dylint tools
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: dylint-tools-${{ matrix.target }}
+          path: ${{ runner.temp }}/dylint-assets/*.tar.gz
+          if-no-files-found: error
+
+  build_musl_dylint_tools:
+    name: build Dylint tools ${{ matrix.target }}
+    needs: prepare_dylint_tools
+    if: needs.prepare_dylint_tools.outputs.required == 'true'
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-24.04-arm
+            rustup-sha256: a97c8f56d7462908695348dd8c71ea6740c138ce303715793a690503a94fc9a9
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-24.04
+            rustup-sha256: e6599a1c7be58a2d8eaca66a80e0dc006d87bbcf780a58b7343d6e14c1605cb2
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    steps:
+      - name: checkout release tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          persist-credentials: false
+      - name: build native musl Dylint tools
+        env:
+          DYLINT_TARGET: ${{ matrix.target }}
+          RUSTUP_SHA256: ${{ matrix.rustup-sha256 }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/dylint-assets"
+          docker run --rm \
+            --env DYLINT_TARGET \
+            --env RUSTUP_SHA256 \
+            --volume "$GITHUB_WORKSPACE:/workspace" \
+            --volume "$RUNNER_TEMP/dylint-assets:/dylint-assets" \
+            --workdir /workspace \
+            alpine@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1 \
+            sh -euc '
+              apk add --no-cache bash build-base ca-certificates cmake curl nodejs openssl-dev perl pkgconf
+              rustup_url="https://static.rust-lang.org/rustup/archive/1.28.2/$DYLINT_TARGET/rustup-init"
+              curl --proto "=https" --tlsv1.2 -sSf "$rustup_url" -o /tmp/rustup-init
+              echo "$RUSTUP_SHA256  /tmp/rustup-init" | sha256sum -c -
+              chmod +x /tmp/rustup-init
+              /tmp/rustup-init -y --profile minimal --default-toolchain stable
+              . "$HOME/.cargo/env"
+              node scripts/lints/build-dylint-tools.mjs \
+                --target "$DYLINT_TARGET" \
+                --output-dir /dylint-assets
+            '
+      - name: upload native musl Dylint tools
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: dylint-tools-${{ matrix.target }}
+          path: ${{ runner.temp }}/dylint-assets/*.tar.gz
+          if-no-files-found: error
+
+  build_freebsd_dylint_tools:
+    name: build Dylint tools x86_64-unknown-freebsd
+    needs: prepare_dylint_tools
+    if: needs.prepare_dylint_tools.outputs.required == 'true'
+    permissions:
+      contents: read
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - name: checkout release tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          persist-credentials: false
+      - name: build native FreeBSD Dylint tools
+        uses: vmactions/freebsd-vm@f0552d3b69211736abd97f02ff3d4674c56b73b1 # v1.5.5
+        with:
+          release: "15.1"
+          usesh: true
+          prepare: pkg install -y cmake curl node24 pkgconf
+          run: |
+            set -euo pipefail
+            rustup_url='https://static.rust-lang.org/rustup/archive/1.28.2/x86_64-unknown-freebsd/rustup-init'
+            curl --proto '=https' --tlsv1.2 -sSf "$rustup_url" -o /tmp/rustup-init
+            test "$(sha256 -q /tmp/rustup-init)" = '4d9fef2e40731489f3186c61a0f178d54d79864fe3d34791edf5b17f70074956'
+            chmod +x /tmp/rustup-init
+            /tmp/rustup-init -y --profile minimal --default-toolchain stable
+            . "$HOME/.cargo/env"
+            node scripts/lints/build-dylint-tools.mjs \
+              --target x86_64-unknown-freebsd \
+              --output-dir ./dylint-assets
+      - name: upload native FreeBSD Dylint tools
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: dylint-tools-x86_64-unknown-freebsd
+          path: dylint-assets/*.tar.gz
+          if-no-files-found: error
+
+  publish_dylint_tools:
+    name: publish or reuse Dylint tools
+    needs:
+      - prepare_dylint_tools
+      - build_dylint_tools
+      - build_musl_dylint_tools
+      - build_freebsd_dylint_tools
+    if: >-
+      always() &&
+      needs.prepare_dylint_tools.result == 'success' &&
+      (needs.prepare_dylint_tools.outputs.required == 'false' ||
+        (needs.build_dylint_tools.result == 'success' &&
+          needs.build_musl_dylint_tools.result == 'success' &&
+          needs.build_freebsd_dylint_tools.result == 'success'))
+    permissions:
+      actions: read # Download the matrix-built Dylint archives.
+      attestations: write # Record provenance for newly built Dylint archives.
+      contents: write # Create or inspect the versioned Dylint release.
+      id-token: write # Exchange GitHub's OIDC identity for attestations.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: checkout release tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          persist-credentials: false
+      - name: download newly built Dylint tools
+        if: needs.prepare_dylint_tools.outputs.required == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: dylint-tools-*
+          path: ${{ runner.temp }}/dylint-assets
+          merge-multiple: true
+      - name: download existing Dylint tools
+        if: needs.prepare_dylint_tools.outputs.required == 'false'
+        env:
+          DYLINT_TAG: ${{ needs.prepare_dylint_tools.outputs.tag }}
+          DYLINT_VERSION: ${{ needs.prepare_dylint_tools.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/dylint-assets"
+          gh release download "$DYLINT_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern "pina-dylint-tools-*-v${DYLINT_VERSION}.tar.gz" \
+            --dir "$RUNNER_TEMP/dylint-assets"
+      - name: validate Dylint tool matrix
+        env:
+          DYLINT_VERSION: ${{ needs.prepare_dylint_tools.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          asset_dir="$RUNNER_TEMP/dylint-assets"
+          while IFS= read -r target; do
+            test -f "$asset_dir/pina-dylint-tools-${target}-v${DYLINT_VERSION}.tar.gz"
+          done < <(jq -r '.targets[]' crates/pina_cli/lints.json)
+          expected_count="$(jq '.targets | length' crates/pina_cli/lints.json)"
+          actual_count="$(find "$asset_dir" -maxdepth 1 -type f -name '*.tar.gz' | wc -l | tr -d ' ')"
+          test "$actual_count" = "$expected_count"
+          sha256sum "$asset_dir"/*.tar.gz
+      - name: attest newly built Dylint tools
+        if: needs.prepare_dylint_tools.outputs.required == 'true'
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: ${{ runner.temp }}/dylint-assets/*.tar.gz
+      - name: create Dylint tool release
+        if: needs.prepare_dylint_tools.outputs.required == 'true'
+        env:
+          DYLINT_COMMIT: ${{ needs.prepare_dylint_tools.outputs.commit }}
+          DYLINT_TAG: ${{ needs.prepare_dylint_tools.outputs.tag }}
+          DYLINT_VERSION: ${{ needs.prepare_dylint_tools.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh release create "$DYLINT_TAG" "$RUNNER_TEMP/dylint-assets"/*.tar.gz \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$DYLINT_COMMIT" \
+            --title "Dylint $DYLINT_VERSION tools for Pina" \
+            --notes "Precompiled cargo-dylint and dylint-link $DYLINT_VERSION tools used by Pina releases. Each archive is target-native, SHA-256 identified by GitHub, and covered by a GitHub build-provenance attestation." \
+            --latest=false
+      - name: verify Dylint tool attestations
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          for archive in "$RUNNER_TEMP/dylint-assets"/*.tar.gz; do
+            verified=false
+            for attempt in 1 2 3 4 5; do
+              if gh attestation verify "$archive" --repo "$GITHUB_REPOSITORY"; then
+                verified=true
+                break
+              fi
+              echo "Attestation for $archive is not available yet (attempt $attempt/5)."
+              sleep 10
+            done
+            if [ "$verified" != true ]; then
+              echo "::error::Failed to verify attestation for $archive" >&2
+              exit 1
+            fi
+          done
+
   upload_assets:
     name: build ${{ matrix.target }}
     if: >-
@@ -39,9 +351,9 @@ jobs:
       startsWith(inputs.tag || github.ref_name, 'v')
     # Upload native archives to the draft release and attest their provenance.
     permissions:
-      attestations: write
-      contents: write
-      id-token: write
+      attestations: write # Record provenance for the native CLI archives.
+      contents: write # Upload archives and checksums to the draft release.
+      id-token: write # Exchange GitHub's OIDC identity for an attestation.
     strategy:
       fail-fast: false
       matrix:
@@ -125,17 +437,328 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           checksum: sha256,sha512
 
+  upload_lint_bundles:
+    name: build lints ${{ matrix.target }}
+    needs:
+      - prepare_dylint_tools
+      - publish_dylint_tools
+    if: >-
+      github.repository_owner == 'pina-rs' &&
+      startsWith(inputs.tag || github.ref_name, 'v')
+    # Upload the completed native bundle to the draft release.
+    permissions:
+      contents: write # Upload the native lint bundle to the draft release.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
+          - target: aarch64-apple-darwin
+            os: macos-15
+          - target: aarch64-pc-windows-msvc
+            os: windows-11-arm
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-24.04
+          - target: x86_64-apple-darwin
+            os: macos-15-intel
+          - target: x86_64-pc-windows-msvc
+            os: windows-2025
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    steps:
+      - name: wait for draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Waiting for the draft release $RELEASE_TAG to be created by the release-pr tag job..."
+          for attempt in $(seq 1 30); do
+            if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+              echo "Draft release $RELEASE_TAG exists after $attempt attempt(s)."
+              exit 0
+            fi
+            echo "  attempt $attempt/30: release not found yet; sleeping 10s"
+            sleep 10
+          done
+          echo "::error::Release $RELEASE_TAG was not created within the wait window. Check the release-pr tag job." >&2
+          exit 1
+      - name: checkout release tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: install lint toolchain
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: nightly-2026-02-20
+          components: rustc-dev
+      - name: setup node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          package-manager-cache: false
+      - name: download verified Dylint tools
+        env:
+          DYLINT_TAG: ${{ needs.prepare_dylint_tools.outputs.tag }}
+          DYLINT_TARGET: ${{ matrix.target }}
+          DYLINT_VERSION: ${{ needs.prepare_dylint_tools.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          asset="pina-dylint-tools-${DYLINT_TARGET}-v${DYLINT_VERSION}.tar.gz"
+          tools_dir="$RUNNER_TEMP/dylint-tools"
+          mkdir -p "$tools_dir"
+          gh release download "$DYLINT_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern "$asset" \
+            --dir "$tools_dir"
+          gh attestation verify "$tools_dir/$asset" --repo "$GITHUB_REPOSITORY"
+          tar -xzf "$tools_dir/$asset" -C "$tools_dir"
+          echo "$tools_dir" >> "$GITHUB_PATH"
+      - name: build native lint bundle
+        env:
+          LINT_TARGET: ${{ matrix.target }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          node scripts/lints/build-bundle.mjs \
+            --target "$LINT_TARGET" \
+            --release-tag "$RELEASE_TAG" \
+            --output-dir "$RUNNER_TEMP/lint-assets"
+      - name: upload native lint bundle
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LINT_TARGET: ${{ matrix.target }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          asset="$RUNNER_TEMP/lint-assets/pina-lints-${LINT_TARGET}-${RELEASE_TAG}.tar.gz"
+          test -f "$asset"
+          gh release upload "$RELEASE_TAG" "$asset" \
+            --clobber \
+            --repo "$GITHUB_REPOSITORY"
+
+  upload_musl_lint_bundles:
+    name: build lints ${{ matrix.target }}
+    needs:
+      - prepare_dylint_tools
+      - publish_dylint_tools
+    if: >-
+      github.repository_owner == 'pina-rs' &&
+      startsWith(inputs.tag || github.ref_name, 'v')
+    # Upload the completed native bundle to the draft release.
+    permissions:
+      contents: write # Upload the native musl lint bundle to the draft release.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-24.04-arm
+            rustup-sha256: a97c8f56d7462908695348dd8c71ea6740c138ce303715793a690503a94fc9a9
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-24.04
+            rustup-sha256: e6599a1c7be58a2d8eaca66a80e0dc006d87bbcf780a58b7343d6e14c1605cb2
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    steps:
+      - name: wait for draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Waiting for the draft release $RELEASE_TAG to be created by the release-pr tag job..."
+          for attempt in $(seq 1 30); do
+            if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+              echo "Draft release $RELEASE_TAG exists after $attempt attempt(s)."
+              exit 0
+            fi
+            echo "  attempt $attempt/30: release not found yet; sleeping 10s"
+            sleep 10
+          done
+          echo "::error::Release $RELEASE_TAG was not created within the wait window. Check the release-pr tag job." >&2
+          exit 1
+      - name: checkout release tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: download verified musl Dylint tools
+        env:
+          DYLINT_TAG: ${{ needs.prepare_dylint_tools.outputs.tag }}
+          DYLINT_TARGET: ${{ matrix.target }}
+          DYLINT_VERSION: ${{ needs.prepare_dylint_tools.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          asset="pina-dylint-tools-${DYLINT_TARGET}-v${DYLINT_VERSION}.tar.gz"
+          mkdir -p "$RUNNER_TEMP/lint-assets"
+          gh release download "$DYLINT_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern "$asset" \
+            --dir "$RUNNER_TEMP/lint-assets"
+          gh attestation verify "$RUNNER_TEMP/lint-assets/$asset" --repo "$GITHUB_REPOSITORY"
+      - name: build native musl lint bundle
+        env:
+          DYLINT_VERSION: ${{ needs.prepare_dylint_tools.outputs.version }}
+          LINT_TARGET: ${{ matrix.target }}
+          RUSTUP_SHA256: ${{ matrix.rustup-sha256 }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/lint-assets"
+          docker run --rm \
+            --env DYLINT_VERSION \
+            --env LINT_TARGET \
+            --env RELEASE_TAG \
+            --env RUSTUP_SHA256 \
+            --volume "$GITHUB_WORKSPACE:/workspace" \
+            --volume "$RUNNER_TEMP/lint-assets:/lint-assets" \
+            --workdir /workspace \
+            alpine@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1 \
+            sh -euc '
+              apk add --no-cache bash build-base ca-certificates cmake curl nodejs openssl-dev perl pkgconf
+              rustup_url="https://static.rust-lang.org/rustup/archive/1.28.2/$LINT_TARGET/rustup-init"
+              curl --proto "=https" --tlsv1.2 -sSf "$rustup_url" -o /tmp/rustup-init
+              echo "$RUSTUP_SHA256  /tmp/rustup-init" | sha256sum -c -
+              chmod +x /tmp/rustup-init
+              /tmp/rustup-init -y --profile minimal --default-toolchain nightly-2026-02-20
+              . "$HOME/.cargo/env"
+              rustup component add rustc-dev
+              asset="/lint-assets/pina-dylint-tools-${LINT_TARGET}-v${DYLINT_VERSION}.tar.gz"
+              mkdir -p /tmp/dylint-tools
+              tar -xzf "$asset" -C /tmp/dylint-tools
+              export PATH="/tmp/dylint-tools:$PATH"
+              node scripts/lints/build-bundle.mjs \
+                --target "$LINT_TARGET" \
+                --release-tag "$RELEASE_TAG" \
+                --output-dir /lint-assets
+            '
+      - name: upload native musl lint bundle
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LINT_TARGET: ${{ matrix.target }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          asset="$RUNNER_TEMP/lint-assets/pina-lints-${LINT_TARGET}-${RELEASE_TAG}.tar.gz"
+          test -f "$asset"
+          gh release upload "$RELEASE_TAG" "$asset" \
+            --clobber \
+            --repo "$GITHUB_REPOSITORY"
+
+  upload_freebsd_lint_bundle:
+    name: build lints x86_64-unknown-freebsd
+    needs:
+      - prepare_dylint_tools
+      - publish_dylint_tools
+    if: >-
+      github.repository_owner == 'pina-rs' &&
+      startsWith(inputs.tag || github.ref_name, 'v')
+    # Upload the completed native bundle to the draft release.
+    permissions:
+      contents: write # Upload the native FreeBSD lint bundle to the draft release.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    steps:
+      - name: wait for draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Waiting for the draft release $RELEASE_TAG to be created by the release-pr tag job..."
+          for attempt in $(seq 1 30); do
+            if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+              echo "Draft release $RELEASE_TAG exists after $attempt attempt(s)."
+              exit 0
+            fi
+            echo "  attempt $attempt/30: release not found yet; sleeping 10s"
+            sleep 10
+          done
+          echo "::error::Release $RELEASE_TAG was not created within the wait window. Check the release-pr tag job." >&2
+          exit 1
+      - name: checkout release tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: download verified FreeBSD Dylint tools
+        env:
+          DYLINT_TAG: ${{ needs.prepare_dylint_tools.outputs.tag }}
+          DYLINT_VERSION: ${{ needs.prepare_dylint_tools.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          asset="pina-dylint-tools-x86_64-unknown-freebsd-v${DYLINT_VERSION}.tar.gz"
+          mkdir -p lint-assets
+          gh release download "$DYLINT_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern "$asset" \
+            --dir lint-assets
+          gh attestation verify "lint-assets/$asset" --repo "$GITHUB_REPOSITORY"
+      - name: build native FreeBSD lint bundle
+        env:
+          DYLINT_VERSION: ${{ needs.prepare_dylint_tools.outputs.version }}
+        uses: vmactions/freebsd-vm@f0552d3b69211736abd97f02ff3d4674c56b73b1 # v1.5.5
+        with:
+          release: "15.1"
+          usesh: true
+          envs: RELEASE_TAG DYLINT_VERSION
+          prepare: pkg install -y cmake curl node24 pkgconf
+          run: |
+            set -euo pipefail
+            rustup_url='https://static.rust-lang.org/rustup/archive/1.28.2/x86_64-unknown-freebsd/rustup-init'
+            curl --proto '=https' --tlsv1.2 -sSf "$rustup_url" -o /tmp/rustup-init
+            test "$(sha256 -q /tmp/rustup-init)" = '4d9fef2e40731489f3186c61a0f178d54d79864fe3d34791edf5b17f70074956'
+            chmod +x /tmp/rustup-init
+            /tmp/rustup-init -y --profile minimal --default-toolchain nightly-2026-02-20
+            . "$HOME/.cargo/env"
+            rustup component add rustc-dev
+            asset="lint-assets/pina-dylint-tools-x86_64-unknown-freebsd-v${DYLINT_VERSION}.tar.gz"
+            mkdir -p /tmp/dylint-tools
+            tar -xzf "$asset" -C /tmp/dylint-tools
+            export PATH="/tmp/dylint-tools:$PATH"
+            node scripts/lints/build-bundle.mjs \
+              --target x86_64-unknown-freebsd \
+              --release-tag "$RELEASE_TAG" \
+              --output-dir ./lint-assets
+      - name: upload native FreeBSD lint bundle
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          asset="lint-assets/pina-lints-x86_64-unknown-freebsd-${RELEASE_TAG}.tar.gz"
+          test -f "$asset"
+          gh release upload "$RELEASE_TAG" "$asset" \
+            --clobber \
+            --repo "$GITHUB_REPOSITORY"
+
   attest_assets:
     name: attest release assets
     if: >-
       github.repository_owner == 'pina-rs' &&
       startsWith(inputs.tag || github.ref_name, 'v')
-    needs: upload_assets
+    needs:
+      - upload_assets
+      - upload_lint_bundles
+      - upload_musl_lint_bundles
+      - upload_freebsd_lint_bundle
     # Read release archives, then attach OIDC-backed provenance attestations.
     permissions:
-      attestations: write
-      contents: write
-      id-token: write
+      attestations: write # Record provenance for every release asset.
+      contents: write # Download assets from the draft release for verification.
+      id-token: write # Exchange GitHub's OIDC identity for an attestation.
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -195,8 +818,8 @@ jobs:
     environment: publisher
     # Use OIDC for registry publishing, then publish the draft GitHub release.
     permissions:
-      contents: write
-      id-token: write
+      contents: write # Publish the draft GitHub release after registry publication.
+      id-token: write # Authenticate to crates.io and npm trusted publishing.
     if: >-
       github.repository_owner == 'pina-rs' &&
       startsWith(inputs.tag || github.ref_name, 'v')

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,7 @@ jobs:
       commit: ${{ steps.release.outputs.commit }}
       required: ${{ steps.release.outputs.required }}
       tag: ${{ steps.release.outputs.tag }}
+      toolchain: ${{ steps.release.outputs.toolchain }}
       version: ${{ steps.release.outputs.version }}
     permissions:
       contents: read # Inspect the versioned Dylint tool release.
@@ -59,9 +60,11 @@ jobs:
         run: |
           set -euo pipefail
           version="$(jq -er .dylintVersion crates/pina_cli/lints.json)"
+          toolchain="$(jq -er .toolchain crates/pina_cli/lints.json)"
           tag="dylint-v${version}"
           {
             echo "commit=$(git rev-parse HEAD)"
+            echo "toolchain=$toolchain"
             echo "version=$version"
             echo "tag=$tag"
           } >> "$GITHUB_OUTPUT"
@@ -447,6 +450,7 @@ jobs:
       startsWith(inputs.tag || github.ref_name, 'v')
     # Upload the completed native bundle to the draft release.
     permissions:
+      attestations: read # Verify the downloaded Dylint tool provenance.
       contents: write # Upload the native lint bundle to the draft release.
     strategy:
       fail-fast: false
@@ -493,7 +497,7 @@ jobs:
       - name: install lint toolchain
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
-          toolchain: nightly-2026-02-20
+          toolchain: ${{ needs.prepare_dylint_tools.outputs.toolchain }}
           components: rustc-dev
       - name: setup node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -552,6 +556,7 @@ jobs:
       startsWith(inputs.tag || github.ref_name, 'v')
     # Upload the completed native bundle to the draft release.
     permissions:
+      attestations: read # Verify the downloaded Dylint tool provenance.
       contents: write # Upload the native musl lint bundle to the draft release.
     strategy:
       fail-fast: false
@@ -608,6 +613,7 @@ jobs:
       - name: build native musl lint bundle
         env:
           DYLINT_VERSION: ${{ needs.prepare_dylint_tools.outputs.version }}
+          LINT_TOOLCHAIN: ${{ needs.prepare_dylint_tools.outputs.toolchain }}
           LINT_TARGET: ${{ matrix.target }}
           RUSTUP_SHA256: ${{ matrix.rustup-sha256 }}
         shell: bash
@@ -616,6 +622,7 @@ jobs:
           mkdir -p "$RUNNER_TEMP/lint-assets"
           docker run --rm \
             --env DYLINT_VERSION \
+            --env LINT_TOOLCHAIN \
             --env LINT_TARGET \
             --env RELEASE_TAG \
             --env RUSTUP_SHA256 \
@@ -629,7 +636,7 @@ jobs:
               curl --proto "=https" --tlsv1.2 -sSf "$rustup_url" -o /tmp/rustup-init
               echo "$RUSTUP_SHA256  /tmp/rustup-init" | sha256sum -c -
               chmod +x /tmp/rustup-init
-              /tmp/rustup-init -y --profile minimal --default-toolchain nightly-2026-02-20
+              /tmp/rustup-init -y --profile minimal --default-toolchain "$LINT_TOOLCHAIN"
               . "$HOME/.cargo/env"
               rustup component add rustc-dev
               asset="/lint-assets/pina-dylint-tools-${LINT_TARGET}-v${DYLINT_VERSION}.tar.gz"
@@ -664,6 +671,7 @@ jobs:
       startsWith(inputs.tag || github.ref_name, 'v')
     # Upload the completed native bundle to the draft release.
     permissions:
+      attestations: read # Verify the downloaded Dylint tool provenance.
       contents: write # Upload the native FreeBSD lint bundle to the draft release.
     runs-on: ubuntu-24.04
     timeout-minutes: 90
@@ -709,11 +717,12 @@ jobs:
       - name: build native FreeBSD lint bundle
         env:
           DYLINT_VERSION: ${{ needs.prepare_dylint_tools.outputs.version }}
+          LINT_TOOLCHAIN: ${{ needs.prepare_dylint_tools.outputs.toolchain }}
         uses: vmactions/freebsd-vm@f0552d3b69211736abd97f02ff3d4674c56b73b1 # v1.5.5
         with:
           release: "15.1"
           usesh: true
-          envs: RELEASE_TAG DYLINT_VERSION
+          envs: RELEASE_TAG DYLINT_VERSION LINT_TOOLCHAIN
           prepare: pkg install -y cmake curl node24 pkgconf
           run: |
             set -euo pipefail
@@ -721,7 +730,7 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf "$rustup_url" -o /tmp/rustup-init
             test "$(sha256 -q /tmp/rustup-init)" = '4d9fef2e40731489f3186c61a0f178d54d79864fe3d34791edf5b17f70074956'
             chmod +x /tmp/rustup-init
-            /tmp/rustup-init -y --profile minimal --default-toolchain nightly-2026-02-20
+            /tmp/rustup-init -y --profile minimal --default-toolchain "$LINT_TOOLCHAIN"
             . "$HOME/.cargo/env"
             rustup component add rustc-dev
             asset="lint-assets/pina-dylint-tools-x86_64-unknown-freebsd-v${DYLINT_VERSION}.tar.gz"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -285,7 +285,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1001,7 +1001,7 @@ checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1029,6 +1029,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "cookie"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a373e3602691c3cdea496d2f0ee5935151e6168fe87739483c463db1b2f2f87"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -1396,6 +1425,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1661,7 +1696,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1722,6 +1757,16 @@ name = "fiat-crypto"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -1953,6 +1998,12 @@ dependencies = [
  "bytes",
  "itoa",
 ]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
@@ -2377,7 +2428,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2502,6 +2553,12 @@ dependencies = [
  "autocfg",
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -2771,10 +2828,12 @@ dependencies = [
  "sha2 0.11.0",
  "solana-address",
  "syn 3.0.3",
+ "tar",
  "tempfile",
  "termimad",
  "thiserror 2.0.20",
  "toml 1.1.4+spec-1.1.0",
+ "ureq",
  "url",
  "walkdir",
 ]
@@ -2934,6 +2993,12 @@ checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -3252,6 +3317,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "role-registry-program-client"
 version = "0.0.0"
 dependencies = [
@@ -3303,7 +3382,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -3643,7 +3757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4799,6 +4913,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-triple"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4814,7 +4939,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4892,6 +5017,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4952,7 +5107,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5147,6 +5302,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
+dependencies = [
+ "base64 0.23.1",
+ "cookie_store",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
+dependencies = [
+ "base64 0.23.1",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5157,6 +5350,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -5245,6 +5444,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5266,7 +5474,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5308,12 +5516,85 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -5352,6 +5633,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,12 +142,14 @@ solana-pubkey = { version = "^4", features = ["bytemuck"], default-features = fa
 solana-sdk-ids = { version = "^3", default-features = false }
 solana-system-interface = { version = "^3", default-features = false }
 syn = { default-features = false, version = "^3", features = ["full"] }
+tar = { default-features = false, version = "^0.4" }
 tempfile = { default-features = false, version = "^3" }
 termimad = { default-features = false, version = "^0.35.1" }
 thiserror = { default-features = false, version = "^2" }
 tokio = { default-features = false, version = "^1" }
 toml = { default-features = false, version = "^1", features = ["parse", "serde"] }
 trybuild = { default-features = false, version = "^1" }
+ureq = { default-features = false, version = "^3", features = ["json", "rustls"] }
 url = { default-features = false, version = "^2.5.4" }
 walkdir = { default-features = false, version = "^2" }
 zeropod = { default-features = false, version = "0.3.5", features = ["solana-address", "solana-program-error"] }

--- a/crates/pina_cli/Cargo.toml
+++ b/crates/pina_cli/Cargo.toml
@@ -43,10 +43,12 @@ serde_json = { workspace = true, default-features = true }
 sha2 = { workspace = true, default-features = true }
 solana-address = { workspace = true, default-features = true }
 syn = { workspace = true, default-features = true, features = ["full", "extra-traits", "visit", "printing"] }
+tar = { workspace = true, default-features = true }
 tempfile = { workspace = true, default-features = true }
 termimad = { workspace = true, default-features = true }
 thiserror = { workspace = true, default-features = true }
 toml = { workspace = true, default-features = true }
+ureq = { workspace = true, default-features = true }
 url = { workspace = true, default-features = true }
 walkdir = { workspace = true, default-features = true }
 

--- a/crates/pina_cli/build.rs
+++ b/crates/pina_cli/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+	let target = std::env::var("TARGET").unwrap_or_else(|error| {
+		panic!("Cargo did not define TARGET for the build script: {error}")
+	});
+	println!("cargo:rustc-env=PINA_BUILD_TARGET={target}");
+}

--- a/crates/pina_cli/lints.json
+++ b/crates/pina_cli/lints.json
@@ -1,0 +1,39 @@
+{
+	"schemaVersion": 1,
+	"dylintVersion": "6.0.4",
+	"toolchain": "nightly-2026-02-20",
+	"targets": [
+		"aarch64-unknown-linux-gnu",
+		"aarch64-unknown-linux-musl",
+		"aarch64-apple-darwin",
+		"aarch64-pc-windows-msvc",
+		"x86_64-unknown-linux-gnu",
+		"x86_64-unknown-linux-musl",
+		"x86_64-apple-darwin",
+		"x86_64-pc-windows-msvc",
+		"x86_64-unknown-freebsd"
+	],
+	"libraries": [
+		"deny_account_borrows_across_cpi",
+		"deny_heap_allocations_in_onchain_instruction_handlers",
+		"require_associated_token_address_before_ata_cast",
+		"require_bounded_remaining_accounts",
+		"require_canonical_bump_before_pda_write",
+		"require_canonical_instruction_dispatch_for_idl",
+		"require_checked_asset_arithmetic",
+		"require_consistent_token_program",
+		"require_empty_before_init",
+		"require_explicit_discriminators_and_seed_namespaces",
+		"require_explicit_token_2022_extension_policy",
+		"require_idl_root_to_define_one_program_id",
+		"require_owner_before_token_cast",
+		"require_post_cpi_balance_reload",
+		"require_program_check_before_cpi",
+		"require_program_owned_before_lamport_mutation",
+		"require_reason_for_duplicate_remaining_accounts",
+		"require_sysvar_assert_before_sysvar_use",
+		"require_type_assert_before_zero_copy_cast",
+		"require_writable_before_account_resize",
+		"require_zeroed_before_close"
+	]
+}

--- a/crates/pina_cli/readme.md
+++ b/crates/pina_cli/readme.md
@@ -120,11 +120,11 @@ pina init my_program
 pina init my_program --path ./programs/my_program --force
 ```
 
-Generated manifests register the immutable-revision official Pina lint set and its pinned Dylint tool versions.
+Generated manifests do not install Dylint or register a source repository for native lint code. `pina lint` owns the pinned tool and library downloads.
 
 ### `pina lint`
 
-Discover the current program and run Pina's official security lints. The first invocation prepares project-local pinned Dylint tools; fix mode applies only machine-applicable suggestions.
+Discover the current program and run Pina's official security lints. The first invocation downloads the pinned, precompiled Dylint tools and verified native bundle; fix mode applies only machine-applicable suggestions.
 
 ```bash
 pina lint

--- a/crates/pina_cli/src/cli.rs
+++ b/crates/pina_cli/src/cli.rs
@@ -101,14 +101,13 @@ pub(crate) enum Commands {
 	/// Run Pina's official security lints against the current program.
 	///
 	/// Discovers the nearest Pina.toml or Cargo package, prepares pinned Dylint
-	/// tools under Cargo home, and runs the lint set from the immutable revision
-	/// reviewed for this CLI. Use --fix to apply machine-applicable suggestions;
+	/// tooling under Cargo home, and runs the precompiled lint bundle published
+	/// with this CLI release. Use --fix to apply machine-applicable suggestions;
 	/// review every resulting source change.
 	#[command(
 		after_help = "Examples:\n  pina lint\n  pina lint --fix\n  pina lint --project \
-		              ./programs/counter\n\nTooling:\n  The first run installs pinned \
-		              cargo-dylint and dylint-link binaries below Cargo home. Lint libraries are \
-		              loaded from the immutable Pina revision reviewed for this CLI. --fix \
+		              ./programs/counter\n\nTooling:\n  The first run downloads verified, \
+		              precompiled cargo-dylint and native lint bundles below Cargo home. --fix \
 		              applies only machine-applicable suggestions and allows Cargo to edit dirty, \
 		              staged, or not-yet-versioned working trees; inspect the diff before \
 		              committing."

--- a/crates/pina_cli/src/commands.rs
+++ b/crates/pina_cli/src/commands.rs
@@ -966,7 +966,10 @@ mod tests {
 
 	fn record_options(temp: &TempDir, confirmed: bool) -> pina_cli::verification::RecordOptions {
 		let artifact_bytes = vec![7_u8; 128];
-		let hash = Sha256::digest(&artifact_bytes).iter().map(|byte| format!("{byte:02x}")).collect::<String>();
+		let hash = Sha256::digest(&artifact_bytes)
+			.iter()
+			.map(|byte| format!("{byte:02x}"))
+			.collect::<String>();
 		let record_dir = temp.path().join("record with spaces");
 		fs::create_dir_all(&record_dir).unwrap();
 		let record = record_dir.join(format!("fixture-{hash}.json"));

--- a/crates/pina_cli/src/init.rs
+++ b/crates/pina_cli/src/init.rs
@@ -4,10 +4,6 @@ use std::path::PathBuf;
 
 use heck::ToUpperCamelCase;
 
-use crate::lint::CARGO_DYLINT_VERSION;
-use crate::lint::DYLINT_LINK_VERSION;
-use crate::lint::PINA_LINT_REVISION;
-
 // A non-system placeholder keeps the generated Surfpool deployment executable.
 // Users must still replace it before sharing or deploying the project.
 const PLACEHOLDER_PROGRAM_ID: &str = "Fg6PaFpoGXkYsidMpWxTWqkZkkM8NufCHCX9ddLKBqd7";
@@ -169,15 +165,6 @@ publish = false
 
 [workspace.metadata.cli]
 solana = "3.0.0"
-
-[workspace.metadata.bin]
-cargo-dylint = {{ version = "{CARGO_DYLINT_VERSION}", bins = ["cargo-dylint"] }}
-dylint-link = {{ version = "{DYLINT_LINK_VERSION}", bins = ["dylint-link"] }}
-
-[workspace.metadata.dylint]
-libraries = [
-	{{ git = "https://github.com/pina-rs/pina", rev = "{PINA_LINT_REVISION}", pattern = "lints/*" }},
-]
 
 [lib]
 crate-type = ["cdylib", "lib"]
@@ -649,13 +636,10 @@ mod tests {
 		assert!(cargo.contains("cpi = []"));
 		assert!(cargo.contains("[workspace.metadata.cli]"));
 		assert!(cargo.contains("solana = \"3.0.0\""));
-		assert!(cargo.contains("[workspace.metadata.bin]"));
-		assert!(cargo.contains("cargo-dylint = { version = \"6.0.4\""));
-		assert!(cargo.contains("dylint-link = { version = \"6.0.4\""));
-		assert!(cargo.contains("[workspace.metadata.dylint]"));
-		assert!(cargo.contains("git = \"https://github.com/pina-rs/pina\""));
-		assert!(cargo.contains(&format!("rev = \"{PINA_LINT_REVISION}\"")));
-		assert!(cargo.contains("pattern = \"lints/*\""));
+		assert!(!cargo.contains("[workspace.metadata.bin]"));
+		assert!(!cargo.contains("cargo-dylint"));
+		assert!(!cargo.contains("dylint-link"));
+		assert!(!cargo.contains("[workspace.metadata.dylint]"));
 		assert!(cargo.contains("cfg(dylint_lib, values(any()))"));
 		assert!(cargo.contains("mollusk-svm = \"0.15.0\""));
 

--- a/crates/pina_cli/src/lib.rs
+++ b/crates/pina_cli/src/lib.rs
@@ -9,6 +9,7 @@ pub mod init;
 pub mod ir;
 pub mod keys;
 pub mod lint;
+mod lint_bundle;
 pub mod parse;
 mod path_security;
 pub mod profile;

--- a/crates/pina_cli/src/lint.rs
+++ b/crates/pina_cli/src/lint.rs
@@ -1,30 +1,15 @@
 //! Project-aware execution of Pina's official security lints.
 
 use std::ffi::OsString;
-use std::fs::OpenOptions;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 
-use fs2::FileExt;
-
+use crate::lint_bundle::BundleError;
+use crate::lint_bundle::prepare_bundle;
+use crate::lint_bundle::prepare_dylint_tools;
 use crate::project::Project;
 use crate::project::ProjectError;
-
-/// The `cargo-dylint` release used by `pina lint`.
-pub const CARGO_DYLINT_VERSION: &str = "6.0.4";
-
-/// The `dylint-link` release used to build Pina's lint libraries.
-pub const DYLINT_LINK_VERSION: &str = "6.0.4";
-
-/// Immutable Git revision containing Pina's reviewed official lint set.
-///
-/// Update this only after reviewing changes below `lints/`. Unlike a release
-/// tag, a full commit ID cannot be redirected to different native lint code.
-pub const PINA_LINT_REVISION: &str = "f6f206e0a4e71ab70c3eeaded52d07cd66a270d8";
-
-const PINA_REPOSITORY: &str = "https://github.com/pina-rs/pina";
-const PINA_LINT_PATTERN: &str = "lints/*";
 
 /// Options for running Pina's official security lints.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -52,47 +37,14 @@ pub enum LintError {
 	#[error(transparent)]
 	Project(#[from] ProjectError),
 
-	#[error("Could not create the managed Dylint directory at {path}: {source}")]
-	CreateToolDirectory {
-		path: PathBuf,
-		source: std::io::Error,
-	},
+	#[error(transparent)]
+	Bundle(#[from] BundleError),
 
 	#[error("Could not resolve Cargo home for Pina's managed Dylint tools")]
 	MissingCargoHome,
 
 	#[error("Could not resolve relative CARGO_HOME from the current directory: {source}")]
 	CurrentDirectory { source: std::io::Error },
-
-	#[error("Could not open the managed Dylint installation lock at {path}: {source}")]
-	OpenInstallLock {
-		path: PathBuf,
-		source: std::io::Error,
-	},
-
-	#[error("Could not lock the managed Dylint installation at {path}: {source}")]
-	LockInstall {
-		path: PathBuf,
-		source: std::io::Error,
-	},
-
-	#[error("Could not install pinned tool `{package}` with Cargo: {source}")]
-	RunInstall {
-		package: &'static str,
-		source: std::io::Error,
-	},
-
-	#[error("Installing pinned tool `{package}` failed with status {status}")]
-	InstallFailed {
-		package: &'static str,
-		status: String,
-	},
-
-	#[error("Cargo reported success but did not install `{package}` at {path}")]
-	MissingInstalledTool {
-		package: &'static str,
-		path: PathBuf,
-	},
 
 	#[error("Could not construct PATH for the pinned Dylint tools: {source}")]
 	ToolPath { source: std::env::JoinPathsError },
@@ -104,13 +56,12 @@ pub enum LintError {
 	LintFailed { status: String },
 }
 
-/// Discover a Pina project and run Pina's revision-pinned official lint set.
+/// Discover a Pina project and run this CLI release's official lint set.
 ///
-/// The first invocation installs pinned `cargo-dylint` and `dylint-link`
-/// binaries below Cargo home. Later invocations and projects reuse that managed
-/// installation. Lint libraries are loaded from the immutable revision reviewed
-/// for this CLI, not from a mutable branch, tag, or project-provided Dylint
-/// metadata.
+/// The first invocation downloads pinned `cargo-dylint` and the precompiled
+/// libraries below Cargo home. Later invocations and projects reuse the
+/// verified caches. Exact library paths are passed to Dylint, so
+/// project-provided Dylint metadata is ignored.
 ///
 /// # Errors
 ///
@@ -118,22 +69,23 @@ pub enum LintError {
 /// prepared, or Dylint reports a lint or compilation failure.
 pub fn lint_project(options: &LintOptions) -> Result<LintOutput, LintError> {
 	let project = Project::discover(&options.project)?;
-	let tools = prepare_tools(&project)?;
+	let cargo_home = cargo_home()?;
+	let tools = prepare_dylint_tools(&cargo_home)?;
+	let bundle = prepare_bundle(&cargo_home)?;
 	let manifest = project.program_dir.join("Cargo.toml");
 	let mut args = vec![
 		OsString::from("dylint"),
 		OsString::from("--no-deps"),
-		OsString::from("--git"),
-		OsString::from(PINA_REPOSITORY),
-		OsString::from("--rev"),
-		OsString::from(PINA_LINT_REVISION),
-		OsString::from("--pattern"),
-		OsString::from(PINA_LINT_PATTERN),
+		OsString::from("--no-metadata"),
 		OsString::from("--manifest-path"),
 		manifest.into_os_string(),
 		OsString::from("--package"),
 		OsString::from(&project.package_name),
 	];
+	for library_path in bundle.library_paths {
+		args.push(OsString::from("--lib-path"));
+		args.push(library_path.into_os_string());
+	}
 
 	if options.fix {
 		args.push(OsString::from("--fix"));
@@ -161,73 +113,6 @@ pub fn lint_project(options: &LintOptions) -> Result<LintOutput, LintError> {
 	Ok(LintOutput {
 		package_name: project.package_name,
 		fix: options.fix,
-	})
-}
-
-/// Executables installed and selected by Pina rather than project metadata.
-#[derive(Debug)]
-struct Tools {
-	bin_dir: PathBuf,
-	cargo_dylint: PathBuf,
-}
-
-/// Prepare the versioned Dylint tools in a user-owned Cargo-home cache.
-fn prepare_tools(project: &Project) -> Result<Tools, LintError> {
-	let root = cargo_home()?.join("pina/tools").join(format!(
-		"dylint-{CARGO_DYLINT_VERSION}-{DYLINT_LINK_VERSION}"
-	));
-	std::fs::create_dir_all(&root).map_err(|source| {
-		LintError::CreateToolDirectory {
-			path: root.clone(),
-			source,
-		}
-	})?;
-
-	let lock_path = root.join("install.lock");
-	let lock = OpenOptions::new()
-		.read(true)
-		.write(true)
-		.create(true)
-		.truncate(false)
-		.open(&lock_path)
-		.map_err(|source| {
-			LintError::OpenInstallLock {
-				path: lock_path.clone(),
-				source,
-			}
-		})?;
-	lock.try_lock_exclusive().map_err(|source| {
-		LintError::LockInstall {
-			path: lock_path,
-			source,
-		}
-	})?;
-
-	let bin_dir = root.join("bin");
-	let cargo_dylint = bin_dir.join(executable_name("cargo-dylint"));
-	let dylint_link = bin_dir.join(executable_name("dylint-link"));
-	let cargo = std::env::var_os("CARGO").unwrap_or_else(|| OsString::from("cargo"));
-
-	install_tool(
-		&cargo,
-		&project.root,
-		&root,
-		"cargo-dylint",
-		CARGO_DYLINT_VERSION,
-		&cargo_dylint,
-	)?;
-	install_tool(
-		&cargo,
-		&project.root,
-		&root,
-		"dylint-link",
-		DYLINT_LINK_VERSION,
-		&dylint_link,
-	)?;
-
-	Ok(Tools {
-		bin_dir,
-		cargo_dylint,
 	})
 }
 
@@ -280,69 +165,11 @@ fn platform_home() -> Option<PathBuf> {
 		})
 }
 
-/// Install one exact crates.io tool release unless its managed binary exists.
-fn install_tool(
-	cargo: &OsString,
-	project_root: &Path,
-	tool_root: &Path,
-	package: &'static str,
-	version: &'static str,
-	executable: &Path,
-) -> Result<(), LintError> {
-	if executable.is_file() {
-		return Ok(());
-	}
-
-	let build_target = tool_root.join("build").join(package);
-	let status = Command::new(cargo)
-		.args([
-			OsString::from("install"),
-			OsString::from("--locked"),
-			OsString::from("--root"),
-			tool_root.as_os_str().to_owned(),
-			OsString::from("--version"),
-			OsString::from(version),
-			OsString::from(package),
-		])
-		.current_dir(project_root)
-		.env("CARGO_TARGET_DIR", build_target)
-		.status()
-		.map_err(|source| LintError::RunInstall { package, source })?;
-
-	if !status.success() {
-		return Err(LintError::InstallFailed {
-			package,
-			status: status.to_string(),
-		});
-	}
-
-	if !executable.is_file() {
-		return Err(LintError::MissingInstalledTool {
-			package,
-			path: executable.to_path_buf(),
-		});
-	}
-
-	Ok(())
-}
-
 /// Prepend Pina's managed tool directory without discarding the caller's PATH.
 fn tool_path(bin_dir: &Path) -> Result<OsString, LintError> {
 	let current_path = std::env::var_os("PATH").unwrap_or_default();
 	let paths = std::iter::once(bin_dir.to_path_buf()).chain(std::env::split_paths(&current_path));
 	std::env::join_paths(paths).map_err(|source| LintError::ToolPath { source })
-}
-
-#[cfg(windows)]
-/// Return a platform executable filename on Windows.
-fn executable_name(name: &str) -> OsString {
-	OsString::from(format!("{name}.exe"))
-}
-
-#[cfg(not(windows))]
-/// Return a platform executable filename on Unix-like systems.
-fn executable_name(name: &str) -> OsString {
-	OsString::from(name)
 }
 
 #[cfg(test)]

--- a/crates/pina_cli/src/lint_bundle.rs
+++ b/crates/pina_cli/src/lint_bundle.rs
@@ -1,0 +1,1184 @@
+//! Downloading and validating release-built Dylint libraries.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::fs::File;
+use std::fs::OpenOptions;
+use std::io::Cursor;
+use std::io::Read;
+use std::io::Write;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+use std::path::Component;
+use std::path::Path;
+use std::path::PathBuf;
+
+use flate2::read::GzDecoder;
+use fs2::FileExt;
+use serde::Deserialize;
+use sha2::Digest;
+use sha2::Sha256;
+
+const BUNDLE_SCHEMA_VERSION: u32 = 1;
+const MAX_ARCHIVE_BYTES: u64 = 512 * 1024 * 1024;
+const MAX_EXTRACTED_BYTES: u64 = 1024 * 1024 * 1024;
+const PINA_RELEASES_API: &str = "https://api.github.com/repos/pina-rs/pina/releases/tags";
+const PINA_RELEASE_DOWNLOADS: &str = "https://github.com/pina-rs/pina/releases/download";
+const TOOL_NAMES: [&str; 2] = ["cargo-dylint", "dylint-link"];
+
+/// Metadata compiled into the CLI and consumed by the release builder.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct LintCatalog {
+	pub(crate) schema_version: u32,
+	pub(crate) dylint_version: String,
+	pub(crate) toolchain: String,
+	pub(crate) targets: Vec<String>,
+	pub(crate) libraries: Vec<String>,
+}
+
+/// One verified release bundle ready for Dylint.
+#[derive(Debug)]
+pub(crate) struct PreparedBundle {
+	pub(crate) library_paths: Vec<PathBuf>,
+}
+
+/// Verified Dylint executables ready to run from Pina's managed cache.
+#[derive(Debug)]
+pub(crate) struct PreparedTools {
+	pub(crate) bin_dir: PathBuf,
+	pub(crate) cargo_dylint: PathBuf,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct BundleManifest {
+	schema_version: u32,
+	version: String,
+	target: String,
+	toolchain: String,
+	dylint_version: String,
+	libraries: Vec<BundleLibrary>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct BundleLibrary {
+	name: String,
+	file: String,
+	sha256: String,
+	size: u64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ToolManifest {
+	schema_version: u32,
+	dylint_version: String,
+	target: String,
+	executables: Vec<ToolExecutable>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ToolExecutable {
+	name: String,
+	file: String,
+	sha256: String,
+	size: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubRelease {
+	tag_name: String,
+	assets: Vec<GithubAsset>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubAsset {
+	name: String,
+	browser_download_url: String,
+	size: u64,
+	digest: Option<String>,
+}
+
+/// Failures while resolving or validating native lint libraries.
+#[derive(Debug, thiserror::Error)]
+pub enum BundleError {
+	#[error("Could not create the managed lint bundle directory at {path}: {source}")]
+	CreateDirectory {
+		path: PathBuf,
+		source: std::io::Error,
+	},
+
+	#[error("Could not open the managed lint bundle lock at {path}: {source}")]
+	OpenLock {
+		path: PathBuf,
+		source: std::io::Error,
+	},
+
+	#[error("Could not lock the managed lint bundle at {path}: {source}")]
+	Lock {
+		path: PathBuf,
+		source: std::io::Error,
+	},
+
+	#[error("Could not fetch {resource}: {source}")]
+	Http {
+		resource: String,
+		#[source]
+		source: ureq::Error,
+	},
+
+	#[error("Release metadata for {tag} did not contain {asset}")]
+	MissingAsset { tag: String, asset: String },
+
+	#[error("Release asset {asset} did not include GitHub's SHA-256 digest")]
+	MissingAssetDigest { asset: String },
+
+	#[error("Release asset {asset} has an unsupported digest: {digest}")]
+	UnsupportedAssetDigest { asset: String, digest: String },
+
+	#[error("Release metadata returned tag {actual} while {expected} was requested")]
+	UnexpectedReleaseTag { expected: String, actual: String },
+
+	#[error("Release asset {asset} used an unexpected download URL: {url}")]
+	UnexpectedDownloadUrl { asset: String, url: String },
+
+	#[error("Release asset {asset} is {actual} bytes; metadata declared {expected} bytes")]
+	UnexpectedAssetSize {
+		asset: String,
+		expected: u64,
+		actual: u64,
+	},
+
+	#[error(
+		"Release asset {asset} failed SHA-256 verification (expected {expected}, got {actual})"
+	)]
+	AssetDigestMismatch {
+		asset: String,
+		expected: String,
+		actual: String,
+	},
+
+	#[error("Could not read the embedded lint catalog: {source}")]
+	Catalog { source: serde_json::Error },
+
+	#[error("The embedded lint catalog is invalid: {reason}")]
+	InvalidCatalog { reason: String },
+
+	#[error("Could not read lint bundle manifest at {path}: {source}")]
+	ReadManifest {
+		path: PathBuf,
+		source: std::io::Error,
+	},
+
+	#[error("Could not parse lint bundle manifest at {path}: {source}")]
+	ParseManifest {
+		path: PathBuf,
+		source: serde_json::Error,
+	},
+
+	#[error("Lint bundle at {path} is invalid: {reason}")]
+	InvalidBundle { path: PathBuf, reason: String },
+
+	#[error("Could not create a temporary lint bundle below {path}: {source}")]
+	CreateTemporaryBundle {
+		path: PathBuf,
+		source: std::io::Error,
+	},
+
+	#[error("Could not unpack lint bundle {asset}: {source}")]
+	Unpack {
+		asset: String,
+		source: std::io::Error,
+	},
+
+	#[error("Lint bundle {asset} contains an unsafe archive entry: {entry}")]
+	UnsafeArchiveEntry { asset: String, entry: String },
+
+	#[error("Could not replace the invalid cached lint bundle at {path}: {source}")]
+	ReplaceCachedBundle {
+		path: PathBuf,
+		source: std::io::Error,
+	},
+
+	#[error("Could not cache the verified lint bundle at {path}: {source}")]
+	CacheBundle {
+		path: PathBuf,
+		source: std::io::Error,
+	},
+}
+
+/// Load the versioned catalog embedded in the `pina_cli` crate.
+pub(crate) fn lint_catalog() -> Result<LintCatalog, BundleError> {
+	let catalog: LintCatalog = serde_json::from_str(include_str!("../lints.json"))
+		.map_err(|source| BundleError::Catalog { source })?;
+	validate_catalog(&catalog)?;
+	Ok(catalog)
+}
+
+/// Download once, then validate and reuse the current CLI's native bundle.
+pub(crate) fn prepare_bundle(cargo_home: &Path) -> Result<PreparedBundle, BundleError> {
+	let catalog = lint_catalog()?;
+	let version = env!("CARGO_PKG_VERSION");
+	let target = env!("PINA_BUILD_TARGET");
+	let root = cargo_home
+		.join("pina/lints")
+		.join(format!("v{version}"))
+		.join(target);
+	fs::create_dir_all(&root).map_err(|source| {
+		BundleError::CreateDirectory {
+			path: root.clone(),
+			source,
+		}
+	})?;
+
+	let lock_path = root.join("bundle.lock");
+	let lock = OpenOptions::new()
+		.read(true)
+		.write(true)
+		.create(true)
+		.truncate(false)
+		.open(&lock_path)
+		.map_err(|source| {
+			BundleError::OpenLock {
+				path: lock_path.clone(),
+				source,
+			}
+		})?;
+	lock.try_lock_exclusive().map_err(|source| {
+		BundleError::Lock {
+			path: lock_path,
+			source,
+		}
+	})?;
+
+	let bundle_path = root.join("bundle");
+	if let Ok(metadata) = fs::symlink_metadata(&bundle_path)
+		&& metadata.is_dir()
+		&& !metadata.file_type().is_symlink()
+		&& let Ok(bundle) = validate_bundle(&bundle_path, &catalog, version, target)
+	{
+		return Ok(bundle);
+	}
+
+	let tag = format!("v{version}");
+	let asset_name = format!("pina-lints-{target}-{tag}.tar.gz");
+	let release = fetch_release(&tag)?;
+	let asset = select_asset(&release, &tag, &asset_name)?;
+	let archive = fetch_archive(asset)?;
+	verify_archive(asset, &archive)?;
+
+	let temporary = tempfile::Builder::new()
+		.prefix("download-")
+		.tempdir_in(&root)
+		.map_err(|source| {
+			BundleError::CreateTemporaryBundle {
+				path: root.clone(),
+				source,
+			}
+		})?;
+	let extracted = temporary.path().join("bundle");
+	fs::create_dir(&extracted).map_err(|source| {
+		BundleError::CreateDirectory {
+			path: extracted.clone(),
+			source,
+		}
+	})?;
+	unpack_archive(&archive, &extracted, &asset.name, ArchiveContents::Lints)?;
+	let bundle = validate_bundle(&extracted, &catalog, version, target)?;
+
+	if fs::symlink_metadata(&bundle_path).is_ok() {
+		let metadata = fs::symlink_metadata(&bundle_path).map_err(|source| {
+			BundleError::ReplaceCachedBundle {
+				path: bundle_path.clone(),
+				source,
+			}
+		})?;
+		if metadata.file_type().is_symlink() || !metadata.is_dir() {
+			return Err(BundleError::InvalidBundle {
+				path: bundle_path,
+				reason: "the cache entry is not a regular directory".to_owned(),
+			});
+		}
+		fs::remove_dir_all(&bundle_path).map_err(|source| {
+			BundleError::ReplaceCachedBundle {
+				path: bundle_path.clone(),
+				source,
+			}
+		})?;
+	}
+	fs::rename(&extracted, &bundle_path).map_err(|source| {
+		BundleError::CacheBundle {
+			path: bundle_path.clone(),
+			source,
+		}
+	})?;
+
+	Ok(PreparedBundle {
+		library_paths: bundle
+			.library_paths
+			.into_iter()
+			.map(|path| bundle_path.join(path.file_name().expect("validated file has a name")))
+			.collect(),
+	})
+}
+
+/// Download once, then validate and reuse the pinned native Dylint tools.
+pub(crate) fn prepare_dylint_tools(cargo_home: &Path) -> Result<PreparedTools, BundleError> {
+	let version = lint_catalog()?.dylint_version;
+	let target = env!("PINA_BUILD_TARGET");
+	let root = cargo_home
+		.join("pina/tools")
+		.join(format!("dylint-v{version}"))
+		.join(target);
+	fs::create_dir_all(&root).map_err(|source| {
+		BundleError::CreateDirectory {
+			path: root.clone(),
+			source,
+		}
+	})?;
+
+	let lock_path = root.join("bundle.lock");
+	let lock = OpenOptions::new()
+		.read(true)
+		.write(true)
+		.create(true)
+		.truncate(false)
+		.open(&lock_path)
+		.map_err(|source| {
+			BundleError::OpenLock {
+				path: lock_path.clone(),
+				source,
+			}
+		})?;
+	lock.try_lock_exclusive().map_err(|source| {
+		BundleError::Lock {
+			path: lock_path,
+			source,
+		}
+	})?;
+
+	let bundle_path = root.join("bundle");
+	if let Ok(metadata) = fs::symlink_metadata(&bundle_path)
+		&& metadata.is_dir()
+		&& !metadata.file_type().is_symlink()
+		&& let Ok(tools) = validate_tool_bundle(&bundle_path, &version, target)
+	{
+		return Ok(tools);
+	}
+
+	let tag = format!("dylint-v{version}");
+	let asset_name = format!("pina-dylint-tools-{target}-v{version}.tar.gz");
+	let release = fetch_release(&tag)?;
+	let asset = select_asset(&release, &tag, &asset_name)?;
+	let archive = fetch_archive(asset)?;
+	verify_archive(asset, &archive)?;
+
+	let temporary = tempfile::Builder::new()
+		.prefix("download-")
+		.tempdir_in(&root)
+		.map_err(|source| {
+			BundleError::CreateTemporaryBundle {
+				path: root.clone(),
+				source,
+			}
+		})?;
+	let extracted = temporary.path().join("bundle");
+	fs::create_dir(&extracted).map_err(|source| {
+		BundleError::CreateDirectory {
+			path: extracted.clone(),
+			source,
+		}
+	})?;
+	unpack_archive(&archive, &extracted, &asset.name, ArchiveContents::Tools)?;
+	validate_tool_bundle(&extracted, &version, target)?;
+
+	if fs::symlink_metadata(&bundle_path).is_ok() {
+		let metadata = fs::symlink_metadata(&bundle_path).map_err(|source| {
+			BundleError::ReplaceCachedBundle {
+				path: bundle_path.clone(),
+				source,
+			}
+		})?;
+		if metadata.file_type().is_symlink() || !metadata.is_dir() {
+			return Err(BundleError::InvalidBundle {
+				path: bundle_path,
+				reason: "the cache entry is not a regular directory".to_owned(),
+			});
+		}
+		fs::remove_dir_all(&bundle_path).map_err(|source| {
+			BundleError::ReplaceCachedBundle {
+				path: bundle_path.clone(),
+				source,
+			}
+		})?;
+	}
+	fs::rename(&extracted, &bundle_path).map_err(|source| {
+		BundleError::CacheBundle {
+			path: bundle_path.clone(),
+			source,
+		}
+	})?;
+	validate_tool_bundle(&bundle_path, &version, target)
+}
+
+fn validate_catalog(catalog: &LintCatalog) -> Result<(), BundleError> {
+	if catalog.schema_version != BUNDLE_SCHEMA_VERSION {
+		return Err(BundleError::InvalidCatalog {
+			reason: format!("schema version {} is not supported", catalog.schema_version),
+		});
+	}
+	if semver::Version::parse(&catalog.dylint_version).is_err() {
+		return Err(BundleError::InvalidCatalog {
+			reason: "Dylint version must use semantic versioning".to_owned(),
+		});
+	}
+	if catalog.toolchain.is_empty() || catalog.targets.is_empty() || catalog.libraries.is_empty() {
+		return Err(BundleError::InvalidCatalog {
+			reason: "toolchain, targets, and libraries must not be empty".to_owned(),
+		});
+	}
+	let unique_targets = catalog.targets.iter().collect::<BTreeSet<_>>();
+	if unique_targets.len() != catalog.targets.len()
+		|| catalog
+			.targets
+			.iter()
+			.any(|target| !is_safe_release_component(target))
+		|| !catalog
+			.targets
+			.iter()
+			.any(|target| target == env!("PINA_BUILD_TARGET"))
+	{
+		return Err(BundleError::InvalidCatalog {
+			reason: "targets must be unique safe components and include this CLI host".to_owned(),
+		});
+	}
+	let unique = catalog.libraries.iter().collect::<BTreeSet<_>>();
+	if unique.len() != catalog.libraries.len()
+		|| catalog
+			.libraries
+			.iter()
+			.any(|name| !is_safe_component(name))
+	{
+		return Err(BundleError::InvalidCatalog {
+			reason: "library names must be unique safe path components".to_owned(),
+		});
+	}
+	Ok(())
+}
+
+fn fetch_release(tag: &str) -> Result<GithubRelease, BundleError> {
+	let url = format!("{PINA_RELEASES_API}/{tag}");
+	let mut response = ureq::get(&url)
+		.header("Accept", "application/vnd.github+json")
+		.header(
+			"User-Agent",
+			concat!("pina-cli/", env!("CARGO_PKG_VERSION")),
+		)
+		.header("X-GitHub-Api-Version", "2022-11-28")
+		.call()
+		.map_err(|source| {
+			BundleError::Http {
+				resource: format!("release metadata for {tag}"),
+				source,
+			}
+		})?;
+	response.body_mut().read_json().map_err(|source| {
+		BundleError::Http {
+			resource: format!("release metadata for {tag}"),
+			source,
+		}
+	})
+}
+
+fn select_asset<'a>(
+	release: &'a GithubRelease,
+	tag: &str,
+	asset_name: &str,
+) -> Result<&'a GithubAsset, BundleError> {
+	if release.tag_name != tag {
+		return Err(BundleError::UnexpectedReleaseTag {
+			expected: tag.to_owned(),
+			actual: release.tag_name.clone(),
+		});
+	}
+	let asset = release
+		.assets
+		.iter()
+		.find(|asset| asset.name == asset_name)
+		.ok_or_else(|| {
+			BundleError::MissingAsset {
+				tag: tag.to_owned(),
+				asset: asset_name.to_owned(),
+			}
+		})?;
+	let expected_url = format!("{PINA_RELEASE_DOWNLOADS}/{tag}/{}", asset.name);
+	if asset.browser_download_url != expected_url {
+		return Err(BundleError::UnexpectedDownloadUrl {
+			asset: asset.name.clone(),
+			url: asset.browser_download_url.clone(),
+		});
+	}
+	Ok(asset)
+}
+
+fn fetch_archive(asset: &GithubAsset) -> Result<Vec<u8>, BundleError> {
+	let mut response = ureq::get(&asset.browser_download_url)
+		.header("Accept", "application/octet-stream")
+		.header(
+			"User-Agent",
+			concat!("pina-cli/", env!("CARGO_PKG_VERSION")),
+		)
+		.call()
+		.map_err(|source| {
+			BundleError::Http {
+				resource: asset.name.clone(),
+				source,
+			}
+		})?;
+	response
+		.body_mut()
+		.with_config()
+		.limit(MAX_ARCHIVE_BYTES)
+		.read_to_vec()
+		.map_err(|source| {
+			BundleError::Http {
+				resource: asset.name.clone(),
+				source,
+			}
+		})
+}
+
+fn verify_archive(asset: &GithubAsset, archive: &[u8]) -> Result<(), BundleError> {
+	let actual_size = u64::try_from(archive.len()).unwrap_or(u64::MAX);
+	if actual_size != asset.size {
+		return Err(BundleError::UnexpectedAssetSize {
+			asset: asset.name.clone(),
+			expected: asset.size,
+			actual: actual_size,
+		});
+	}
+	let digest = asset.digest.as_deref().ok_or_else(|| {
+		BundleError::MissingAssetDigest {
+			asset: asset.name.clone(),
+		}
+	})?;
+	let expected = digest.strip_prefix("sha256:").ok_or_else(|| {
+		BundleError::UnsupportedAssetDigest {
+			asset: asset.name.clone(),
+			digest: digest.to_owned(),
+		}
+	})?;
+	let actual = sha256(archive);
+	if !actual.eq_ignore_ascii_case(expected) {
+		return Err(BundleError::AssetDigestMismatch {
+			asset: asset.name.clone(),
+			expected: expected.to_owned(),
+			actual,
+		});
+	}
+	Ok(())
+}
+
+#[derive(Clone, Copy)]
+enum ArchiveContents {
+	Lints,
+	Tools,
+}
+
+fn unpack_archive(
+	archive: &[u8],
+	destination: &Path,
+	asset: &str,
+	contents: ArchiveContents,
+) -> Result<(), BundleError> {
+	let decoder = GzDecoder::new(Cursor::new(archive));
+	let mut archive = tar::Archive::new(decoder);
+	let entries = archive.entries().map_err(|source| {
+		BundleError::Unpack {
+			asset: asset.to_owned(),
+			source,
+		}
+	})?;
+	let mut total_size = 0_u64;
+	for entry in entries {
+		let mut entry = entry.map_err(|source| {
+			BundleError::Unpack {
+				asset: asset.to_owned(),
+				source,
+			}
+		})?;
+		let path = entry.path().map_err(|source| {
+			BundleError::Unpack {
+				asset: asset.to_owned(),
+				source,
+			}
+		})?;
+		let mut components = path.components();
+		let Some(Component::Normal(file_name)) = components.next() else {
+			return Err(BundleError::UnsafeArchiveEntry {
+				asset: asset.to_owned(),
+				entry: path.display().to_string(),
+			});
+		};
+		if components.next().is_some() || !entry.header().entry_type().is_file() {
+			return Err(BundleError::UnsafeArchiveEntry {
+				asset: asset.to_owned(),
+				entry: path.display().to_string(),
+			});
+		}
+		let file_name = file_name.to_string_lossy();
+		let allowed = file_name == "manifest.json"
+			|| match contents {
+				ArchiveContents::Lints => is_dynamic_library(&file_name),
+				ArchiveContents::Tools => is_tool_executable(&file_name),
+			};
+		if !allowed {
+			return Err(BundleError::UnsafeArchiveEntry {
+				asset: asset.to_owned(),
+				entry: path.display().to_string(),
+			});
+		}
+		total_size = total_size.saturating_add(entry.size());
+		if total_size > MAX_EXTRACTED_BYTES {
+			return Err(BundleError::UnsafeArchiveEntry {
+				asset: asset.to_owned(),
+				entry: "archive exceeds the extraction size limit".to_owned(),
+			});
+		}
+		let output_path = destination.join(file_name.as_ref());
+		let mut output = OpenOptions::new()
+			.write(true)
+			.create_new(true)
+			.open(&output_path)
+			.map_err(|source| {
+				BundleError::Unpack {
+					asset: asset.to_owned(),
+					source,
+				}
+			})?;
+		std::io::copy(&mut entry, &mut output).map_err(|source| {
+			BundleError::Unpack {
+				asset: asset.to_owned(),
+				source,
+			}
+		})?;
+		output.flush().map_err(|source| {
+			BundleError::Unpack {
+				asset: asset.to_owned(),
+				source,
+			}
+		})?;
+	}
+	Ok(())
+}
+
+fn validate_tool_bundle(
+	path: &Path,
+	version: &str,
+	target: &str,
+) -> Result<PreparedTools, BundleError> {
+	let manifest_path = path.join("manifest.json");
+	let bytes = fs::read(&manifest_path).map_err(|source| {
+		BundleError::ReadManifest {
+			path: manifest_path.clone(),
+			source,
+		}
+	})?;
+	let manifest: ToolManifest = serde_json::from_slice(&bytes).map_err(|source| {
+		BundleError::ParseManifest {
+			path: manifest_path,
+			source,
+		}
+	})?;
+	if manifest.schema_version != BUNDLE_SCHEMA_VERSION
+		|| manifest.dylint_version != version
+		|| manifest.target != target
+	{
+		return invalid_bundle(
+			path,
+			"Dylint tool metadata does not match this CLI and host",
+		);
+	}
+
+	let names = manifest
+		.executables
+		.iter()
+		.map(|executable| executable.name.as_str())
+		.collect::<Vec<_>>();
+	if names != TOOL_NAMES {
+		return invalid_bundle(
+			path,
+			"Dylint tool bundle does not contain the required tools",
+		);
+	}
+
+	let mut expected_files = BTreeSet::from(["manifest.json".to_owned()]);
+	for executable in &manifest.executables {
+		let expected_file = tool_filename(&executable.name, target);
+		if executable.file != expected_file || !is_safe_component(&executable.file) {
+			return invalid_bundle(
+				path,
+				&format!("unexpected Dylint tool filename {}", executable.file),
+			);
+		}
+		if !expected_files.insert(executable.file.clone()) {
+			return invalid_bundle(
+				path,
+				&format!("duplicate Dylint tool file {}", executable.file),
+			);
+		}
+		let executable_path = path.join(&executable.file);
+		let metadata = fs::symlink_metadata(&executable_path).map_err(|source| {
+			BundleError::InvalidBundle {
+				path: path.to_path_buf(),
+				reason: format!("could not inspect {}: {source}", executable.file),
+			}
+		})?;
+		if !metadata.is_file()
+			|| metadata.file_type().is_symlink()
+			|| metadata.len() != executable.size
+		{
+			return invalid_bundle(path, &format!("invalid Dylint tool {}", executable.file));
+		}
+		let actual = sha256_file(&executable_path).map_err(|source| {
+			BundleError::InvalidBundle {
+				path: path.to_path_buf(),
+				reason: format!("could not hash {}: {source}", executable.file),
+			}
+		})?;
+		if !actual.eq_ignore_ascii_case(&executable.sha256) {
+			return invalid_bundle(
+				path,
+				&format!("digest mismatch for Dylint tool {}", executable.file),
+			);
+		}
+	}
+
+	let actual_files = fs::read_dir(path)
+		.map_err(|source| {
+			BundleError::InvalidBundle {
+				path: path.to_path_buf(),
+				reason: format!("could not list Dylint tool files: {source}"),
+			}
+		})?
+		.map(|entry| {
+			entry
+				.map(|entry| entry.file_name().to_string_lossy().into_owned())
+				.map_err(|source| {
+					BundleError::InvalidBundle {
+						path: path.to_path_buf(),
+						reason: format!("could not inspect Dylint tool entry: {source}"),
+					}
+				})
+		})
+		.collect::<Result<BTreeSet<_>, _>>()?;
+	if actual_files != expected_files {
+		return invalid_bundle(
+			path,
+			"Dylint tool bundle contains unexpected or missing files",
+		);
+	}
+
+	set_executable_permissions(path, target)?;
+	Ok(PreparedTools {
+		bin_dir: path.to_path_buf(),
+		cargo_dylint: path.join(tool_filename("cargo-dylint", target)),
+	})
+}
+
+fn validate_bundle(
+	path: &Path,
+	catalog: &LintCatalog,
+	version: &str,
+	target: &str,
+) -> Result<PreparedBundle, BundleError> {
+	let manifest_path = path.join("manifest.json");
+	let bytes = fs::read(&manifest_path).map_err(|source| {
+		BundleError::ReadManifest {
+			path: manifest_path.clone(),
+			source,
+		}
+	})?;
+	let manifest: BundleManifest = serde_json::from_slice(&bytes).map_err(|source| {
+		BundleError::ParseManifest {
+			path: manifest_path,
+			source,
+		}
+	})?;
+	let expected_toolchain = format!("{}-{target}", catalog.toolchain);
+	if manifest.schema_version != BUNDLE_SCHEMA_VERSION
+		|| manifest.version != version
+		|| manifest.target != target
+		|| manifest.toolchain != expected_toolchain
+		|| manifest.dylint_version != catalog.dylint_version
+	{
+		return invalid_bundle(path, "bundle metadata does not match this CLI and host");
+	}
+
+	let names = manifest
+		.libraries
+		.iter()
+		.map(|library| library.name.as_str())
+		.collect::<Vec<_>>();
+	let expected_names = catalog
+		.libraries
+		.iter()
+		.map(String::as_str)
+		.collect::<Vec<_>>();
+	if names != expected_names {
+		return invalid_bundle(
+			path,
+			"bundle libraries do not match the embedded lint catalog",
+		);
+	}
+
+	let mut library_paths = Vec::with_capacity(manifest.libraries.len());
+	let mut expected_files = BTreeSet::from(["manifest.json".to_owned()]);
+	for library in manifest.libraries {
+		let expected_file = library_filename(&library.name, &manifest.toolchain);
+		if library.file != expected_file || !is_safe_component(&library.file) {
+			return invalid_bundle(
+				path,
+				&format!("unexpected library filename {}", library.file),
+			);
+		}
+		if !expected_files.insert(library.file.clone()) {
+			return invalid_bundle(path, &format!("duplicate library file {}", library.file));
+		}
+		let library_path = path.join(&library.file);
+		let metadata = fs::symlink_metadata(&library_path).map_err(|source| {
+			BundleError::InvalidBundle {
+				path: path.to_path_buf(),
+				reason: format!("could not inspect {}: {source}", library.file),
+			}
+		})?;
+		if !metadata.is_file()
+			|| metadata.file_type().is_symlink()
+			|| metadata.len() != library.size
+		{
+			return invalid_bundle(path, &format!("invalid library file {}", library.file));
+		}
+		let actual = sha256_file(&library_path).map_err(|source| {
+			BundleError::InvalidBundle {
+				path: path.to_path_buf(),
+				reason: format!("could not hash {}: {source}", library.file),
+			}
+		})?;
+		if !actual.eq_ignore_ascii_case(&library.sha256) {
+			return invalid_bundle(path, &format!("digest mismatch for {}", library.file));
+		}
+		library_paths.push(library_path);
+	}
+
+	let actual_files = fs::read_dir(path)
+		.map_err(|source| {
+			BundleError::InvalidBundle {
+				path: path.to_path_buf(),
+				reason: format!("could not list bundle files: {source}"),
+			}
+		})?
+		.map(|entry| {
+			entry
+				.map(|entry| entry.file_name().to_string_lossy().into_owned())
+				.map_err(|source| {
+					BundleError::InvalidBundle {
+						path: path.to_path_buf(),
+						reason: format!("could not inspect bundle entry: {source}"),
+					}
+				})
+		})
+		.collect::<Result<BTreeSet<_>, _>>()?;
+	if actual_files != expected_files {
+		return invalid_bundle(path, "bundle contains unexpected or missing files");
+	}
+
+	Ok(PreparedBundle { library_paths })
+}
+
+fn invalid_bundle<T>(path: &Path, reason: &str) -> Result<T, BundleError> {
+	Err(BundleError::InvalidBundle {
+		path: path.to_path_buf(),
+		reason: reason.to_owned(),
+	})
+}
+
+fn library_filename(name: &str, toolchain: &str) -> String {
+	if cfg!(target_os = "windows") {
+		format!("{name}@{toolchain}.dll")
+	} else if cfg!(target_os = "macos") {
+		format!("lib{name}@{toolchain}.dylib")
+	} else {
+		format!("lib{name}@{toolchain}.so")
+	}
+}
+
+fn is_safe_component(value: &str) -> bool {
+	!value.is_empty()
+		&& Path::new(value).components().count() == 1
+		&& matches!(
+			Path::new(value).components().next(),
+			Some(Component::Normal(_))
+		)
+}
+
+fn is_safe_release_component(value: &str) -> bool {
+	!value.is_empty()
+		&& value.chars().all(|character| {
+			character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.')
+		})
+}
+
+fn is_dynamic_library(file_name: &str) -> bool {
+	matches!(
+		Path::new(file_name)
+			.extension()
+			.and_then(|value| value.to_str()),
+		Some("so" | "dylib" | "dll")
+	)
+}
+
+fn is_tool_executable(file_name: &str) -> bool {
+	TOOL_NAMES
+		.iter()
+		.any(|name| file_name == tool_filename(name, env!("PINA_BUILD_TARGET")))
+}
+
+fn tool_filename(name: &str, target: &str) -> String {
+	if target.contains("windows") {
+		format!("{name}.exe")
+	} else {
+		name.to_owned()
+	}
+}
+
+#[cfg(unix)]
+fn set_executable_permissions(path: &Path, target: &str) -> Result<(), BundleError> {
+	for name in TOOL_NAMES {
+		let executable = path.join(tool_filename(name, target));
+		let mut permissions = fs::metadata(&executable)
+			.map_err(|source| {
+				BundleError::InvalidBundle {
+					path: path.to_path_buf(),
+					reason: format!(
+						"could not inspect {} permissions: {source}",
+						executable.display()
+					),
+				}
+			})?
+			.permissions();
+		permissions.set_mode(0o755);
+		fs::set_permissions(&executable, permissions).map_err(|source| {
+			BundleError::InvalidBundle {
+				path: path.to_path_buf(),
+				reason: format!(
+					"could not set {} executable: {source}",
+					executable.display()
+				),
+			}
+		})?;
+	}
+	Ok(())
+}
+
+#[cfg(windows)]
+fn set_executable_permissions(_path: &Path, _target: &str) -> Result<(), BundleError> {
+	Ok(())
+}
+
+fn sha256(bytes: &[u8]) -> String {
+	hex_digest(Sha256::digest(bytes).as_ref())
+}
+
+fn sha256_file(path: &Path) -> Result<String, std::io::Error> {
+	let mut file = File::open(path)?;
+	let mut hasher = Sha256::new();
+	let mut buffer = [0_u8; 16 * 1024];
+	loop {
+		let count = file.read(&mut buffer)?;
+		if count == 0 {
+			break;
+		}
+		hasher.update(&buffer[..count]);
+	}
+	Ok(hex_digest(hasher.finalize().as_ref()))
+}
+
+fn hex_digest(bytes: &[u8]) -> String {
+	const HEX: &[u8; 16] = b"0123456789abcdef";
+	let mut encoded = String::with_capacity(bytes.len() * 2);
+	for byte in bytes {
+		encoded.push(char::from(HEX[usize::from(byte >> 4)]));
+		encoded.push(char::from(HEX[usize::from(byte & 0x0f)]));
+	}
+	encoded
+}
+
+#[cfg(test)]
+mod tests {
+	use flate2::Compression;
+	use flate2::write::GzEncoder;
+	use serde_json::json;
+
+	use super::*;
+	const TEST_DYLINT_VERSION: &str = "6.0.4";
+
+	#[test]
+	fn embedded_catalog_is_valid_and_sorted() {
+		let catalog = lint_catalog().expect("embedded catalog should be valid");
+		let mut sorted = catalog.libraries.clone();
+		sorted.sort();
+		assert_eq!(catalog.libraries, sorted);
+	}
+
+	#[test]
+	fn asset_selection_rejects_redirectable_release_inputs() {
+		let release = GithubRelease {
+			tag_name: "v1.2.3".to_owned(),
+			assets: vec![GithubAsset {
+				name: "pina-lints-test-v1.2.3.tar.gz".to_owned(),
+				browser_download_url: "https://example.com/native-code.tar.gz".to_owned(),
+				size: 1,
+				digest: Some("sha256:00".to_owned()),
+			}],
+		};
+		assert!(matches!(
+			select_asset(&release, "v1.2.3", "pina-lints-test-v1.2.3.tar.gz"),
+			Err(BundleError::UnexpectedDownloadUrl { .. })
+		));
+	}
+
+	#[test]
+	fn archive_digest_and_size_are_both_required() {
+		let bytes = b"verified bundle";
+		let asset = GithubAsset {
+			name: "bundle.tar.gz".to_owned(),
+			browser_download_url: String::new(),
+			size: bytes.len() as u64,
+			digest: Some(format!("sha256:{}", sha256(bytes))),
+		};
+		verify_archive(&asset, bytes).expect("matching archive should verify");
+
+		let wrong_size = GithubAsset { size: 1, ..asset };
+		assert!(matches!(
+			verify_archive(&wrong_size, bytes),
+			Err(BundleError::UnexpectedAssetSize { .. })
+		));
+	}
+
+	#[test]
+	fn extraction_rejects_nested_archive_paths() {
+		let encoder = GzEncoder::new(Vec::new(), Compression::default());
+		let mut archive = tar::Builder::new(encoder);
+		let contents = b"{}";
+		let mut header = tar::Header::new_gnu();
+		header.set_size(contents.len() as u64);
+		header.set_mode(0o644);
+		header.set_cksum();
+		archive
+			.append_data(&mut header, "nested/manifest.json", contents.as_slice())
+			.expect("test archive should be created");
+		let encoder = archive.into_inner().expect("tar stream should finish");
+		let bytes = encoder.finish().expect("gzip stream should finish");
+		let destination = tempfile::tempdir().expect("temporary directory should exist");
+		assert!(matches!(
+			unpack_archive(
+				&bytes,
+				destination.path(),
+				"bundle.tar.gz",
+				ArchiveContents::Lints,
+			),
+			Err(BundleError::UnsafeArchiveEntry { .. })
+		));
+	}
+
+	#[test]
+	fn bundle_validation_detects_tampered_library_bytes() {
+		let catalog = LintCatalog {
+			schema_version: 1,
+			dylint_version: TEST_DYLINT_VERSION.to_owned(),
+			toolchain: "nightly-test".to_owned(),
+			targets: vec![env!("PINA_BUILD_TARGET").to_owned()],
+			libraries: vec!["secure_lint".to_owned()],
+		};
+		let target = env!("PINA_BUILD_TARGET");
+		let toolchain = format!("{}-{target}", catalog.toolchain);
+		let file = library_filename("secure_lint", &toolchain);
+		let directory = tempfile::tempdir().expect("temporary directory should exist");
+		let contents = b"trusted native library";
+		fs::write(directory.path().join(&file), contents).expect("library should be written");
+		let manifest = json!({
+			"schema_version": 1,
+			"version": "1.2.3",
+			"target": target,
+			"toolchain": toolchain,
+			"dylint_version": TEST_DYLINT_VERSION,
+			"libraries": [{
+				"name": "secure_lint",
+				"file": file,
+				"sha256": sha256(contents),
+				"size": contents.len(),
+			}],
+		});
+		fs::write(
+			directory.path().join("manifest.json"),
+			serde_json::to_vec(&manifest).expect("manifest should encode"),
+		)
+		.expect("manifest should be written");
+		validate_bundle(directory.path(), &catalog, "1.2.3", target)
+			.expect("untampered bundle should validate");
+
+		fs::write(directory.path().join(&file), b"tampered native library")
+			.expect("library should be replaced");
+		assert!(matches!(
+			validate_bundle(directory.path(), &catalog, "1.2.3", target),
+			Err(BundleError::InvalidBundle { .. })
+		));
+	}
+
+	#[test]
+	fn tool_validation_requires_exact_version_target_and_digests() {
+		let target = env!("PINA_BUILD_TARGET");
+		let directory = tempfile::tempdir().expect("temporary directory should exist");
+		let executables = TOOL_NAMES
+			.into_iter()
+			.map(|name| {
+				let file = tool_filename(name, target);
+				let contents = format!("trusted executable {name}");
+				fs::write(directory.path().join(&file), contents.as_bytes())
+					.expect("tool should be written");
+				json!({
+					"name": name,
+					"file": file,
+					"sha256": sha256(contents.as_bytes()),
+					"size": contents.len(),
+				})
+			})
+			.collect::<Vec<_>>();
+		let manifest = json!({
+			"schema_version": 1,
+			"dylint_version": TEST_DYLINT_VERSION,
+			"target": target,
+			"executables": executables,
+		});
+		fs::write(
+			directory.path().join("manifest.json"),
+			serde_json::to_vec(&manifest).expect("manifest should encode"),
+		)
+		.expect("manifest should be written");
+		let tools = validate_tool_bundle(directory.path(), TEST_DYLINT_VERSION, target)
+			.expect("untampered tools should validate");
+		assert_eq!(
+			tools.cargo_dylint,
+			directory.path().join(tool_filename("cargo-dylint", target))
+		);
+
+		fs::write(&tools.cargo_dylint, b"tampered executable").expect("tool should be replaced");
+		assert!(matches!(
+			validate_tool_bundle(directory.path(), TEST_DYLINT_VERSION, target),
+			Err(BundleError::InvalidBundle { .. })
+		));
+	}
+}

--- a/crates/pina_cli/src/lint_bundle.rs
+++ b/crates/pina_cli/src/lint_bundle.rs
@@ -247,7 +247,7 @@ pub(crate) fn prepare_bundle(cargo_home: &Path) -> Result<PreparedBundle, Bundle
 				source,
 			}
 		})?;
-	lock.try_lock_exclusive().map_err(|source| {
+	lock.lock_exclusive().map_err(|source| {
 		BundleError::Lock {
 			path: lock_path,
 			source,
@@ -353,7 +353,7 @@ pub(crate) fn prepare_dylint_tools(cargo_home: &Path) -> Result<PreparedTools, B
 				source,
 			}
 		})?;
-	lock.try_lock_exclusive().map_err(|source| {
+	lock.lock_exclusive().map_err(|source| {
 		BundleError::Lock {
 			path: lock_path,
 			source,

--- a/crates/pina_cli/src/verifiable.rs
+++ b/crates/pina_cli/src/verifiable.rs
@@ -1504,14 +1504,20 @@ mod tests {
 		let path = temp.path().join("program.so");
 		fs::write(&path, b"program\0\0")
 			.unwrap_or_else(|error| panic!("fixture write failed: {error}"));
-		let expected = Sha256::digest(b"program").iter().map(|byte| format!("{byte:02x}")).collect::<String>();
+		let expected = Sha256::digest(b"program")
+			.iter()
+			.map(|byte| format!("{byte:02x}"))
+			.collect::<String>();
 		assert_eq!(
 			executable_hash(&path).unwrap_or_else(|error| panic!("hash failed: {error}")),
 			expected
 		);
 		assert_eq!(
 			sha256_file(&path).unwrap_or_else(|error| panic!("raw hash failed: {error}")),
-			Sha256::digest(b"program\0\0").iter().map(|byte| format!("{byte:02x}")).collect::<String>()
+			Sha256::digest(b"program\0\0")
+				.iter()
+				.map(|byte| format!("{byte:02x}"))
+				.collect::<String>()
 		);
 
 		let mut large = vec![0_u8; 2 * 1024 * 1024];
@@ -1521,7 +1527,10 @@ mod tests {
 			.unwrap_or_else(|error| panic!("large fixture write failed: {error}"));
 		assert_eq!(
 			executable_hash(&path).unwrap_or_else(|error| panic!("streaming hash failed: {error}")),
-			Sha256::digest(&large[..64 * 1024 + 8]).iter().map(|byte| format!("{byte:02x}")).collect::<String>()
+			Sha256::digest(&large[..64 * 1024 + 8])
+				.iter()
+				.map(|byte| format!("{byte:02x}"))
+				.collect::<String>()
 		);
 	}
 
@@ -1717,7 +1726,10 @@ mod tests {
 	fn record_reader_validates_size_shape_hash_and_accessors() {
 		let temp = TempDir::new().unwrap_or_else(|error| panic!("temp dir failed: {error}"));
 		let artifact_contents = b"program\0\0";
-		let hash = Sha256::digest(b"program").iter().map(|byte| format!("{byte:02x}")).collect::<String>();
+		let hash = Sha256::digest(b"program")
+			.iter()
+			.map(|byte| format!("{byte:02x}"))
+			.collect::<String>();
 		let record_path = temp.path().join(format!("program-{hash}.json"));
 		let artifact_path = record_path.with_extension("so");
 		let manifest = valid_manifest(&hash);
@@ -1973,7 +1985,10 @@ mod tests {
 		let artifact = snapshot.path().join("program.so");
 		fs::write(&artifact, b"program")
 			.unwrap_or_else(|error| panic!("artifact write failed: {error}"));
-		let hash = Sha256::digest(b"program").iter().map(|byte| format!("{byte:02x}")).collect::<String>();
+		let hash = Sha256::digest(b"program")
+			.iter()
+			.map(|byte| format!("{byte:02x}"))
+			.collect::<String>();
 		let verified = VerifiedBuild {
 			_snapshot: snapshot,
 			artifact,

--- a/crates/pina_cli/src/verification.rs
+++ b/crates/pina_cli/src/verification.rs
@@ -1513,7 +1513,10 @@ mod tests {
 	}
 
 	fn record_hash() -> String {
-		Sha256::digest([7_u8; 128]).iter().map(|byte| format!("{byte:02x}")).collect::<String>()
+		Sha256::digest([7_u8; 128])
+			.iter()
+			.map(|byte| format!("{byte:02x}"))
+			.collect::<String>()
 	}
 
 	fn record_program_for_test(
@@ -1875,7 +1878,10 @@ mod tests {
 		default_features: bool,
 	) -> PathBuf {
 		let bytes = vec![7_u8; 128];
-		let hash = Sha256::digest(&bytes).iter().map(|byte| format!("{byte:02x}")).collect::<String>();
+		let hash = Sha256::digest(&bytes)
+			.iter()
+			.map(|byte| format!("{byte:02x}"))
+			.collect::<String>();
 		let record = temp.path().join(format!("verify_fixture-{hash}.json"));
 		let artifact = record.with_extension("so");
 		let json = serde_json::json!({

--- a/crates/pina_cli/tests/lint_command.rs
+++ b/crates/pina_cli/tests/lint_command.rs
@@ -5,6 +5,9 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
+use std::process::Stdio;
+use std::thread;
+use std::time::Duration;
 
 use fs2::FileExt;
 use serde_json::Value;
@@ -313,7 +316,7 @@ fn lint_reports_when_the_managed_tool_directory_cannot_be_created() {
 }
 
 #[test]
-fn lint_reports_a_concurrent_managed_runner_download() {
+fn lint_waits_for_a_concurrent_managed_runner_download() {
 	let fixture = Fixture::new("pina-lint-lock-contention");
 	let lock_path = fixture.managed_tool_root().join("bundle.lock");
 	fs::create_dir_all(
@@ -327,12 +330,29 @@ fn lint_reports_a_concurrent_managed_runner_download() {
 	lock.lock_exclusive()
 		.unwrap_or_else(|error| panic!("failed to acquire install lock: {error}"));
 
-	let output = fixture
+	let mut child = fixture
 		.command()
-		.output()
+		.stdout(Stdio::piped())
+		.stderr(Stdio::piped())
+		.spawn()
 		.unwrap_or_else(|error| panic!("failed to run pina lint: {error}"));
-	assert!(!output.status.success());
+	thread::sleep(Duration::from_millis(250));
+	let exited_while_locked = child
+		.try_wait()
+		.unwrap_or_else(|error| panic!("failed to inspect pina lint: {error}"));
+	FileExt::unlock(&lock)
+		.unwrap_or_else(|error| panic!("failed to release install lock: {error}"));
+	let output = child
+		.wait_with_output()
+		.unwrap_or_else(|error| panic!("failed to wait for pina lint: {error}"));
 	assert!(
-		String::from_utf8_lossy(&output.stderr).contains("Could not lock the managed lint bundle")
+		exited_while_locked.is_none(),
+		"pina lint exited instead of waiting for the managed bundle lock: {}",
+		String::from_utf8_lossy(&output.stderr)
+	);
+	assert!(
+		output.status.success(),
+		"pina lint failed after the managed bundle lock was released: {}",
+		String::from_utf8_lossy(&output.stderr)
 	);
 }

--- a/crates/pina_cli/tests/lint_command.rs
+++ b/crates/pina_cli/tests/lint_command.rs
@@ -7,6 +7,10 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use fs2::FileExt;
+use serde_json::Value;
+use serde_json::json;
+use sha2::Digest;
+use sha2::Sha256;
 use tempfile::TempDir;
 
 fn write_project(root: &Path) {
@@ -43,13 +47,126 @@ fn executable(path: &Path, contents: &str) {
 		.unwrap_or_else(|error| panic!("failed to make {} executable: {error}", path.display()));
 }
 
+fn hex_digest(bytes: &[u8]) -> String {
+	const HEX: &[u8; 16] = b"0123456789abcdef";
+	let mut encoded = String::with_capacity(bytes.len() * 2);
+	for byte in bytes {
+		encoded.push(char::from(HEX[usize::from(byte >> 4)]));
+		encoded.push(char::from(HEX[usize::from(byte & 0x0f)]));
+	}
+	encoded
+}
+
+fn dylint_library_filename(name: &str, toolchain: &str) -> String {
+	if cfg!(target_os = "macos") {
+		format!("lib{name}@{toolchain}.dylib")
+	} else {
+		format!("lib{name}@{toolchain}.so")
+	}
+}
+
+fn write_cached_bundle(cargo_home: &Path) {
+	let catalog: Value = serde_json::from_str(include_str!("../lints.json"))
+		.unwrap_or_else(|error| panic!("failed to parse lint catalog: {error}"));
+	let target = env!("PINA_BUILD_TARGET");
+	let toolchain = format!(
+		"{}-{target}",
+		catalog["toolchain"]
+			.as_str()
+			.unwrap_or_else(|| panic!("catalog toolchain should be a string"))
+	);
+	let bundle = cargo_home
+		.join("pina/lints")
+		.join(format!("v{}", env!("CARGO_PKG_VERSION")))
+		.join(target)
+		.join("bundle");
+	fs::create_dir_all(&bundle)
+		.unwrap_or_else(|error| panic!("failed to create cached bundle: {error}"));
+	let libraries = catalog["libraries"]
+		.as_array()
+		.unwrap_or_else(|| panic!("catalog libraries should be an array"))
+		.iter()
+		.map(|name| {
+			let name = name
+				.as_str()
+				.unwrap_or_else(|| panic!("catalog library should be a string"));
+			let file = dylint_library_filename(name, &toolchain);
+			let contents = format!("test dylint library: {name}");
+			fs::write(bundle.join(&file), contents.as_bytes())
+				.unwrap_or_else(|error| panic!("failed to write cached lint: {error}"));
+			json!({
+				"name": name,
+				"file": file,
+				"sha256": hex_digest(Sha256::digest(contents.as_bytes()).as_ref()),
+				"size": contents.len(),
+			})
+		})
+		.collect::<Vec<_>>();
+	let manifest = json!({
+		"schema_version": 1,
+		"version": env!("CARGO_PKG_VERSION"),
+		"target": target,
+		"toolchain": toolchain,
+		"dylint_version": "6.0.4",
+		"libraries": libraries,
+	});
+	fs::write(
+		bundle.join("manifest.json"),
+		serde_json::to_vec_pretty(&manifest)
+			.unwrap_or_else(|error| panic!("failed to encode manifest: {error}")),
+	)
+	.unwrap_or_else(|error| panic!("failed to write manifest: {error}"));
+}
+
+fn write_cached_tools(cargo_home: &Path, cargo_dylint: &Path) {
+	let target = env!("PINA_BUILD_TARGET");
+	let bundle = cargo_home
+		.join("pina/tools/dylint-v6.0.4")
+		.join(target)
+		.join("bundle");
+	fs::create_dir_all(&bundle)
+		.unwrap_or_else(|error| panic!("failed to create cached Dylint tools: {error}"));
+	let executables = [
+		("cargo-dylint", cargo_dylint.to_path_buf()),
+		("dylint-link", bundle.join("dylint-link")),
+	]
+	.into_iter()
+	.map(|(name, source)| {
+		let file = name.to_owned();
+		if name == "cargo-dylint" {
+			fs::copy(&source, bundle.join(&file))
+				.unwrap_or_else(|error| panic!("failed to cache cargo-dylint: {error}"));
+		} else {
+			executable(&source, "#!/usr/bin/env bash\nexit 0\n");
+		}
+		let bytes = fs::read(bundle.join(&file))
+			.unwrap_or_else(|error| panic!("failed to read cached Dylint tool: {error}"));
+		json!({
+			"name": name,
+			"file": file,
+			"sha256": hex_digest(Sha256::digest(&bytes).as_ref()),
+			"size": bytes.len(),
+		})
+	})
+	.collect::<Vec<_>>();
+	let manifest = json!({
+		"schema_version": 1,
+		"dylint_version": "6.0.4",
+		"target": target,
+		"executables": executables,
+	});
+	fs::write(
+		bundle.join("manifest.json"),
+		serde_json::to_vec_pretty(&manifest)
+			.unwrap_or_else(|error| panic!("failed to encode Dylint tool manifest: {error}")),
+	)
+	.unwrap_or_else(|error| panic!("failed to write Dylint tool manifest: {error}"));
+}
+
 struct Fixture {
 	_temp: TempDir,
 	project: PathBuf,
 	cargo_home: PathBuf,
-	cargo: PathBuf,
-	cargo_dylint: PathBuf,
-	dylint_link: PathBuf,
 	log: PathBuf,
 }
 
@@ -65,56 +182,9 @@ impl Fixture {
 		write_project(&project);
 
 		let cargo_home = temp.path().join("cargo-home");
-		let cargo = temp.path().join("cargo");
+		write_cached_bundle(&cargo_home);
 		let cargo_dylint = temp.path().join("cargo-dylint");
-		let dylint_link = temp.path().join("dylint-link");
 		let log = temp.path().join("commands.log");
-		executable(
-			&cargo,
-			r#"#!/usr/bin/env bash
-set -euo pipefail
-
-if [[ "${1:-}" == "metadata" ]]; then
-	"$REAL_CARGO" "$@"
-	status="$?"
-	if [[ "${FAKE_CARGO_DISAPPEAR:-0}" == "1" ]]; then
-		rm "$0"
-	fi
-	exit "$status"
-fi
-
-printf 'cargo' >> "$PINA_LINT_LOG"
-printf ' %q' "$@" >> "$PINA_LINT_LOG"
-printf '\n' >> "$PINA_LINT_LOG"
-
-package="${!#}"
-if [[ "${FAKE_INSTALL_FAIL:-}" == "$package" ]]; then
-	exit 41
-fi
-
-root=""
-previous=""
-for argument in "$@"; do
-	if [[ "$previous" == "--root" ]]; then
-		root="$argument"
-		break
-	fi
-	previous="$argument"
-done
-test -n "$root"
-mkdir -p "$root/bin"
-
-if [[ "${FAKE_INSTALL_OMIT:-}" == "$package" ]]; then
-	exit 0
-fi
-
-case "$package" in
-	cargo-dylint) cp "$FAKE_CARGO_DYLINT_SOURCE" "$root/bin/cargo-dylint" ;;
-	dylint-link) cp "$FAKE_DYLINT_LINK_SOURCE" "$root/bin/dylint-link" ;;
-	*) exit 42 ;;
-esac
-"#,
-		);
 		executable(
 			&cargo_dylint,
 			r#"#!/usr/bin/env bash
@@ -122,21 +192,17 @@ set -euo pipefail
 printf 'dylint' >> "$PINA_LINT_LOG"
 printf ' %q' "$@" >> "$PINA_LINT_LOG"
 printf '\n' >> "$PINA_LINT_LOG"
-printf 'link=%s\n' "$(command -v dylint-link)" >> "$PINA_LINT_LOG"
 if [[ "${FAKE_LINT_FAIL:-0}" == "1" ]]; then
 	exit 43
 fi
 "#,
 		);
-		executable(&dylint_link, "#!/usr/bin/env bash\nexit 0\n");
+		write_cached_tools(&cargo_home, &cargo_dylint);
 
 		Self {
 			_temp: temp,
 			project,
 			cargo_home,
-			cargo,
-			cargo_dylint,
-			dylint_link,
 			log,
 		}
 	}
@@ -147,12 +213,9 @@ fi
 		command
 			.args(["lint", "--project"])
 			.arg(&self.project)
-			.env("CARGO", &self.cargo)
 			.env("CARGO_HOME", &self.cargo_home)
-			.env("REAL_CARGO", real_cargo)
-			.env("PINA_LINT_LOG", &self.log)
-			.env("FAKE_CARGO_DYLINT_SOURCE", &self.cargo_dylint)
-			.env("FAKE_DYLINT_LINK_SOURCE", &self.dylint_link);
+			.env("CARGO", real_cargo)
+			.env("PINA_LINT_LOG", &self.log);
 		command
 	}
 
@@ -162,12 +225,14 @@ fi
 	}
 
 	fn managed_tool_root(&self) -> PathBuf {
-		self.cargo_home.join("pina/tools/dylint-6.0.4-6.0.4")
+		self.cargo_home
+			.join("pina/tools/dylint-v6.0.4")
+			.join(env!("PINA_BUILD_TARGET"))
 	}
 }
 
 #[test]
-fn lint_installs_pinned_tools_once_and_runs_release_lints() {
+fn lint_reuses_precompiled_runner_and_release_lints() {
 	let fixture = Fixture::new("pina-lint-success");
 	let first = fixture
 		.command()
@@ -184,16 +249,13 @@ fn lint_installs_pinned_tools_once_and_runs_release_lints() {
 	);
 
 	let first_log = fixture.log();
-	assert!(first_log.contains("install --locked --root"));
-	assert!(first_log.contains("--version 6.0.4 cargo-dylint"));
-	assert!(first_log.contains("--version 6.0.4 dylint-link"));
-	assert!(first_log.contains("dylint dylint --no-deps"));
-	assert!(first_log.contains("--git https://github.com/pina-rs/pina"));
-	assert!(first_log.contains("--rev f6f206e0a4e71ab70c3eeaded52d07cd66a270d8"));
-	assert!(first_log.contains("--pattern lints/\\*"));
+	assert!(first_log.contains("dylint dylint --no-deps --no-metadata"));
+	assert!(first_log.contains("--lib-path"));
+	assert!(first_log.contains("require_owner_before_token_cast"));
 	assert!(first_log.contains("--package lint-fixture"));
-	assert!(first_log.contains("link="));
-	assert!(first_log.contains("/cargo-home/pina/tools/dylint-6.0.4-6.0.4/bin/dylint-link"));
+	assert!(!first_log.contains("--git"));
+	assert!(!first_log.contains("--rev"));
+	assert!(!first_log.contains("install"));
 
 	let second = fixture
 		.command()
@@ -201,146 +263,22 @@ fn lint_installs_pinned_tools_once_and_runs_release_lints() {
 		.unwrap_or_else(|error| panic!("failed to rerun pina lint: {error}"));
 	assert!(second.status.success());
 	let second_log = fixture.log();
-	assert_eq!(second_log.matches("cargo install").count(), 2);
 	assert_eq!(second_log.matches("dylint dylint").count(), 2);
 }
 
 #[test]
-fn lint_discovers_cargo_from_path_when_the_cargo_variable_is_absent() {
-	let fixture = Fixture::new("pina-lint-cargo-path");
-	let fake_bin = fixture
-		.cargo
-		.parent()
-		.unwrap_or_else(|| panic!("fake Cargo should have a parent directory"));
-	let current_path = std::env::var_os("PATH").unwrap_or_default();
-	let path = std::iter::once(fake_bin.to_path_buf()).chain(std::env::split_paths(&current_path));
-	let path = std::env::join_paths(path)
-		.unwrap_or_else(|error| panic!("failed to construct test PATH: {error}"));
-	let output = fixture
-		.command()
-		.env_remove("CARGO")
-		.env("PATH", path)
-		.output()
-		.unwrap_or_else(|error| panic!("failed to run pina lint: {error}"));
-	assert!(
-		output.status.success(),
-		"pina lint failed: {}",
-		String::from_utf8_lossy(&output.stderr)
-	);
-	assert!(fixture.log().contains("cargo install --locked --root"));
-}
-
-#[test]
-fn lint_resolves_relative_cargo_home_from_the_invocation_directory() {
-	let fixture = Fixture::new("pina-lint-relative-cargo-home");
-	let invocation_directory = fixture._temp.path().join("invocation");
-	fs::create_dir_all(&invocation_directory)
-		.unwrap_or_else(|error| panic!("failed to create invocation directory: {error}"));
-	let output = fixture
-		.command()
-		.current_dir(&invocation_directory)
-		.env("CARGO_HOME", "relative-cargo-home")
-		.output()
-		.unwrap_or_else(|error| panic!("failed to run pina lint: {error}"));
-	assert!(
-		output.status.success(),
-		"pina lint failed: {}",
-		String::from_utf8_lossy(&output.stderr)
-	);
-	assert!(
-		invocation_directory
-			.join("relative-cargo-home/pina/tools/dylint-6.0.4-6.0.4/bin/cargo-dylint")
-			.is_file()
-	);
-}
-
-#[test]
-fn lint_defaults_managed_tools_to_the_platform_cargo_home() {
-	let fixture = Fixture::new("pina-lint-default-cargo-home");
-	let home = fixture._temp.path().join("home");
-	fs::create_dir_all(&home)
-		.unwrap_or_else(|error| panic!("failed to create platform home: {error}"));
-	let output = fixture
-		.command()
-		.env_remove("CARGO_HOME")
-		.env("HOME", &home)
-		.output()
-		.unwrap_or_else(|error| panic!("failed to run pina lint: {error}"));
-	assert!(
-		output.status.success(),
-		"pina lint failed: {}",
-		String::from_utf8_lossy(&output.stderr)
-	);
-	assert!(
-		home.join(".cargo/pina/tools/dylint-6.0.4-6.0.4/bin/cargo-dylint")
-			.is_file()
-	);
-}
-
-#[test]
-fn lint_reports_project_discovery_failures() {
-	let fixture = Fixture::new("pina-lint-discovery-failure");
-	let missing = fixture.project.join("missing");
-	let output = Command::new(env!("CARGO_BIN_EXE_pina"))
-		.args(["lint", "--project"])
-		.arg(&missing)
-		.output()
-		.unwrap_or_else(|error| panic!("failed to run pina lint: {error}"));
-	assert!(!output.status.success());
-	assert!(String::from_utf8_lossy(&output.stderr).contains("Could not inspect"));
-}
-
-#[test]
-fn lint_fix_allows_cargo_to_edit_dirty_and_staged_sources() {
+fn lint_fix_forwards_machine_applicable_fix_permissions() {
 	let fixture = Fixture::new("pina-lint-fix");
 	let output = fixture
 		.command()
 		.arg("--fix")
 		.output()
 		.unwrap_or_else(|error| panic!("failed to run pina lint --fix: {error}"));
+	assert!(output.status.success());
 	assert!(
-		output.status.success(),
-		"pina lint --fix failed: {}",
-		String::from_utf8_lossy(&output.stderr)
-	);
-	assert!(
-		String::from_utf8_lossy(&output.stdout)
-			.contains("Applied available Pina security lint fixes for lint-fixture")
-	);
-	assert!(
-		fixture.log().contains(
-			"--package lint-fixture --fix -- --allow-dirty --allow-staged --allow-no-vcs"
-		)
-	);
-}
-
-#[test]
-fn lint_reports_pinned_tool_install_failure() {
-	let fixture = Fixture::new("pina-lint-install-failure");
-	let output = fixture
-		.command()
-		.env("FAKE_INSTALL_FAIL", "cargo-dylint")
-		.output()
-		.unwrap_or_else(|error| panic!("failed to run pina lint: {error}"));
-	assert!(!output.status.success());
-	assert!(
-		String::from_utf8_lossy(&output.stderr)
-			.contains("Installing pinned tool `cargo-dylint` failed with status")
-	);
-}
-
-#[test]
-fn lint_rejects_a_successful_install_without_the_expected_binary() {
-	let fixture = Fixture::new("pina-lint-missing-tool");
-	let output = fixture
-		.command()
-		.env("FAKE_INSTALL_OMIT", "dylint-link")
-		.output()
-		.unwrap_or_else(|error| panic!("failed to run pina lint: {error}"));
-	assert!(!output.status.success());
-	assert!(
-		String::from_utf8_lossy(&output.stderr)
-			.contains("Cargo reported success but did not install `dylint-link`")
+		fixture
+			.log()
+			.contains("--fix -- --allow-dirty --allow-staged --allow-no-vcs")
 	);
 }
 
@@ -357,56 +295,6 @@ fn lint_propagates_lint_failures() {
 }
 
 #[test]
-fn lint_reports_when_cargo_disappears_after_discovery() {
-	let fixture = Fixture::new("pina-lint-cargo-disappears");
-	let output = fixture
-		.command()
-		.env("FAKE_CARGO_DISAPPEAR", "1")
-		.output()
-		.unwrap_or_else(|error| panic!("failed to run pina lint: {error}"));
-	assert!(!output.status.success());
-	assert!(
-		String::from_utf8_lossy(&output.stderr)
-			.contains("Could not install pinned tool `cargo-dylint` with Cargo")
-	);
-}
-
-#[test]
-fn lint_reports_when_the_cached_runner_is_not_executable() {
-	let fixture = Fixture::new("pina-lint-runner-permissions");
-	let mut permissions = fs::metadata(&fixture.cargo_dylint)
-		.unwrap_or_else(|error| panic!("failed to inspect fake cargo-dylint: {error}"))
-		.permissions();
-	permissions.set_mode(0o644);
-	fs::set_permissions(&fixture.cargo_dylint, permissions)
-		.unwrap_or_else(|error| panic!("failed to remove execute permission: {error}"));
-	let output = fixture
-		.command()
-		.output()
-		.unwrap_or_else(|error| panic!("failed to run pina lint: {error}"));
-	assert!(!output.status.success());
-	assert!(
-		String::from_utf8_lossy(&output.stderr).contains("Could not run Pina"),
-		"unexpected stderr: {}",
-		String::from_utf8_lossy(&output.stderr)
-	);
-}
-
-#[test]
-fn lint_reports_an_invalid_managed_tool_path() {
-	let fixture = Fixture::new("pina:lint-invalid-path");
-	let output = fixture
-		.command()
-		.output()
-		.unwrap_or_else(|error| panic!("failed to run pina lint: {error}"));
-	assert!(!output.status.success());
-	assert!(
-		String::from_utf8_lossy(&output.stderr)
-			.contains("Could not construct PATH for the pinned Dylint tools")
-	);
-}
-
-#[test]
 fn lint_reports_when_the_managed_tool_directory_cannot_be_created() {
 	let fixture = Fixture::new("pina-lint-tool-directory");
 	let cargo_home = fixture.project.join("blocked-cargo-home");
@@ -420,31 +308,14 @@ fn lint_reports_when_the_managed_tool_directory_cannot_be_created() {
 	assert!(!output.status.success());
 	assert!(
 		String::from_utf8_lossy(&output.stderr)
-			.contains("Could not create the managed Dylint directory")
+			.contains("Could not create the managed lint bundle directory")
 	);
 }
 
 #[test]
-fn lint_reports_when_the_install_lock_cannot_be_opened() {
-	let fixture = Fixture::new("pina-lint-open-lock");
-	let lock = fixture.managed_tool_root().join("install.lock");
-	fs::create_dir_all(&lock)
-		.unwrap_or_else(|error| panic!("failed to create blocking lock directory: {error}"));
-	let output = fixture
-		.command()
-		.output()
-		.unwrap_or_else(|error| panic!("failed to run pina lint: {error}"));
-	assert!(!output.status.success());
-	assert!(
-		String::from_utf8_lossy(&output.stderr)
-			.contains("Could not open the managed Dylint installation lock")
-	);
-}
-
-#[test]
-fn lint_reports_a_concurrent_managed_tool_installation() {
+fn lint_reports_a_concurrent_managed_runner_download() {
 	let fixture = Fixture::new("pina-lint-lock-contention");
-	let lock_path = fixture.managed_tool_root().join("install.lock");
+	let lock_path = fixture.managed_tool_root().join("bundle.lock");
 	fs::create_dir_all(
 		lock_path
 			.parent()
@@ -462,7 +333,6 @@ fn lint_reports_a_concurrent_managed_tool_installation() {
 		.unwrap_or_else(|error| panic!("failed to run pina lint: {error}"));
 	assert!(!output.status.success());
 	assert!(
-		String::from_utf8_lossy(&output.stderr)
-			.contains("Could not lock the managed Dylint installation")
+		String::from_utf8_lossy(&output.stderr).contains("Could not lock the managed lint bundle")
 	);
 }

--- a/crates/pina_cli/tests/snapshots/cli_snapshots__lint_help.snap
+++ b/crates/pina_cli/tests/snapshots/cli_snapshots__lint_help.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/pina_cli/tests/cli_snapshots.rs
+assertion_line: 148
 info:
   program: pina
   args:
@@ -11,7 +12,7 @@ exit_code: 0
 ----- stdout -----
 Run Pina's official security lints against the current program.
 
-Discovers the nearest Pina.toml or Cargo package, prepares pinned Dylint tools under Cargo home, and runs the lint set from the immutable revision reviewed for this CLI. Use --fix to apply machine-applicable suggestions; review every resulting source change.
+Discovers the nearest Pina.toml or Cargo package, prepares pinned Dylint tooling under Cargo home, and runs the precompiled lint bundle published with this CLI release. Use --fix to apply machine-applicable suggestions; review every resulting source change.
 
 Usage: pina lint [OPTIONS]
 
@@ -31,6 +32,6 @@ Examples:
   pina lint --project ./programs/counter
 
 Tooling:
-  The first run installs pinned cargo-dylint and dylint-link binaries below Cargo home. Lint libraries are loaded from the immutable Pina revision reviewed for this CLI. --fix applies only machine-applicable suggestions and allows Cargo to edit dirty, staged, or not-yet-versioned working trees; inspect the diff before committing.
+  The first run downloads verified, precompiled cargo-dylint and native lint bundles below Cargo home. --fix applies only machine-applicable suggestions and allows Cargo to edit dirty, staged, or not-yet-versioned working trees; inspect the diff before committing.
 
 ----- stderr -----

--- a/crates/pina_cli/tests/verification_command.rs
+++ b/crates/pina_cli/tests/verification_command.rs
@@ -64,7 +64,10 @@ esac
 
 fn create_record_and_keypair(temp: &TempDir) -> (std::path::PathBuf, std::path::PathBuf, String) {
 	let bytes = vec![7_u8; 128];
-	let hash = Sha256::digest(&bytes).iter().map(|byte| format!("{byte:02x}")).collect::<String>();
+	let hash = Sha256::digest(&bytes)
+		.iter()
+		.map(|byte| format!("{byte:02x}"))
+		.collect::<String>();
 	let record = temp.path().join(format!("fixture-{hash}.json"));
 	let artifact = record.with_extension("so");
 	let json = serde_json::json!({

--- a/deny.toml
+++ b/deny.toml
@@ -26,6 +26,8 @@ allow = [
 	"Apache-2.0 WITH LLVM-exception",
 	"BSD-2-Clause",
 	"BSD-3-Clause",
+	# webpki-roots distributes Mozilla's public certificate trust-store data.
+	"CDLA-Permissive-2.0",
 	"ISC",
 	"MIT",
 	"MPL-2.0",

--- a/docs/src/ci-and-releases.md
+++ b/docs/src/ci-and-releases.md
@@ -113,6 +113,12 @@ The `publish` workflow builds and uploads the `pina` CLI binary for all supporte
 - Build scope: `crates/pina_cli` only (`bin = "pina"`)
 - Artifacts: `pina-<target>-<tag>` archives with `sha256`/`sha512` checksums, attested with build provenance
 
+The same workflow resolves a reusable `dylint-v<version>` tool release before building `pina-lints-<target>-<tag>.tar.gz`. A complete existing tool release is verified and reused. If the exact version has no release, the workflow builds `cargo-dylint` and `dylint-link` for the full target matrix, attests the archives, and publishes them once under that versioned tag. This makes the lint runner independent of both a Pina commit revision and the Linux-only upstream Dylint binary matrix.
+
+Lint libraries are then built natively because Dylint compiler plugins are tied to the host, pinned nightly toolchain, and dynamic loader. Linux musl builds run inside a digest-pinned Alpine image; FreeBSD runs in a pinned VM action. The workflow waits for all CLI and lint assets, attests and verifies every `pina-*` asset, and only then publishes packages and makes the GitHub release public.
+
+`crates/pina_cli/lints.json` is the single release contract shared by the CLI and bundle builders. Its `dylintVersion` field is the pointer to the reusable tool release; changing it causes the next publish run to create that release if it does not already exist. Tests require the catalog to match every crate under `lints/`, the repository Rust toolchain, and the workspace's Dylint dependency version. The installed CLI selects releases by semantic version rather than embedding a commit revision, so automated releases remain a single merge-and-publish flow.
+
 After attestation, the publish job downloads those same archives and fills the platform-specific npm packages. `@pina-rs/cli` uses optional dependencies to install the matching native package without compiling Rust. The release target and npm package matrices are checked one-to-one for:
 
 - macOS arm64 and x64

--- a/docs/src/cli/index.md
+++ b/docs/src/cli/index.md
@@ -32,7 +32,7 @@ The shortcut runs `cargo run -p pina_cli -- ...` against the checked-out source.
 | Command                                        | Purpose                                                      | Primary output                            |
 | ---------------------------------------------- | ------------------------------------------------------------ | ----------------------------------------- |
 | [`pina init`](./init.md)                       | Create a project-aware program scaffold                      | Files plus next steps                     |
-| [`pina lint`](./lint.md)                       | Run the revision-pinned Pina security lint set               | Dylint diagnostics and optional fixes     |
+| [`pina lint`](./lint.md)                       | Run the release-matched Pina security lint bundle            | Dylint diagnostics and optional fixes     |
 | [`pina build`](./build.md)                     | Build SBF, optionally with deterministic verification inputs | SBF, IDL, and optional build-record files |
 | [`pina verify`](./verify.md)                   | Compare deployments and record verified source               | Status or transaction                     |
 | [`pina generate`](./generate.md)               | Generate configured client ecosystems                        | Generated clients                         |

--- a/docs/src/cli/init.md
+++ b/docs/src/cli/init.md
@@ -49,7 +49,7 @@ The scaffold includes:
 - an `Accounts` struct with signer validation;
 - an SBF Cargo target and `cargo build-program` alias;
 - a pinned nightly Rust toolchain with the `rust-src` component;
-- immutable-revision Pina security lint metadata and pinned Dylint tool versions;
+- no source-installed Dylint metadata; `pina lint` downloads the pinned runner and official native lint bundles from Pina releases;
 - host-side discriminator and program-ID smoke tests;
 - Pina and Mollusk dependencies;
 - a dedicated host-only test package with one `pina_test` dependency for the isolated Surfpool test;

--- a/docs/src/cli/lint.md
+++ b/docs/src/cli/lint.md
@@ -27,14 +27,32 @@ pina lint --project ./programs/counter
 
 The command owns the complete official-lint selection:
 
-- `cargo-dylint` 6.0.4 and `dylint-link` 6.0.4 are installed below Cargo home on first use;
-- later runs and projects reuse that versioned, user-owned installation;
-- the lint libraries come from `lints/*` at the full immutable Git revision reviewed for this CLI;
+- precompiled `cargo-dylint` 6.0.4 and `dylint-link` are downloaded from Pina's reusable `dylint-v6.0.4` tool release on first use;
+- later Pina releases, runs, and projects reuse that versioned, user-owned tool cache instead of compiling Dylint;
+- native lint libraries are downloaded from the GitHub release for the installed `pina` version, never compiled from repository source on the user's machine;
+- the release asset name includes the exact host target and CLI version, for example `pina-lints-aarch64-apple-darwin-v0.11.0.tar.gz`;
 - project-provided Dylint metadata is ignored by this command, so adding an unrelated library cannot silently extend the trusted code loaded by `pina lint`.
 
-The generated `Cargo.toml` records the same binary versions under `[workspace.metadata.bin]` and the same revision-pinned lint source under `[workspace.metadata.dylint]`. This lets Dylint-aware editors and direct `cargo dylint --all` workflows discover the official set. `pina lint` still supplies its own reviewed selection so older projects receive the set associated with their installed CLI.
+There is deliberately no `PINA_LINT_REVISION`. The CLI version is the lint-library release identity, while `dylintVersion` in the embedded lint catalog selects the reusable Dylint tool release. The workflow builds either versioned release before package publication can continue. A release therefore cannot require a follow-up commit merely to point back at itself.
 
-The first run requires network access to install the pinned tools and fetch the lint libraries. Set `CARGO_HOME` to move Pina's managed Dylint installation; `CARGO_TARGET_DIR` continues to control normal project build artifacts.
+Generated projects do not install Dylint or register a Git source under `[workspace.metadata.dylint]`. Use `pina lint` for the official catalog. Direct `cargo dylint` remains available when a project intentionally manages additional libraries itself.
+
+The first run requires network access to download the pinned runner and lint bundle. Set `CARGO_HOME` to move both caches. Managed runners use `$CARGO_HOME/pina/tools/dylint-v<version>/<target>/`; bundles use `$CARGO_HOME/pina/lints/v<version>/<target>/`. `CARGO_TARGET_DIR` continues to control normal project build artifacts.
+
+`cargo-dylint`, `dylint-link`, and Pina's lint libraries are precompiled. Dylint itself may still compile and cache its small `dylint-driver` executable for the project's exact nightly toolchain on first use. That driver links against the local `rustc-dev` installation and is not portable between Rust toolchain locations, so it is deliberately not shipped as a release asset. This step does not fetch or compile Pina lint source.
+
+## Download and verification
+
+Pina treats lint libraries as native executable code:
+
+1. It queries `dylint-v<version>` for the pinned Dylint executables and the GitHub release whose tag exactly matches the installed CLI for the lint libraries.
+2. It accepts only the target-specific asset names and canonical `github.com/pina-rs/pina/releases/download/<tag>/` URLs.
+3. It checks the downloaded byte count and GitHub-provided SHA-256 asset digest before extraction.
+4. It rejects nested paths, links, special files, unknown extensions, duplicate files, and oversized archives.
+5. It validates the bundle manifest against the CLI's embedded catalog, Dylint version, Rust toolchain, host target, exact filenames, file sizes, and per-library SHA-256 digests.
+6. It passes every verified absolute path with `--lib-path` and `--no-metadata`; Dylint neither discovers nor builds project-provided library sources.
+
+Every published Dylint tool bundle, lint bundle, and CLI archive receives GitHub's OIDC-backed build-provenance attestation. The release job first checks whether the exact `dylint-v<version>` release already has the complete target matrix. When it does, every Pina release reuses it. When it does not exist, the workflow builds and publishes `cargo-dylint` and `dylint-link` natively for macOS, Linux glibc, Linux musl, and Windows on arm64 and x64, plus FreeBSD x64. It then builds the Pina lint libraries for that same matrix.
 
 ## Fix mode
 
@@ -47,10 +65,10 @@ Dylint delegates fix mode to `cargo fix`. Pina supplies `--allow-dirty`, `--allo
 
 ## Security boundary
 
-Dylint libraries are native compiler plugins, not passive rule files. Running a lint grants the selected library code the same local permissions as the invoking user. Pina therefore selects only its official, immutable reviewed revision, keeps reusable Dylint executables outside project-controlled target trees, and disables project metadata for `pina lint`. Obtain the CLI from a trusted channel and review CLI upgrades as executable tooling changes.
+Dylint libraries are native compiler plugins, not passive rule files. Running a lint grants the selected library code the same local permissions as the invoking user. Pina therefore couples each bundle to an exact CLI release and host, verifies it before every use, keeps reusable Dylint executables outside project-controlled target trees, and disables project metadata for `pina lint`. Obtain the CLI from a trusted channel and review CLI upgrades as executable tooling changes.
 
 Use direct `cargo dylint` only when you intentionally want to run additional project-defined lint libraries. Review and pin every such source before loading it.
 
 ## Exit behavior
 
-The command exits successfully only when tool preparation, compilation, and all enabled security lints succeed. A diagnostic at an error level, a compilation failure, an unavailable network dependency on first use, or a failed tool installation produces a non-zero exit. Child Cargo and Dylint output stays attached to the terminal; Pina prints a short completion summary only after success.
+The command exits successfully only when tool preparation, compilation, and all enabled security lints succeed. A diagnostic at an error level, a compilation failure, an unavailable network dependency on first use, or an invalid download produces a non-zero exit. Child Cargo and Dylint output stays attached to the terminal; Pina prints a short completion summary only after success.

--- a/lints/readme.md
+++ b/lints/readme.md
@@ -6,22 +6,17 @@ The lints complement tests and audits; they do not prove that a program's econom
 
 ## Installation and execution
 
-Register the libraries in the consuming workspace:
+Run the catalog published with your installed Pina CLI:
 
-```toml
-[workspace.metadata.dylint]
-libraries = [
-	{ git = "https://github.com/pina-rs/pina", tag = "v0.11.0", pattern = "lints/*" },
-]
+```bash
+pina lint
+# Apply machine-applicable suggestions, then inspect the diff.
+pina lint --fix
 ```
 
-Run every registered lint against all targets:
+`pina lint` downloads precompiled Dylint executables from Pina's reusable release for the pinned Dylint version, then downloads native libraries from the matching Pina release. It verifies each release digest, bundle manifest, host/toolchain identity, and file digest. Consuming projects do not register or build Pina's lint source; Dylint may still build its location-specific compiler driver for the active nightly toolchain.
 
-```sh
-cargo dylint --all -- --all-targets
-```
-
-Inside this repository, use:
+Pina contributors still build the local source catalog when changing a lint:
 
 ```sh
 devenv shell -- security:dylint

--- a/readme.md
+++ b/readme.md
@@ -903,7 +903,7 @@ pina lint
 pina lint --fix
 ```
 
-`pina init` registers the revision-pinned official lint set automatically. `pina lint` prepares pinned Dylint tools below Cargo home and does not load extra project-defined lint libraries.
+`pina lint` downloads pinned, precompiled `cargo-dylint` and Pina lint libraries instead of installing or compiling them from source, and it does not load extra project-defined lint libraries. Dylint may still build its internal compiler driver for the project's exact Rust toolchain on first use. `pina init` does not add source-based lint metadata or a self-referential commit pin.
 
 - account ownership, initialization, PDA, sysvar, ATA, resize, close, and CPI validation
 - mutable-borrow lifetime, checked arithmetic, remaining-account bounds, and custody balance accounting

--- a/scripts/lints/build-bundle.mjs
+++ b/scripts/lints/build-bundle.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+	cpSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	realpathSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const repositoryRoot = resolve(
+	dirname(fileURLToPath(import.meta.url)),
+	"../..",
+);
+const catalogPath = join(repositoryRoot, "crates/pina_cli/lints.json");
+
+function fail(message) {
+	throw new Error(message);
+}
+
+function parseArguments(arguments_) {
+	const options = {};
+	for (let index = 0; index < arguments_.length; index += 2) {
+		const name = arguments_[index];
+		const value = arguments_[index + 1];
+		if (!name?.startsWith("--") || value === undefined) {
+			fail("Expected --target, --release-tag, and --output-dir arguments.");
+		}
+		options[name.slice(2)] = value;
+	}
+	if (!options.target || !options["release-tag"] || !options["output-dir"]) {
+		fail("Expected --target, --release-tag, and --output-dir arguments.");
+	}
+	return {
+		outputDirectory: resolve(options["output-dir"]),
+		releaseTag: options["release-tag"],
+		target: options.target,
+	};
+}
+
+function run(command, arguments_, options = {}) {
+	return execFileSync(command, arguments_, {
+		cwd: repositoryRoot,
+		encoding: "utf8",
+		stdio: options.capture ? ["ignore", "pipe", "inherit"] : "inherit",
+		...options,
+	});
+}
+
+function sha256(path) {
+	return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+export function libraryFilename(name, toolchain, target) {
+	if (target.includes("windows")) {
+		return `${name}@${toolchain}.dll`;
+	}
+	if (target.includes("apple-darwin")) {
+		return `lib${name}@${toolchain}.dylib`;
+	}
+	return `lib${name}@${toolchain}.so`;
+}
+
+function validateRelease(releaseTag) {
+	if (!/^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(releaseTag)) {
+		fail(`Invalid release tag: ${releaseTag}`);
+	}
+	const version = releaseTag.slice(1);
+	const metadata = JSON.parse(
+		run("cargo", ["metadata", "--no-deps", "--format-version", "1"], {
+			capture: true,
+		}),
+	);
+	const cli = metadata.packages.find((item) => item.name === "pina_cli");
+	if (!cli || cli.version !== version) {
+		fail(
+			`Release ${releaseTag} does not match pina_cli version ${
+				cli?.version ?? "missing"
+			}.`,
+		);
+	}
+	return version;
+}
+
+function validateHost(target, catalog) {
+	const rustc = run("rustc", ["-vV"], { capture: true });
+	const host = /^host: (.+)$/m.exec(rustc)?.[1];
+	if (host !== target) {
+		fail(
+			`Lint bundles must be built natively: rustc host is ${host}, requested ${target}.`,
+		);
+	}
+	const activeToolchain = run("rustup", ["show", "active-toolchain"], {
+		capture: true,
+	})
+		.trim()
+		.split(/\s+/u)[0];
+	const expectedToolchain = `${catalog.toolchain}-${target}`;
+	if (activeToolchain !== expectedToolchain) {
+		fail(
+			`Active toolchain is ${activeToolchain}; expected ${expectedToolchain}.`,
+		);
+	}
+	return expectedToolchain;
+}
+
+export function buildBundle(arguments_) {
+	const { outputDirectory, releaseTag, target } = parseArguments(arguments_);
+	const catalog = JSON.parse(readFileSync(catalogPath, "utf8"));
+	if (catalog.schemaVersion !== 1 || catalog.libraries.length === 0) {
+		fail("The lint catalog is empty or uses an unsupported schema.");
+	}
+	if (new Set(catalog.libraries).size !== catalog.libraries.length) {
+		fail("The lint catalog contains duplicate library names.");
+	}
+	if (!catalog.targets.includes(target)) {
+		fail(`Target ${target} is not in the lint release catalog.`);
+	}
+	const version = validateRelease(releaseTag);
+	const toolchain = validateHost(target, catalog);
+	const temporaryDirectory = mkdtempSync(join(tmpdir(), "pina-lint-bundle-"));
+	const targetDirectory = join(temporaryDirectory, "target");
+	const stagingDirectory = join(temporaryDirectory, "bundle");
+	const linkerVariable = `CARGO_TARGET_${
+		target.replaceAll("-", "_").toUpperCase()
+	}_LINKER`;
+	mkdirSync(stagingDirectory);
+	mkdirSync(outputDirectory, { recursive: true });
+
+	try {
+		const libraries = [];
+		for (const name of catalog.libraries) {
+			const manifestPath = join(repositoryRoot, "lints", name, "Cargo.toml");
+			run("cargo", ["build", "--release", "--manifest-path", manifestPath], {
+				env: {
+					...process.env,
+					CARGO_INCREMENTAL: "0",
+					CARGO_TARGET_DIR: targetDirectory,
+					[linkerVariable]: "dylint-link",
+				},
+			});
+			const file = libraryFilename(name, toolchain, target);
+			const source = realpathSync(join(targetDirectory, "release", file));
+			const destination = join(stagingDirectory, file);
+			cpSync(source, destination);
+			libraries.push({
+				name,
+				file,
+				sha256: sha256(destination),
+				size: statSync(destination).size,
+			});
+		}
+
+		writeFileSync(
+			join(stagingDirectory, "manifest.json"),
+			`${
+				JSON.stringify(
+					{
+						schema_version: 1,
+						version,
+						target,
+						toolchain,
+						dylint_version: catalog.dylintVersion,
+						libraries,
+					},
+					null,
+					"\t",
+				)
+			}\n`,
+		);
+
+		const archiveName = `pina-lints-${target}-${releaseTag}.tar.gz`;
+		const archivePath = join(outputDirectory, archiveName);
+		run("tar", [
+			"-czf",
+			archivePath,
+			"-C",
+			stagingDirectory,
+			"manifest.json",
+			...libraries.map((library) => library.file),
+		]);
+		console.log(
+			JSON.stringify({
+				archive: archivePath,
+				name: basename(archivePath),
+				sha256: sha256(archivePath),
+				size: statSync(archivePath).size,
+			}),
+		);
+		return archivePath;
+	} finally {
+		rmSync(temporaryDirectory, { force: true, recursive: true });
+	}
+}
+
+if (
+	process.argv[1] &&
+	pathToFileURL(resolve(process.argv[1])).href === import.meta.url
+) {
+	buildBundle(process.argv.slice(2));
+}

--- a/scripts/lints/build-bundle.test.mjs
+++ b/scripts/lints/build-bundle.test.mjs
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { libraryFilename } from "./build-bundle.mjs";
+import { executableFilename } from "./build-dylint-tools.mjs";
+
+const repositoryRoot = resolve(
+	dirname(fileURLToPath(import.meta.url)),
+	"../..",
+);
+
+test("Dylint bundle filenames match each native loader convention", () => {
+	assert.equal(
+		libraryFilename(
+			"secure_lint",
+			"nightly-test-x86_64-unknown-linux-gnu",
+			"x86_64-unknown-linux-gnu",
+		),
+		"libsecure_lint@nightly-test-x86_64-unknown-linux-gnu.so",
+	);
+	assert.equal(
+		libraryFilename(
+			"secure_lint",
+			"nightly-test-aarch64-apple-darwin",
+			"aarch64-apple-darwin",
+		),
+		"libsecure_lint@nightly-test-aarch64-apple-darwin.dylib",
+	);
+	assert.equal(
+		libraryFilename(
+			"secure_lint",
+			"nightly-test-x86_64-pc-windows-msvc",
+			"x86_64-pc-windows-msvc",
+		),
+		"secure_lint@nightly-test-x86_64-pc-windows-msvc.dll",
+	);
+});
+
+test("Dylint tool filenames match Unix and Windows conventions", () => {
+	assert.equal(
+		executableFilename("cargo-dylint", "aarch64-apple-darwin"),
+		"cargo-dylint",
+	);
+	assert.equal(
+		executableFilename("cargo-dylint", "x86_64-pc-windows-msvc"),
+		"cargo-dylint.exe",
+	);
+});
+
+test("the release catalog covers every lint crate and matches the pinned toolchain", () => {
+	const catalog = JSON.parse(
+		readFileSync(join(repositoryRoot, "crates/pina_cli/lints.json"), "utf8"),
+	);
+	const lintCrates = readdirSync(join(repositoryRoot, "lints"), {
+		withFileTypes: true,
+	})
+		.filter((entry) => entry.isDirectory())
+		.filter((entry) => {
+			try {
+				readFileSync(join(repositoryRoot, "lints", entry.name, "Cargo.toml"));
+				return true;
+			} catch {
+				return false;
+			}
+		})
+		.map((entry) => entry.name)
+		.sort();
+	assert.deepEqual(catalog.libraries, lintCrates);
+	assert.deepEqual(catalog.targets, [
+		"aarch64-unknown-linux-gnu",
+		"aarch64-unknown-linux-musl",
+		"aarch64-apple-darwin",
+		"aarch64-pc-windows-msvc",
+		"x86_64-unknown-linux-gnu",
+		"x86_64-unknown-linux-musl",
+		"x86_64-apple-darwin",
+		"x86_64-pc-windows-msvc",
+		"x86_64-unknown-freebsd",
+	]);
+
+	const rustToolchain = readFileSync(
+		join(repositoryRoot, "rust-toolchain.toml"),
+		"utf8",
+	);
+	assert.match(
+		rustToolchain,
+		new RegExp(`channel = "${catalog.toolchain}"`, "u"),
+	);
+	const rootManifest = readFileSync(join(repositoryRoot, "Cargo.toml"), "utf8");
+	assert.match(
+		rootManifest,
+		new RegExp(`dylint-link = \\{ version = "${catalog.dylintVersion}"`, "u"),
+	);
+	const publishWorkflow = readFileSync(
+		join(repositoryRoot, ".github/workflows/publish.yml"),
+		"utf8",
+	);
+	for (const target of catalog.targets) {
+		assert.match(publishWorkflow, new RegExp(`target: ${target}`, "u"));
+	}
+});

--- a/scripts/lints/build-bundle.test.mjs
+++ b/scripts/lints/build-bundle.test.mjs
@@ -101,4 +101,9 @@ test("the release catalog covers every lint crate and matches the pinned toolcha
 	for (const target of catalog.targets) {
 		assert.match(publishWorkflow, new RegExp(`target: ${target}`, "u"));
 	}
+	assert.match(
+		publishWorkflow,
+		/toolchain: \$\{\{ needs\.prepare_dylint_tools\.outputs\.toolchain \}\}/u,
+	);
+	assert.doesNotMatch(publishWorkflow, /toolchain: nightly-/u);
 });

--- a/scripts/lints/build-dylint-tools.mjs
+++ b/scripts/lints/build-dylint-tools.mjs
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+	chmodSync,
+	cpSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const repositoryRoot = resolve(
+	dirname(fileURLToPath(import.meta.url)),
+	"../..",
+);
+const catalogPath = join(repositoryRoot, "crates/pina_cli/lints.json");
+const toolNames = ["cargo-dylint", "dylint-link"];
+
+function fail(message) {
+	throw new Error(message);
+}
+
+function parseArguments(arguments_) {
+	const options = {};
+	for (let index = 0; index < arguments_.length; index += 2) {
+		const name = arguments_[index];
+		const value = arguments_[index + 1];
+		if (!name?.startsWith("--") || value === undefined) {
+			fail("Expected --target and --output-dir arguments.");
+		}
+		options[name.slice(2)] = value;
+	}
+	if (!options.target || !options["output-dir"]) {
+		fail("Expected --target and --output-dir arguments.");
+	}
+	return {
+		outputDirectory: resolve(options["output-dir"]),
+		target: options.target,
+	};
+}
+
+function run(command, arguments_, options = {}) {
+	return execFileSync(command, arguments_, {
+		cwd: repositoryRoot,
+		encoding: "utf8",
+		stdio: options.capture ? ["ignore", "pipe", "inherit"] : "inherit",
+		...options,
+	});
+}
+
+function sha256(path) {
+	return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+export function executableFilename(name, target) {
+	return target.includes("windows") ? `${name}.exe` : name;
+}
+
+function validateHost(target) {
+	const rustc = run("rustc", ["-vV"], { capture: true });
+	const host = /^host: (.+)$/m.exec(rustc)?.[1];
+	if (host !== target) {
+		fail(
+			`Dylint tools must be built natively: rustc host is ${host}, requested ${target}.`,
+		);
+	}
+}
+
+export function buildDylintTools(arguments_) {
+	const { outputDirectory, target } = parseArguments(arguments_);
+	const catalog = JSON.parse(readFileSync(catalogPath, "utf8"));
+	const version = catalog.dylintVersion;
+	if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
+		fail(`Invalid Dylint version in lint catalog: ${version}`);
+	}
+	if (!catalog.targets.includes(target)) {
+		fail(`Target ${target} is not in the lint release catalog.`);
+	}
+	validateHost(target);
+
+	const temporaryDirectory = mkdtempSync(join(tmpdir(), "pina-dylint-tools-"));
+	const installDirectory = join(temporaryDirectory, "install");
+	const stagingDirectory = join(temporaryDirectory, "bundle");
+	mkdirSync(stagingDirectory);
+	mkdirSync(outputDirectory, { recursive: true });
+
+	try {
+		for (const name of toolNames) {
+			run("cargo", [
+				"install",
+				"--locked",
+				"--force",
+				"--root",
+				installDirectory,
+				"--version",
+				`=${version}`,
+				name,
+			], {
+				env: {
+					...process.env,
+					CARGO_INCREMENTAL: "0",
+					CARGO_TARGET_DIR: join(temporaryDirectory, "target", name),
+				},
+			});
+		}
+
+		const executables = toolNames.map((name) => {
+			const file = executableFilename(name, target);
+			const source = join(installDirectory, "bin", file);
+			const destination = join(stagingDirectory, file);
+			cpSync(source, destination);
+			if (!target.includes("windows")) {
+				chmodSync(destination, 0o755);
+			}
+			return {
+				name,
+				file,
+				sha256: sha256(destination),
+				size: statSync(destination).size,
+			};
+		});
+
+		writeFileSync(
+			join(stagingDirectory, "manifest.json"),
+			`${
+				JSON.stringify(
+					{
+						schema_version: 1,
+						dylint_version: version,
+						target,
+						executables,
+					},
+					null,
+					"\t",
+				)
+			}\n`,
+		);
+
+		const archiveName = `pina-dylint-tools-${target}-v${version}.tar.gz`;
+		const archivePath = join(outputDirectory, archiveName);
+		run("tar", [
+			"-czf",
+			archivePath,
+			"-C",
+			stagingDirectory,
+			"manifest.json",
+			...executables.map((executable) => executable.file),
+		]);
+		console.log(
+			JSON.stringify({
+				archive: archivePath,
+				name: basename(archivePath),
+				sha256: sha256(archivePath),
+				size: statSync(archivePath).size,
+			}),
+		);
+		return archivePath;
+	} finally {
+		rmSync(temporaryDirectory, { force: true, recursive: true });
+	}
+}
+
+if (
+	process.argv[1] &&
+	pathToFileURL(resolve(process.argv[1])).href === import.meta.url
+) {
+	buildDylintTools(process.argv.slice(2));
+}

--- a/scripts/lints/build-dylint-tools.mjs
+++ b/scripts/lints/build-dylint-tools.mjs
@@ -76,6 +76,9 @@ function validateHost(target) {
 export function buildDylintTools(arguments_) {
 	const { outputDirectory, target } = parseArguments(arguments_);
 	const catalog = JSON.parse(readFileSync(catalogPath, "utf8"));
+	if (catalog.schemaVersion !== 1 || !Array.isArray(catalog.targets)) {
+		fail("The lint catalog is empty or uses an unsupported schema.");
+	}
 	const version = catalog.dylintVersion;
 	if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
 		fail(`Invalid Dylint version in lint catalog: ${version}`);


### PR DESCRIPTION
## Summary

- replace revision-pinned lint source builds with verified, release-native Pina lint bundles
- use `crates/pina_cli/lints.json` as the single Dylint version, toolchain, target, and lint catalog contract
- publish or reuse a `dylint-v<version>` release containing precompiled `cargo-dylint` and `dylint-link` for Linux GNU/musl, macOS, and Windows on arm64/x64, plus FreeBSD x64
- validate GitHub asset digests, canonical URLs, safe archives, manifests, target identity, file sizes, and per-file SHA-256 digests before caching native code
- remove `PINA_LINT_REVISION` and generated source-install metadata, document the complete lifecycle, and include a `pina_cli` feature changeset

## Validation

- `devenv shell -- lint:all`
- `devenv shell -- cargo test -p pina_cli`
- `devenv shell -- actionlint .github/workflows/publish.yml .github/workflows/docs-pages.yml`
- `devenv shell -- zizmor --persona pedantic .github/workflows/publish.yml .github/workflows/docs-pages.yml` (informational findings only)
- `devenv shell -- node --test scripts/lints/build-bundle.test.mjs`
- `devenv shell -- mc check && mc step validate`
- built a real `cargo-dylint`/`dylint-link` archive and a real 21-library archive for `aarch64-apple-darwin`
- ran `pina lint` end to end against `examples/hello_solana` using only those cached precompiled archives

The local all-workspace pre-push hook additionally reached the existing fuzz build, where the local Nix libc++ headers conflicted with Xcode 26.5 SDK headers while compiling `libfuzzer-sys`. The repository lint gate and complete `pina_cli` suite pass; Linux CI remains the authoritative fuzz check.

Created on behalf of Ifiok Jr. (@ifiokjr) using GPT-5.6-sol (xhigh reasoning).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `pina lint` now downloads verified, precompiled lint tools and native security lint bundles.
  * Lint artifacts are cached locally and reused on subsequent runs.
  * Added support for multiple Linux, macOS, Windows, and FreeBSD targets.

* **Documentation**
  * Updated setup, linting, release, and security documentation to reflect release-based lint downloads and verification.
  * Clarified that `pina init` no longer adds source-based lint configuration.

* **Reliability**
  * Added artifact integrity, provenance, archive-safety, and metadata validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->